### PR TITLE
DCS-329 Fixing returned data from new reference data endpoints

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/ReferenceDataResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/ReferenceDataResource.java
@@ -70,12 +70,7 @@ public class ReferenceDataResource {
             final @PathVariable String code) {
 
         log.info("Call to getLdusForProbationCode");
-        final var ldus = referenceDataService.getLocalDeliveryUnitsForProbationArea(code);
-
-        if (ldus.isEmpty()) {
-            throw new NotFoundException(String.format("Probation area with code %s", code));
-        }
-        return ldus;
+        return referenceDataService.getLocalDeliveryUnitsForProbationArea(code);
     }
 
     @ApiOperation(

--- a/src/main/java/uk/gov/justice/digital/delius/service/ReferenceDataService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ReferenceDataService.java
@@ -104,8 +104,10 @@ public class ReferenceDataService {
     }
 
     private Stream<District> getSelectableLdusForProbationArea(String code) {
-        return probationAreaRepository.findByCode(code).stream()
-                .flatMap(probationArea -> probationArea.getBoroughs().stream())
+        var probationArea = probationAreaRepository.findByCode(code).orElseThrow(() ->
+                new NotFoundException(format("Could not find probation area with code: '%s'", code)));
+
+        return probationArea.getBoroughs().stream()
                 // LDUs are represented as districts in the delius schema
                 .flatMap(borough -> borough.getDistricts().stream())
                 .filter(district -> ynToBoolean(district.getSelectable()));

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/TypesTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/TypesTransformer.java
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.delius.transformers;
 import java.util.Optional;
 
 public class TypesTransformer {
-    static Boolean ynToBoolean(String yn) {
+    public static Boolean ynToBoolean(String yn) {
         return Optional.ofNullable(yn).map("Y"::equalsIgnoreCase).orElse(null);
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/integration/secure/ReferenceDataResourceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/integration/secure/ReferenceDataResourceTest.java
@@ -26,9 +26,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ActiveProfiles("dev-seed")
 public class ReferenceDataResourceTest {
 
-    private static final String ACTIVE_PROBATION_AREA = "TES";
+    private static final String ACTIVE_PROBATION_AREA = "N02";
     private static final String INACTIVE_PROBATION_AREA = "BED";
-    private static final String EXISTING_LDU = "TESUAT";
+    private static final String EXISTING_LDU = "YSS_SHF";
     private static final String MISSING_LDU = "NOT_EXISTING";
 
     @LocalServerPort
@@ -102,7 +102,7 @@ public class ReferenceDataResourceTest {
                 .body()
                 .jsonPath().getList("content", KeyValue.class);
 
-        assertThat(localDeliveryUnits).extracting("code").containsOnly("TESMIG", "TESUAT", "TESSPG");
+        assertThat(localDeliveryUnits).extracting("code").contains(EXISTING_LDU, "N02LEE", "N02NNT", "N02SDL");
     }
 
     @Test
@@ -120,7 +120,7 @@ public class ReferenceDataResourceTest {
 
         assertThat(response).isEqualTo(ErrorResponse.builder()
                 .status(404)
-                .developerMessage("Probation area with code A_MISSING_PROBATION_AREA")
+                .developerMessage("Could not find probation area with code: 'A_MISSING_PROBATION_AREA'")
                 .build());
     }
 
@@ -137,7 +137,7 @@ public class ReferenceDataResourceTest {
                 .body()
                 .jsonPath().getList("content", KeyValue.class);
 
-        assertThat(localDeliveryUnits).extracting("code").containsOnly("TESUAT", "TESPRC");
+        assertThat(localDeliveryUnits).extracting("code").containsOnly("N02N30", "N02N21");
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/digital/delius/service/ReferenceDataServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ReferenceDataServiceTest.java
@@ -205,6 +205,8 @@ public class ReferenceDataServiceTest {
     @Test
     public void getLocalDeliveryUnits_missingProbationArea() {
         when(probationAreaRepository.findByCode(aProbationArea().getCode())).thenReturn(Optional.empty());
-        assertThat(referenceDataService.getLocalDeliveryUnitsForProbationArea(aProbationArea().getCode()).getContent()).isEmpty();
+        assertThatThrownBy(() -> referenceDataService.getLocalDeliveryUnitsForProbationArea(aProbationArea().getCode()))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Could not find probation area with code: 'NO2'");
     }
 }


### PR DESCRIPTION
So now:
 * Only including selectable LDUs from new endpoints
 * Also now returning all teams for a given LDU code rather than just those for the first LDU with that specific code