### PR TITLE
Add an endpoint to retrieve the details of a single conviction

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
@@ -334,7 +334,7 @@ public class OffendersResource {
     @ApiOperation(value = "Return the conviction (AKA Delius Event) for a conviction ID and a CRN")
     @ApiResponses(
         value = {
-            @ApiResponse(code = 200, message = "OK", response = Conviction.class, responseContainer = "List"),
+            @ApiResponse(code = 200, message = "OK", response = Conviction.class),
             @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
             @ApiResponse(code = 401, message = "Unauthorised", response = ErrorResponse.class),
             @ApiResponse(code = 403, message = "Forbidden", response = ErrorResponse.class),

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
@@ -330,5 +330,28 @@ public class OffendersResource {
                 .map(convictionService::convictionsFor)
                 .orElseThrow(() -> new NotFoundException(String.format("Offender with crn %s not found", crn)));
     }
+
+    @ApiOperation(value = "Return the conviction (AKA Delius Event) for a conviction ID and a CRN")
+    @ApiResponses(
+        value = {
+            @ApiResponse(code = 200, message = "OK", response = Conviction.class, responseContainer = "List"),
+            @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
+            @ApiResponse(code = 401, message = "Unauthorised", response = ErrorResponse.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = ErrorResponse.class),
+            @ApiResponse(code = 404, message = "The offender CRN or conviction ID is not found", response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
+        })
+    @GetMapping(path = "/offenders/crn/{crn}/convictions/{convictionId}")
+    public Conviction getConvictionForOffenderByCrnAndConvictionId(
+        @ApiParam(name = "crn", value = "CRN for the offender", example = "A123456", required = true)
+        @NotNull @PathVariable(value = "crn") final String crn,
+        @ApiParam(name = "crn", value = "ID for the conviction / event", example = "2500295345", required = true)
+        @NotNull @PathVariable(value = "convictionId") final Long convictionId) {
+
+        return offenderService.offenderIdOfCrn(crn)
+            .map((offenderId) -> convictionService.convictionFor(offenderId, convictionId))
+            .orElseThrow(() -> new NotFoundException(String.format("Offender with crn %s not found", crn)))
+            .orElseThrow(() -> new NotFoundException(String.format("Conviction with ID %s for Offender with crn %s not found", convictionId, crn)));
+    }
 }
 

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/EventRepository.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/EventRepository.java
@@ -10,6 +10,8 @@ import java.util.List;
 public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findByOffenderId(Long offenderId);
 
+    List<Event> findByEventId(Long eventId);
+
     @Query("select event from Event event join DISPOSAL disposal on disposal.event = event join CUSTODY custody on custody.disposal = disposal where custody.prisonerNumber = :prisonBookingNumber")
     List<Event> findByPrisonBookingNumber(@Param("prisonBookingNumber") String prisonBookingNumber);
     @Query("select event from Event event join DISPOSAL disposal on disposal.event = event join CUSTODY custody on custody.disposal = disposal where custody.prisonerNumber = :prisonBookingNumber and event.offenderId  = :offenderId")

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/EventRepository.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/EventRepository.java
@@ -10,8 +10,6 @@ import java.util.List;
 public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findByOffenderId(Long offenderId);
 
-    List<Event> findByEventId(Long eventId);
-
     @Query("select event from Event event join DISPOSAL disposal on disposal.event = event join CUSTODY custody on custody.disposal = disposal where custody.prisonerNumber = :prisonBookingNumber")
     List<Event> findByPrisonBookingNumber(@Param("prisonBookingNumber") String prisonBookingNumber);
     @Query("select event from Event event join DISPOSAL disposal on disposal.event = event join CUSTODY custody on custody.disposal = disposal where custody.prisonerNumber = :prisonBookingNumber and event.offenderId  = :offenderId")

--- a/src/main/java/uk/gov/justice/digital/delius/service/ConvictionService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ConvictionService.java
@@ -116,13 +116,11 @@ public class ConvictionService {
 
     @Transactional(readOnly = true)
     public Optional<Conviction> convictionFor(Long offenderId, Long eventId) {
-        List<uk.gov.justice.digital.delius.jpa.standard.entity.Event> events = eventRepository.findByEventId(eventId);
-        return events
-            .stream()
-            .filter(event -> offenderId.equals(event.getOffenderId()))
-            .filter(event -> !convertToBoolean(event.getSoftDeleted()))
-            .map(convictionTransformer::convictionOf)
-            .findFirst();
+        val event = eventRepository.findById(eventId);
+        return event
+            .filter(e ->  offenderId.equals(e.getOffenderId()))
+            .filter(e -> !convertToBoolean(e.getSoftDeleted()))
+            .map(convictionTransformer::convictionOf);
     }
 
     @Transactional

--- a/src/main/java/uk/gov/justice/digital/delius/service/ConvictionService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ConvictionService.java
@@ -114,6 +114,17 @@ public class ConvictionService {
                 .collect(toList());
     }
 
+    @Transactional(readOnly = true)
+    public Optional<Conviction> convictionFor(Long offenderId, Long eventId) {
+        List<uk.gov.justice.digital.delius.jpa.standard.entity.Event> events = eventRepository.findByEventId(eventId);
+        return events
+            .stream()
+            .filter(event -> offenderId.equals(event.getOffenderId()))
+            .filter(event -> !convertToBoolean(event.getSoftDeleted()))
+            .map(convictionTransformer::convictionOf)
+            .findFirst();
+    }
+
     @Transactional
     public Conviction addCourtCaseFor(Long offenderId, CourtCase courtCase) {
         val event = convictionTransformer.eventOf(

--- a/src/test/java/uk/gov/justice/digital/delius/integration/secure/OffendersResource_getOffenderConvictionsByCrn.java
+++ b/src/test/java/uk/gov/justice/digital/delius/integration/secure/OffendersResource_getOffenderConvictionsByCrn.java
@@ -65,6 +65,24 @@ public class OffendersResource_getOffenderConvictionsByCrn {
     }
 
     @Test
+    public void canGetOffenderConvictionByCrnAndConvictionId() {
+        final var conviction = given()
+            .auth()
+            .oauth2(validOauthToken)
+            .contentType(APPLICATION_JSON_VALUE)
+            .when()
+            .get("/offenders/crn/X320741/convictions/2500295343")
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .as(Conviction.class);
+
+        final var offence = conviction.getOffences().stream().filter(Offence::getMainOffence).findAny().orElseThrow();
+        assertThat(offence.getDetail().getCode()).isEqualTo("05600");
+    }
+
+    @Test
     public void convictionsHaveAssociatedUnpaidWorkData() {
         given()
                 .auth()

--- a/src/test/java/uk/gov/justice/digital/delius/service/ConvictionServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ConvictionServiceTest.java
@@ -45,9 +45,11 @@ public class ConvictionServiceTest {
     @MockBean
     private EventRepository convictionRepository;
 
+    @SuppressWarnings("unused")
     @MockBean
     private OffenderRepository offenderRepository;
 
+    @SuppressWarnings("unused")
     @MockBean
     private ContactService contactService;
 
@@ -57,6 +59,7 @@ public class ConvictionServiceTest {
     @MockBean
     private SpgNotificationService spgNotificationService;
 
+    @SuppressWarnings("unused")
     @MockBean
     private IAPSNotificationService iapsNotificationService;
 
@@ -74,6 +77,26 @@ public class ConvictionServiceTest {
                 .collect(Collectors.toList()))
                 .containsSequence(999L, 99L, 9L);
 
+    }
+
+    @Test
+    public void convictionForEventIdButIsSoftDeleted() {
+        Mockito.when(convictionRepository.findByEventId(99L))
+            .thenReturn(ImmutableList.of(
+                aEvent().toBuilder().eventId(99L).softDeleted(1L).referralDate(LocalDate.now().minusDays(1)).build()
+            ));
+
+        assertThat(convictionService.convictionFor(1L, 99L)).isEmpty();
+    }
+
+    @Test
+    public void convictionForEventId() {
+        Mockito.when(convictionRepository.findByEventId(99L))
+            .thenReturn(ImmutableList.of(
+                aEvent().toBuilder().eventId(99L).offenderId(1L).build()
+            ));
+
+        assertThat(convictionService.convictionFor(1L, 99L)).isPresent();
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/digital/delius/service/ConvictionServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ConvictionServiceTest.java
@@ -81,8 +81,8 @@ public class ConvictionServiceTest {
 
     @Test
     public void convictionForEventIdButIsSoftDeleted() {
-        Mockito.when(convictionRepository.findByEventId(99L))
-            .thenReturn(ImmutableList.of(
+        Mockito.when(convictionRepository.findById(99L))
+            .thenReturn(Optional.of(
                 aEvent().toBuilder().eventId(99L).softDeleted(1L).referralDate(LocalDate.now().minusDays(1)).build()
             ));
 
@@ -91,8 +91,8 @@ public class ConvictionServiceTest {
 
     @Test
     public void convictionForEventId() {
-        Mockito.when(convictionRepository.findByEventId(99L))
-            .thenReturn(ImmutableList.of(
+        Mockito.when(convictionRepository.findById(99L))
+            .thenReturn(Optional.of(
                 aEvent().toBuilder().eventId(99L).offenderId(1L).build()
             ));
 


### PR DESCRIPTION
Code returns the same conviction type but just for a single ID.

Search by event ID which is PK on the EVENT table. 