### PR TITLE
Dt 835 parallel circle steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
           path: build/reports/tests
   validate-integration:
     executor: hmpps/java
+    parallelism: 4
     environment:
       _JAVA_OPTIONS: -Xmx1024m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false
     steps:
@@ -36,7 +37,10 @@ jobs:
             - gradle-{{ checksum "build.gradle" }}
             - gradle-
       - run:
-          command: ./gradlew testIntegration
+          command: |
+            circleci tests glob "src/testIntegration/**/*.java" | circleci tests split | xargs -n 1 echo
+      - run:
+          command: ./gradlew testIntegration -PtestFilter="`circleci tests glob "src/testIntegration/**/*.java" | circleci tests split`"
       - save_cache:
           paths:
             - ~/.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,13 @@ dependencies {
 }
 
 testIntegration {
+    println(project.getProperties().get("testFilter"))
+    if (project.hasProperty("testFilter")) {
+        List<String> props = project.getProperties().get("testFilter").split("\\s+")
+        props.each {
+            include(it.replace("src/testIntegration/java/", "**/").replace(".java", ".class"))
+        }
+    }
     timeout = Duration.ofMinutes(15)
     useJUnitPlatform ()
     testLogging {

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyKeyDatesAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyKeyDatesAPITest.java
@@ -6,6 +6,8 @@ import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.path.json.JsonPath;
+import org.flywaydb.core.Flyway;
+import org.junit.After;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -55,6 +57,8 @@ public class CustodyKeyDatesAPITest {
     JdbcTemplate jdbcTemplate;
     @Autowired
     protected JwtAuthenticationHelper jwtAuthenticationHelper;
+    @Autowired
+    private Flyway flyway;
 
     @Value("${test.token.good}")
     private String validOauthToken;
@@ -70,6 +74,13 @@ public class CustodyKeyDatesAPITest {
         //noinspection SqlWithoutWhere
         jdbcTemplate.execute("DELETE FROM CONTACT");
     }
+
+    @After
+    public void after() {
+        flyway.clean();
+        flyway.migrate();
+    }
+
 
     @Test
     public void anAddedKeyDateCanBeRetrievedByCRN()  {

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyKeyDatesAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyKeyDatesAPITest.java
@@ -7,7 +7,6 @@ import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.path.json.JsonPath;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +38,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(SpringExtension.class)
 @ActiveProfiles("dev-seed")
 @DirtiesContext
-@Disabled("Disabled until CI memory issues are addressed")
 public class CustodyKeyDatesAPITest {
     private static final String OFFENDER_ID = "2500343964";
     private static final String CRN = "X320741";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyUpdateAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyUpdateAPITest.java
@@ -9,7 +9,6 @@ import io.restassured.config.RestAssuredConfig;
 import org.flywaydb.core.Flyway;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,7 +48,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ActiveProfiles("dev-seed")
 @DirtiesContext
-@Ignore("Disabled until CI memory issues are addressed")
 public class CustodyUpdateAPITest {
     private static final String NOMS_NUMBER = "G9542VP";
     private static final String OFFENDER_ID = "2500343964";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyUpdateBookingNumberAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyUpdateBookingNumberAPITest.java
@@ -9,7 +9,6 @@ import io.restassured.config.RestAssuredConfig;
 import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,7 +44,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @ExtendWith(SpringExtension.class)
 @ActiveProfiles("dev-seed")
 @DirtiesContext
-@Disabled("Disabled until CI memory issues are addressed")
 public class CustodyUpdateBookingNumberAPITest {
     private static final String NOMS_NUMBER = "G9542VP";
     private static final String OFFENDER_ID = "2500343964";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyUpdateNomsNumberAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyUpdateNomsNumberAPITest.java
@@ -9,7 +9,6 @@ import io.restassured.config.RestAssuredConfig;
 import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +35,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(SpringExtension.class)
 @ActiveProfiles("dev-seed")
 @DirtiesContext
-@Disabled("Disabled until CI memory issues are addressed see https://dsdmoj.atlassian.net/browse/PIC-368")
 public class CustodyUpdateNomsNumberAPITest {
 
     @Autowired

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyUpdateNomsNumberAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyUpdateNomsNumberAPITest.java
@@ -88,7 +88,7 @@ public class CustodyUpdateNomsNumberAPITest {
 
         // AND previous owner of NOMS number will have their NOMS number moved to an additional identifier
         final var additionalIdentifier = jdbcTemplate.query(
-                "SELECT ad.IDENTIFIER, o.NOMS_NUMBER, srl.CODE_VALUE from ADDITIONAL_IDENTIFIER ad, OFFENDER o, R_STANDARD_REFERENCE_LIST srl  where o.CRN = ? and o.OFFENDER_ID = ad.OFFENDER_ID and ad.IDENTIFIER_NAME_ID = srl.STANDARD_REFERENCE_LIST_ID",
+                "SELECT ad.IDENTIFIER, o.NOMS_NUMBER, srl.CODE_VALUE from ADDITIONAL_IDENTIFIER ad, OFFENDER o, R_STANDARD_REFERENCE_LIST srl  where o.CRN = ? and o.OFFENDER_ID = ad.OFFENDER_ID and ad.IDENTIFIER_NAME_ID = srl.STANDARD_REFERENCE_LIST_ID order by ad.CREATED_DATETIME desc ",
                 List.of("X320741").toArray(),
                 new ColumnMapRowMapper())
                 .stream()

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffenderIdentifiersAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffenderIdentifiersAPITest.java
@@ -5,7 +5,6 @@ import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +25,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @RunWith(SpringJUnit4ClassRunner.class)
 @ActiveProfiles("dev-seed")
-@Ignore("Disabled until CI memory issues are addressed")
 public class OffenderIdentifiersAPITest {
     private static final String NOMS_NUMBER = "G9542VP";
     private static final String OFFENDER_ID = "2500343964";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_AllocatePrisonOffenderManagerIT.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_AllocatePrisonOffenderManagerIT.java
@@ -8,7 +8,6 @@ import io.restassured.config.RestAssuredConfig;
 import org.flywaydb.core.Flyway;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +39,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @ActiveProfiles("dev-seed")
 @DirtiesContext
 @RunWith(SpringJUnit4ClassRunner.class)
-@Ignore("Disabled until CI memory issues are addressed")
 public class OffendersResource_AllocatePrisonOffenderManagerIT {
 
     @LocalServerPort

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/PersonalCircumstancesAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/PersonalCircumstancesAPITest.java
@@ -5,7 +5,6 @@ import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +27,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ActiveProfiles("dev-seed")
 @DirtiesContext
-@Ignore("Disabled until CI memory issues are addressed")
 public class PersonalCircumstancesAPITest {
     private static final String NOMS_NUMBER = "G9542VP";
     private static final String OFFENDER_ID = "2500343964";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/RegistrationsAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/RegistrationsAPITest.java
@@ -5,7 +5,6 @@ import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +27,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ActiveProfiles("dev-seed")
 @DirtiesContext
-@Ignore("Disabled until CI memory issues are addressed")
 public class RegistrationsAPITest {
     private static final String NOMS_NUMBER = "G9542VP";
     private static final String OFFENDER_ID = "2500343964";


### PR DESCRIPTION
Tactical solution to get all tests running with running out of memory; run them in 4 parallel containers.

- Strategic solution is to convert some SpringBoot tests to our unit tests
- Remove the need to reload flyway data using test transactions

 