### PR TITLE
DT-341 Allow console and app insights logging at same time

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,54 +6,81 @@
 
     <springProperty scope="context" name="app" source="spring.application.name"/>
 
-    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <layout class="ch.qos.logback.classic.PatternLayout">
-            <Pattern>${LOG_PATTERN}</Pattern>
-        </layout>
-    </appender>
-
-    <springProfile name="dev || stdout">
-        <appender name="logAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <springProfile name="stdout">
+        <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
             <layout class="ch.qos.logback.classic.PatternLayout">
                 <Pattern>${LOG_PATTERN}</Pattern>
             </layout>
         </appender>
+
+        <logger name="uk.gov.justice.hmpps" additivity="false" level="DEBUG">
+            <appender-ref ref="consoleAppender"/>
+        </logger>
+
+        <logger name="org.springframework" additivity="false" level="INFO" >
+            <appender-ref ref="consoleAppender"/>
+        </logger>
+
+        <logger name="springfox.documentation.spring" additivity="false" level="INFO" >
+            <appender-ref ref="consoleAppender"/>
+        </logger>
+
+        <logger name="com.microsoft.applicationinsights" additivity="false" level="INFO" >
+            <appender-ref ref="consoleAppender"/>
+        </logger>
+
+        <logger name="com.zaxxer.hikari" additivity="false" level="INFO" >
+            <appender-ref ref="consoleAppender"/>
+        </logger>
+
+        <logger name="org.apache.catalina" additivity="false" level="INFO" >
+            <appender-ref ref="consoleAppender"/>
+        </logger>
+
+        <logger name="org.flywaydb" additivity="false" level="INFO" >
+            <appender-ref ref="consoleAppender"/>
+        </logger>
+
+        <root level="INFO">
+            <appender-ref ref="consoleAppender"/>
+        </root>
+
     </springProfile>
 
     <springProfile name="!(dev)">
         <appender name="logAppender" class="com.microsoft.applicationinsights.logback.ApplicationInsightsAppender"/>
+        <logger name="uk.gov.justice.hmpps" additivity="false" level="INFO">
+            <appender-ref ref="logAppender"/>
+        </logger>
+
+        <logger name="org.springframework" additivity="false" level="INFO" >
+            <appender-ref ref="logAppender"/>
+        </logger>
+
+        <logger name="springfox.documentation.spring" additivity="false" level="INFO" >
+            <appender-ref ref="logAppender"/>
+        </logger>
+
+        <logger name="com.microsoft.applicationinsights" additivity="false" level="INFO" >
+            <appender-ref ref="logAppender"/>
+        </logger>
+
+        <logger name="com.zaxxer.hikari" additivity="false" level="INFO" >
+            <appender-ref ref="logAppender"/>
+        </logger>
+
+        <logger name="org.apache.catalina" additivity="false" level="INFO" >
+            <appender-ref ref="logAppender"/>
+        </logger>
+
+        <logger name="org.flywaydb" additivity="false" level="INFO" >
+            <appender-ref ref="logAppender"/>
+        </logger>
+
+        <root level="INFO">
+            <appender-ref ref="logAppender"/>
+        </root>
+
     </springProfile>
-
-    <logger name="uk.gov.justice.hmpps" additivity="false" level="DEBUG">
-        <appender-ref ref="logAppender"/>
-    </logger>
-
-    <logger name="org.springframework" additivity="false" level="INFO" >
-        <appender-ref ref="logAppender"/>
-    </logger>
-
-    <logger name="springfox.documentation.spring" additivity="false" level="INFO" >
-        <appender-ref ref="logAppender"/>
-    </logger>
-
-    <logger name="com.microsoft.applicationinsights" additivity="false" level="INFO" >
-        <appender-ref ref="logAppender"/>
-    </logger>
-
-    <logger name="com.zaxxer.hikari" additivity="false" level="INFO" >
-        <appender-ref ref="logAppender"/>
-    </logger>
-
-    <logger name="org.apache.catalina" additivity="false" level="INFO" >
-        <appender-ref ref="consoleAppender"/>
-    </logger>
-
-    <logger name="org.flywaydb" additivity="false" level="INFO" >
-        <appender-ref ref="logAppender"/>
-    </logger>
-
-    <root level="INFO">
-        <appender-ref ref="logAppender"/>
-    </root>
 
 </configuration>


### PR DESCRIPTION
To allow app insights and console logging in a prod "oracle" profile. This is different to other DPS apps since this API is shared with probation that don't yet app insights yet.

