### PR TITLE
DCS-312 Exposing district as LDU rather than local_delivery_unit

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/Team.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/Team.java
@@ -17,8 +17,10 @@ public class Team {
     private String description;
     @ApiModelProperty(value = "Team telephone, often not populated", required = false, example = "OMU A")
     private String telephone;
-    @ApiModelProperty(value = "Local Delivery Unit - LDU")
+    @ApiModelProperty(value = "Local Delivery Unit - provides a geographic grouping of teams")
     private KeyValue localDeliveryUnit;
+    @ApiModelProperty(value = "Team Type - provides a logical, not necessarily geographic, grouping of teams")
+    private KeyValue teamType;
     @ApiModelProperty(value = "Team's district")
     private KeyValue district;
     @ApiModelProperty(value = "Team's borough")

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Borough.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Borough.java
@@ -12,11 +12,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "BOROUGH")
@@ -63,4 +64,9 @@ public class Borough {
     @JoinColumn(name = "PROBATION_AREA_ID")
     @OneToOne
     private ProbationArea probationArea;
+
+    @OneToMany
+    @JoinColumn(name = "BOROUGH_ID")
+    private List<District> districts;
+
 }

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/ProbationArea.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/ProbationArea.java
@@ -41,12 +41,12 @@ public class ProbationArea {
     private List<Team> teams;
 
     @OneToMany
-    @JoinColumn(name = "PROBATION_AREA_ID", referencedColumnName = "PROBATION_AREA_ID")
-    private List<ProviderTeam> providerTeams;
+    @JoinColumn(name = "PROBATION_AREA_ID")
+    private List<Borough> boroughs;
 
     @OneToMany
     @JoinColumn(name = "PROBATION_AREA_ID", referencedColumnName = "PROBATION_AREA_ID")
-    private List<LocalDeliveryUnit> localDeliveryUnits;
+    private List<ProviderTeam> providerTeams;
 
     @Column(name = "END_DATE")
     private LocalDate endDate;

--- a/src/main/java/uk/gov/justice/digital/delius/service/ReferenceDataService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ReferenceDataService.java
@@ -79,7 +79,8 @@ public class ReferenceDataService {
 
     public Page<KeyValue> getLocalDeliveryUnitsForProbationArea(String code) {
         return probationAreaRepository.findByCode(code).stream()
-                .flatMap(probationArea -> probationArea.getLocalDeliveryUnits().stream())
+                .flatMap(probationArea -> probationArea.getBoroughs().stream())
+                .flatMap(borough -> borough.getDistricts().stream())
                 .map(unit -> new KeyValue(unit.getCode(), unit.getDescription()))
                 .collect(collectingAndThen(toList(), PageImpl::new));
     }

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/OffenderTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/OffenderTransformer.java
@@ -250,6 +250,10 @@ public class OffenderTransformer {
     }
 
     private Team teamOf(uk.gov.justice.digital.delius.jpa.standard.entity.OffenderManager offenderManager) {
+        /**
+         * This only populates a subset of team data - this is currently indexed in elasticsearch so if this is modified
+         * then it will lead to inconsistent data and the index will need to be rebuilt.
+         */
         return Optional.ofNullable(offenderManager.getTrustProviderTeam())
                 .map(tpt -> Team.builder()
                         .description(tpt.getDescription())

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/TeamTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/TeamTransformer.java
@@ -14,7 +14,10 @@ public class TeamTransformer {
                 .telephone(team.getTelephone())
                 .borough(keyValueOf(team.getDistrict().getBorough()))
                 .district(keyValueOf(team.getDistrict()))
-                .localDeliveryUnit(keyValueOf(team.getLocalDeliveryUnit()))
+                // Delius exposes districts as local delivery units.
+                .localDeliveryUnit(keyValueOf(team.getDistrict()))
+                // Delius repurposes LDUs to represent a logical grouping of teams which it describes as "team types"
+                .teamType(keyValueOf(team.getLocalDeliveryUnit()))
                 .build();
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/ReferenceDataResourceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/ReferenceDataResourceTest.java
@@ -110,7 +110,7 @@ public class ReferenceDataResourceTest {
                 .when()
                 .auth()
                 .oauth2(validOauthToken)
-                .get("/probationAreas/code/A_MISSING_LDU/localDeliveryUnits")
+                .get("/probationAreas/code/A_MISSING_PROBATION_AREA/localDeliveryUnits")
                 .then()
                 .statusCode(404)
                 .extract()
@@ -119,7 +119,7 @@ public class ReferenceDataResourceTest {
 
         assertThat(response).isEqualTo(ErrorResponse.builder()
                 .status(404)
-                .developerMessage("Probation area with code A_MISSING_LDU")
+                .developerMessage("Probation area with code A_MISSING_PROBATION_AREA")
                 .build());
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/ReferenceDataServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ReferenceDataServiceTest.java
@@ -80,10 +80,16 @@ public class ReferenceDataServiceTest {
         when(probationAreaRepository.findByCode(aProbationArea().getCode())).thenReturn(
                 Optional.of(
                         aProbationArea().toBuilder()
-                                .localDeliveryUnits(List.of(
-                                        aLocalDeliveryUnit("LDU-1"),
-                                        aLocalDeliveryUnit("LDU-2"),
-                                        aLocalDeliveryUnit("LDU-3")))
+                                .boroughs(List.of(
+                                        aBorough("BB-1").toBuilder()
+                                                .districts(List.of(
+                                                        aDistrict().toBuilder().code("LDU-1").build()))
+                                                .build(),
+                                        aBorough("BB-2").toBuilder()
+                                                .districts(List.of(
+                                                        aDistrict().toBuilder().code("LDU-2").build(),
+                                                        aDistrict().toBuilder().code("LDU-3").build()))
+                                        .build()))
                                 .build()));
 
         assertThat(referenceDataService.getLocalDeliveryUnitsForProbationArea(aProbationArea().getCode()).getContent())

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/TeamTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/TeamTransformerTest.java
@@ -49,14 +49,26 @@ public class TeamTransformerTest {
     }
 
     @Test
-    public void willCopyLocalDeliveryUnit() {
+    public void willCopyDistrictAcrossAsLocalDeliveryUnit() {
+        assertThat(teamTransformer
+                .teamOf(aTeam().toBuilder()
+                        .district(aDistrict().toBuilder()
+                                .code("LL")
+                                .description("My Description").build())
+                        .build())
+                .getLocalDeliveryUnit()).isEqualTo(
+                KeyValue.builder().code("LL").description("My Description").build());
+    }
+
+    @Test
+    public void willCopyLduAcrossAsTeamType() {
         assertThat(teamTransformer
                 .teamOf(aTeam().toBuilder()
                         .localDeliveryUnit(LocalDeliveryUnit.builder().code("LL")
                                 .description("My Description").build())
                         .build())
-                .getLocalDeliveryUnit()).isEqualTo(
-                        KeyValue.builder().code("LL").description("My Description").build());
+                .getTeamType()).isEqualTo(
+                KeyValue.builder().code("LL").description("My Description").build());
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
+++ b/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
@@ -510,14 +510,21 @@ public class EntityHelper {
         return aTeam("TEAM-1");
     }
 
+    public static Borough aBorough() {
+        return aBorough("BB");
+    }
+    public static Borough aBorough(String code) {
+        return Borough.builder()
+                .code(code)
+                .description("Borough description")
+                .build();
+    }
+
      public static District aDistrict() {
         return District.builder()
                 .code("XX")
                 .description("DD description")
-                .borough(Borough.builder()
-                        .code("BB")
-                        .description("Borough description")
-                        .build())
+                .borough(aBorough())
                 .build();
      }
 


### PR DESCRIPTION
This is because local_delivery_unit really refers to team type.

This effects 4 endpoints:
* /allOffenderManagers
* /staff/code
* /staff/username
* /probationArea/localdeliveryunits

Which were all added recently for licences.