### PR TITLE
DT-784 Fix to not notify IAPS when SED changes due to DSS

### DIFF
--- a/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_AddOrReplaceOrDeleteCustodyKeyDatesTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_AddOrReplaceOrDeleteCustodyKeyDatesTest.java
@@ -182,6 +182,22 @@ public class ConvictionService_AddOrReplaceOrDeleteCustodyKeyDatesTest {
     }
 
     @Test
+    void willNotNotifyIAPSWhenSentenceExpiryDateChangesDeletesExistingKeyDate() {
+        when(eventRepository.findById(88L)).thenReturn(Optional.of(aCustodyEvent(88L, new ArrayList<>(List.of(
+                aKeyDate("SED", "sentenceExpiryDate", LocalDate.now())
+        )))));
+
+        convictionService.addOrReplaceOrDeleteCustodyKeyDates(99L, 88L, ReplaceCustodyKeyDates
+                .builder()
+                .paroleEligibilityDate(LocalDate.now())
+                .build());
+
+        verify(convictionTransformer).custodyOf(custodyArgumentCaptor.capture());
+
+        verify(iapsNotificationService, never()).notifyEventUpdated(any());
+    }
+
+    @Test
     void willAddContactWithUpdatedRemovedAndDeletedDates() {
         final var event = aCustodyEvent(88L, new ArrayList<>(List.of(
                 aKeyDate("XX", "whatever", LocalDate.of(1995, 1, 1)),


### PR DESCRIPTION
For reasons unknown Delius doe not write a IAPS (?)  row when a sentence expiry date is removed via the DSS feature. This replicates the same behaviour.