### PR TITLE
DT-337 recall by crn

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
@@ -173,7 +173,7 @@ public class OffendersResource {
     }
 
     @ApiOperation(
-            value = "Returns the latest recall and release details for an offender",
+            value = "WARNING: This is a work in progress!  Returns the latest recall and release details for an offender", // TODO DT-337 remove warning when finished
             notes = "Accepts a NOMIS offender nomsNumber in the format A9999AA")
     @ApiResponses(
             value = {
@@ -190,6 +190,28 @@ public class OffendersResource {
             @PathVariable(value = "nomsNumber") final String nomsNumber) {
 
         return offenderService.offenderIdOfNomsNumber(nomsNumber)
+                .map(offenderId -> new ResponseEntity<>(offenderService.getOffenderLatestRecall(offenderId), HttpStatus.OK))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Offender not found"));
+    }
+
+    @ApiOperation(
+            value = "WARNING: This is a work in progress! Returns the latest recall and release details for an offender", // TODO DT-337 remove warning when finished
+            notes = "Accepts an offender CRN in the format A999999")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(code = 200, message = "OK", response = OffenderLatestRecall.class),
+                    @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
+                    @ApiResponse(code = 401, message = "Unauthorised", response = ErrorResponse.class),
+                    @ApiResponse(code = 403, message = "Forbidden", response = ErrorResponse.class),
+                    @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
+            })
+    @GetMapping(path = "/offenders/crn/{crn}/release")
+    public ResponseEntity<OffenderLatestRecall> getLatestRecallAndReleaseForOffenderByCrn(
+            @ApiParam(name = "crn", value = "CRN for the offender", example = "X320741", required = true)
+            @NotNull
+            @PathVariable(value = "crn") final String crn) {
+
+        return offenderService.offenderIdOfCrn(crn)
                 .map(offenderId -> new ResponseEntity<>(offenderService.getOffenderLatestRecall(offenderId), HttpStatus.OK))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Offender not found"));
     }

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
@@ -10,6 +10,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 import uk.gov.justice.digital.delius.controller.NotFoundException;
 import uk.gov.justice.digital.delius.controller.advice.ErrorResponse;
 import uk.gov.justice.digital.delius.data.api.Contact;
@@ -188,7 +189,9 @@ public class OffendersResource {
             @NotNull
             @PathVariable(value = "nomsNumber") final String nomsNumber) {
 
-        return new ResponseEntity<>(offenderService.getOffenderLatestRecall(nomsNumber), HttpStatus.OK);
+        return offenderService.offenderIdOfNomsNumber(nomsNumber)
+                .map(offenderId -> new ResponseEntity<>(offenderService.getOffenderLatestRecall(offenderId), HttpStatus.OK))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Offender not found"));
     }
 }
 

--- a/src/main/java/uk/gov/justice/digital/delius/service/OffenderService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/OffenderService.java
@@ -169,5 +169,5 @@ public class OffenderService {
 
     // TODO DT-337 Flesh out this stub
     @Transactional(readOnly = true)
-    public OffenderLatestRecall getOffenderLatestRecall(String nomsNumber) { return null; }
+    public OffenderLatestRecall getOffenderLatestRecall(Long offenderId) { return null; }
 }

--- a/src/test/java/uk/gov/justice/digital/delius/OffendersResource_GetLatestRecallAndReleaseForOffender.java
+++ b/src/test/java/uk/gov/justice/digital/delius/OffendersResource_GetLatestRecallAndReleaseForOffender.java
@@ -133,6 +133,61 @@ public class OffendersResource_GetLatestRecallAndReleaseForOffender {
                 .statusCode(404);
     }
 
+    @Test
+    public void getLatestRecallAndReleaseForOffenderByCrn_offenderFound_returnsOk() {
+        org.mockito.BDDMockito.given(mockOffenderService.offenderIdOfCrn(anyString()))
+                .willReturn(ANY_OFFENDER_ID);
+        given()
+                .auth()
+                .oauth2(validOauthToken)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .get("/offenders/crn/X320741/release")
+                .then()
+                .statusCode(200);
+
+    }
+
+    @Test
+    public void getLatestRecallAndReleaseForOffenderByCrn_offenderFound_recallDataOk() {
+        org.mockito.BDDMockito.given(mockOffenderService.offenderIdOfCrn(anyString()))
+                .willReturn(ANY_OFFENDER_ID);
+        final var expectedOffenderRecall = OffenderLatestRecall.builder()
+                .lastRecall(getDefaultOffenderRecall())
+                .lastRelease(getDefaultOffenderRelease())
+                .build();
+        org.mockito.BDDMockito.given(mockOffenderService.getOffenderLatestRecall(anyLong()))
+                .willReturn(expectedOffenderRecall);
+
+        final var offenderLatestRecall = given()
+                .auth()
+                .oauth2(validOauthToken)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .get("/offenders/crn/X320741/release")
+                .then()
+                .extract()
+                .body()
+                .as(OffenderLatestRecall.class);
+
+        assertThat(offenderLatestRecall).isEqualTo(expectedOffenderRecall);
+    }
+
+    @Test
+    public void getLatestRecallAndReleaseForOffenderByCrn_offenderNotFound_returnsNotFound() {
+        org.mockito.BDDMockito.given(mockOffenderService.offenderIdOfCrn(anyString()))
+                .willReturn(OFFENDER_ID_NOT_FOUND);
+        given()
+                .auth()
+                .oauth2(validOauthToken)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .get("/offenders/crn/X320741/release")
+                .then()
+                .statusCode(404);
+
+    }
+
     private OffenderRecall getDefaultOffenderRecall() {
         return offenderRecallBuilder().build();
     }


### PR DESCRIPTION
Add the crn version of the recall/release endpoint, and check for offender not found.
Lacking any consumers and returning no data, this can be safely merged into master once approved.