### PR TITLE
Do the Delius Updates

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/OffenderPrisoner.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/OffenderPrisoner.java
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.delius.jpa.standard.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "OFFENDER_PRISONER")
+@IdClass(OffenderPrisonerPk.class)
+public class OffenderPrisoner {
+
+    @Id
+    @Column(name = "OFFENDER_ID")
+    private Long offenderId;
+
+    @Id
+    @Column(name = "PRISONER_NUMBER")
+    private String prisonerNumber;
+
+    @Column(name = "ROW_VERSION")
+    @Builder.Default
+    private Long rowVersion = 1L;
+
+    @Column(name = "PARTITION_AREA_ID")
+    @Builder.Default
+    private Long partitionAreaId = 0L;
+}

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/OffenderPrisonerPk.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/OffenderPrisonerPk.java
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.delius.jpa.standard.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Id;
+import java.io.Serializable;
+
+@EqualsAndHashCode
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OffenderPrisonerPk implements Serializable {
+    @Id
+    @Column(name = "OFFENDER_ID")
+    private Long offenderId;
+
+    @Id
+    @Column(name = "PRISONER_NUMBER")
+    private String prisonerNumber;
+}

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/OffenderPrisonerRepository.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/OffenderPrisonerRepository.java
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.delius.jpa.standard.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.justice.digital.delius.jpa.standard.entity.OffenderPrisoner;
+import uk.gov.justice.digital.delius.jpa.standard.entity.OffenderPrisonerPk;
+
+public interface OffenderPrisonerRepository extends JpaRepository<OffenderPrisoner, OffenderPrisonerPk> {
+    void deleteAllByOffenderId(long offenderId);
+}

