### PR TITLE
DT-247 Fixed issue where id had wrong value

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/SpgNotificationHelperRepositoryImpl.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/SpgNotificationHelperRepositoryImpl.java
@@ -33,8 +33,8 @@ public class SpgNotificationHelperRepositoryImpl implements SpgNotificationHelpe
             while (result.next()) {
                 areas.add(ProbationArea
                         .builder()
-                        .probationAreaId(result.getBigDecimal(1).longValue())
-                        .code(result.getString(2))
+                        .probationAreaId(result.getBigDecimal(2).longValue())
+                        .code(result.getString(3))
                         .build());
             }
             return areas;


### PR DESCRIPTION
Calling the stored procedure via a callable statement rather than a JPA store procedure somehow affects the index value of the result set, from zero based to 1 based