--- a/src/main/java/uk/gov/justice/digital/delius/service/OffenderPrisonerService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/OffenderPrisonerService.java
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.delius.service;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.justice.digital.delius.jpa.standard.entity.*;
+import uk.gov.justice.digital.delius.jpa.standard.repository.EventRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderPrisonerRepository;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class OffenderPrisonerService {
+    private final EventRepository eventRepository;
+    private final OffenderPrisonerRepository offenderPrisonerRepository;
+
+    public OffenderPrisonerService(EventRepository eventRepository, OffenderPrisonerRepository offenderPrisonerRepository) {
+        this.eventRepository = eventRepository;
+        this.offenderPrisonerRepository = offenderPrisonerRepository;
+    }
+
+    @Transactional
+    public Offender refreshOffenderPrisonersFor(Offender offender) {
+        final var offenderId = offender.getOffenderId();
+        final var events = eventRepository.findByOffenderId(offenderId);
+        offenderPrisonerRepository.deleteAllByOffenderId(offenderId);
+        offenderPrisonerRepository.saveAll(createOffenderPrisonersFromEvents(offenderId, events));
+        offender.setMostRecentPrisonerNumber(getPrisonNumberFromLatestEvent(events));
+        return offender;
+    }
+
+    public String getPrisonNumberFromLatestEvent(List<Event> events) {
+        return events
+                .stream()
+                .map(Event::getDisposal)
+                .filter(Objects::nonNull)
+                .filter(disposal -> Objects.nonNull(disposal.getCustody()))
+                .filter(disposal -> StringUtils.isNotEmpty(disposal.getCustody().getPrisonerNumber()))
+                .max(Comparator.comparing(Disposal::getStartDate))
+                .map(Disposal::getCustody)
+                .map(Custody::getPrisonerNumber)
+                .orElse("");
+    }
+
+    public Set<OffenderPrisoner> createOffenderPrisonersFromEvents(Long offenderId, List<Event> events) {
+        return events
+                .stream()
+                .map(Event::getDisposal)
+                .filter(Objects::nonNull)
+                .map(Disposal::getCustody)
+                .filter(Objects::nonNull)
+                .map(Custody::getPrisonerNumber)
+                .filter(StringUtils::isNotEmpty)
+                .map(prisonerNumber -> OffenderPrisoner
+                        .builder()
+                        .offenderId(offenderId)
+                        .prisonerNumber(prisonerNumber)
+                        .build())
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/delius/service/ContactService_addContactForBookingNumberUpdateTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ContactService_addContactForBookingNumberUpdateTest.java
@@ -1,0 +1,120 @@
+package uk.gov.justice.digital.delius.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Contact;
+import uk.gov.justice.digital.delius.jpa.standard.repository.ContactRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.ContactTypeRepository;
+import uk.gov.justice.digital.delius.transformers.ContactTransformer;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.justice.digital.delius.util.EntityHelper.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ContactService_addContactForBookingNumberUpdateTest {
+
+    private ContactService contactService;
+
+    @Mock
+    private ContactRepository contactRepository;
+    @Mock
+    private ContactTypeRepository contactTypeRepository;
+    @Captor
+    private ArgumentCaptor<Contact> contactArgumentCaptor;
+
+    @Before
+    public void setup() {
+        contactService = new ContactService(contactRepository, contactTypeRepository, new ContactTransformer());
+        when(contactTypeRepository.findByCode(any())).thenReturn(Optional.of(aContactType()));
+    }
+
+    @Test
+    public void willSetContactTypeAsDSSUpdate() {
+        contactService.addContactForBookingNumberUpdate(anOffender(), aCustodyEvent());
+
+        verify(contactTypeRepository).findByCode("EDSS");
+    }
+
+    @Test
+    public void willSetEventOnContact() {
+        final var event = aCustodyEvent();
+        contactService.addContactForBookingNumberUpdate(anOffender(), event);
+
+        verify(contactRepository).save(contactArgumentCaptor.capture());
+        assertThat(contactArgumentCaptor.getValue().getEvent()).isEqualTo(event);
+    }
+
+
+
+    @Test
+    public void willSetNoteToIncludeCustodialStatus() {
+        final var event = aCustodyEvent();
+        event.getDisposal().getCustody().setPrisonerNumber("44463B");
+        contactService.addContactForBookingNumberUpdate(anOffender(), event);
+
+        verify(contactRepository).save(contactArgumentCaptor.capture());
+
+        assertThat(contactArgumentCaptor.getValue().getNotes()).contains("Prison Number: 44463B\n");
+    }
+
+    @Test
+    public void willUseFirstOrderManagerForOrganisationLinks() {
+        final var teamForActiveOM = aTeam().toBuilder().teamId(88L).build();
+        final var staffForActiveOM = aStaff().toBuilder().staffId(77L).build();
+        final var teamForInactiveOM1 = aTeam().toBuilder().teamId(66L).build();
+        final var staffForInactiveOM1 = aStaff().toBuilder().staffId(55L).build();
+        final var teamForInactiveOM2 = aTeam().toBuilder().teamId(44L).build();
+        final var staffForInactiveOM2 = aStaff().toBuilder().staffId(33L).build();
+        final var probationArea = aProbationArea();
+        final var activeOrderManager = anOrderManager()
+                .toBuilder()
+                .team(teamForActiveOM)
+                .staff(staffForActiveOM)
+                .probationArea(probationArea)
+                .endDate(null)
+                .activeFlag(1L)
+                .build();
+        final var inactiveOrderManager1 = anOrderManager()
+                .toBuilder()
+                .team(teamForInactiveOM1)
+                .staff(staffForInactiveOM1)
+                .probationArea(probationArea)
+                .endDate(LocalDateTime.now())
+                .activeFlag(0L)
+                .build();
+        final var inactiveOrderManager2 = anOrderManager()
+                .toBuilder()
+                .team(teamForInactiveOM2)
+                .staff(staffForInactiveOM2)
+                .probationArea(probationArea)
+                .endDate(LocalDateTime.now())
+                .activeFlag(0L)
+                .build();
+        final var event = aCustodyEvent()
+                .toBuilder()
+                .orderManagers(List.of(inactiveOrderManager1, activeOrderManager, inactiveOrderManager2))
+                .build();
+
+        contactService.addContactForBookingNumberUpdate(anOffender(), event);
+
+        verify(contactRepository).save(contactArgumentCaptor.capture());
+        assertThat(contactArgumentCaptor.getValue().getTeam()).isEqualTo(teamForActiveOM);
+        assertThat(contactArgumentCaptor.getValue().getTeamProviderId()).isEqualTo(teamForActiveOM.getTeamId());
+        assertThat(contactArgumentCaptor.getValue().getStaff()).isEqualTo(staffForActiveOM);
+        assertThat(contactArgumentCaptor.getValue().getStaffEmployeeId()).isEqualTo(staffForActiveOM.getStaffId());
+        assertThat(contactArgumentCaptor.getValue().getProbationArea()).isEqualTo(probationArea);
+    }
+
+}

--- a/src/test/java/uk/gov/justice/digital/delius/service/OffenderPrisonerServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/OffenderPrisonerServiceTest.java
@@ -1,0 +1,108 @@
+package uk.gov.justice.digital.delius.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.MockitoAnnotations;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
+import uk.gov.justice.digital.delius.jpa.standard.entity.OffenderPrisoner;
+import uk.gov.justice.digital.delius.jpa.standard.repository.EventRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderPrisonerRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static uk.gov.justice.digital.delius.util.EntityHelper.*;
+
+class OffenderPrisonerServiceTest {
+    private OffenderPrisonerRepository offenderPrisonerRepository;
+    private EventRepository eventRepository;
+    private OffenderPrisonerService offenderPrisonerService;
+
+    @Captor
+    private ArgumentCaptor<Set<OffenderPrisoner>> offenderPrisonersCaptor;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        offenderPrisonerRepository = mock(OffenderPrisonerRepository.class);
+        eventRepository = mock(EventRepository.class);
+
+        offenderPrisonerService = new OffenderPrisonerService(eventRepository, offenderPrisonerRepository);
+        when(eventRepository.findByOffenderId(anyLong())).thenReturn(List.of(aCustodyEvent()));
+    }
+
+    @Test
+    void willDeleteExistingByOffenderId() {
+        offenderPrisonerService.refreshOffenderPrisonersFor(anOffender().toBuilder().offenderId(99L).build());
+
+        verify(offenderPrisonerRepository).deleteAllByOffenderId(99L);
+    }
+
+    @Test
+    void willCollateAllEventsWithPrisonerNumbers() {
+        when(eventRepository.findByOffenderId(99L)).thenReturn(List.of(
+                anEvent(),
+                custodyEvent("12345A", LocalDate.now()),
+                custodyEvent("12345B", LocalDate.now().minusDays(1)),
+                custodyEvent("12345C", LocalDate.now().minusDays(2)),
+                custodyEvent("12345D", LocalDate.now().minusDays(3)),
+                custodyEvent(null, LocalDate.now().minusDays(4)),
+                anEvent(),
+                anEvent()
+        ));
+
+        offenderPrisonerService.refreshOffenderPrisonersFor(anOffender().toBuilder().offenderId(99L).build());
+
+        verify(offenderPrisonerRepository).saveAll(offenderPrisonersCaptor.capture());
+
+        assertThat(offenderPrisonersCaptor.getValue()).containsExactlyInAnyOrder(
+                OffenderPrisoner.builder().prisonerNumber("12345A").offenderId(99L).build(),
+                OffenderPrisoner.builder().prisonerNumber("12345B").offenderId(99L).build(),
+                OffenderPrisoner.builder().prisonerNumber("12345C").offenderId(99L).build(),
+                OffenderPrisoner.builder().prisonerNumber("12345D").offenderId(99L).build()
+        );
+    }
+
+    @Test
+    void willSetPrisonNumberFromLatestCustodialEvent() {
+        when(eventRepository.findByOffenderId(99L)).thenReturn(List.of(
+                anEvent(),
+                custodyEvent("12345C", LocalDate.now().minusDays(2)),
+                custodyEvent("12345B", LocalDate.now().minusDays(1)),
+                custodyEvent("12345A", LocalDate.now()),
+                custodyEvent("12345D", LocalDate.now().minusDays(3)),
+                custodyEvent(null, LocalDate.now().minusDays(4)),
+                anEvent(),
+                anEvent()
+        ));
+
+        var offender = offenderPrisonerService.refreshOffenderPrisonersFor(anOffender().toBuilder().offenderId(99L).build());
+        assertThat(offender.getMostRecentPrisonerNumber()).isEqualTo("12345A");
+
+    }
+
+    private Event custodyEvent(String prisonNumber, LocalDate disposalStartDate) {
+        final var custody = aCustodyEvent()
+                .getDisposal()
+                .getCustody()
+                .toBuilder()
+                .prisonerNumber(prisonNumber)
+                .build();
+        final var disposal = aCustodyEvent()
+                .getDisposal()
+                .toBuilder()
+                .custody(custody)
+                .startDate(disposalStartDate)
+                .build();
+        return aCustodyEvent()
+                .toBuilder()
+                .disposal(disposal)
+                .build();
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
+++ b/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
@@ -422,6 +422,7 @@ public class EntityHelper {
                                 .sentenceType("SC")
                                 .build())
                 .event(anEvent(eventId))
+                .startDate(LocalDate.now())
                 .build();
     }
 


### PR DESCRIPTION
We replicate Delius when updating booking number which includes

- Updating the booking number (aka prison number) on Custody record
- Updating the most recent number of the Offender record
- Recreating all the associated OFFENDER_PRISONER records
- Creating a CONTACT record
- Notify CRCs via the SPG of the updated EVENT

All rules have been lifted from existing Delius legacy application