### PR TITLE
DT-864 Make transformers stateless pure functions - stage 1

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/NsiManager.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/NsiManager.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 import java.time.LocalDate;
 
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @Entity
 @Table(name = "NSI_MANAGER")

--- a/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
@@ -25,7 +25,7 @@ public class AppointmentService {
     }
 
     public List<Appointment> appointmentsFor(Long offenderId, AppointmentFilter filter) {
-        return appointmentTransformer.appointmentsOf(
+        return AppointmentTransformer.appointmentsOf(
                 contactRepository.findAll(
                         filter.toBuilder().offenderId(offenderId).build(),
                         Sort.by(DESC, "contactDate")));

--- a/src/main/java/uk/gov/justice/digital/delius/service/ContactService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ContactService.java
@@ -39,7 +39,7 @@ public class ContactService {
     }
 
     public List<Contact> contactsFor(Long offenderId, ContactFilter filter) {
-        return contactTransformer.contactsOf(contactRepository.findAll(filter.toBuilder().offenderId(offenderId).build()));
+        return ContactTransformer.contactsOf(contactRepository.findAll(filter.toBuilder().offenderId(offenderId).build()));
     }
 
 

--- a/src/main/java/uk/gov/justice/digital/delius/service/ConvictionService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ConvictionService.java
@@ -110,7 +110,7 @@ public class ConvictionService {
                 .stream()
                 .filter(event -> !convertToBoolean(event.getSoftDeleted()))
                 .sorted(Comparator.comparing(uk.gov.justice.digital.delius.jpa.standard.entity.Event::getReferralDate).reversed())
-                .map(convictionTransformer::convictionOf)
+                .map(ConvictionTransformer::convictionOf)
                 .collect(toList());
     }
 
@@ -120,7 +120,7 @@ public class ConvictionService {
         return event
             .filter(e ->  offenderId.equals(e.getOffenderId()))
             .filter(e -> !convertToBoolean(e.getSoftDeleted()))
-            .map(convictionTransformer::convictionOf);
+            .map(ConvictionTransformer::convictionOf);
     }
 
     @Transactional
@@ -130,7 +130,7 @@ public class ConvictionService {
                 courtCase,
                 calculateNextEventNumber(offenderId));
 
-        val conviction = convictionTransformer.convictionOf(eventRepository.save(event));
+        val conviction = ConvictionTransformer.convictionOf(eventRepository.save(event));
         spgNotificationService.notifyNewCourtCaseCreated(event);
         return conviction;
     }
@@ -277,7 +277,7 @@ public class ConvictionService {
             log.warn("Update custody key dates will be ignored, this feature is switched off ");
         }
 
-        return convictionTransformer.custodyOf(event
+        return ConvictionTransformer.custodyOf(event
                 .getDisposal()
                 .getCustody());
     }
@@ -359,7 +359,7 @@ public class ConvictionService {
                 .stream()
                 .filter(matchTypeCode(typeCode))
                 .findAny()
-                .map(custodyKeyDateTransformer::custodyKeyDateOf);
+                .map(CustodyKeyDateTransformer::custodyKeyDateOf);
     }
 
     private Predicate<KeyDate> matchTypeCode(String typeCode) {
@@ -413,7 +413,7 @@ public class ConvictionService {
     private List<CustodyKeyDate> getCustodyKeyDates(Event event) {
         return event.getDisposal().getCustody().getKeyDates()
                 .stream()
-                .map(custodyKeyDateTransformer::custodyKeyDateOf)
+                .map(CustodyKeyDateTransformer::custodyKeyDateOf)
                 .collect(toList());
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/service/CourtAppearanceService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/CourtAppearanceService.java
@@ -37,7 +37,8 @@ public class CourtAppearanceService {
             .stream()
             .filter(courtAppearance -> !convertToBoolean(courtAppearance.getSoftDeleted()))
             .sorted(Comparator.comparing(uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance::getAppearanceDate).reversed())
-            .map(courtAppearance -> courtAppearanceTransformer.courtAppearanceOf(courtAppearance).toBuilder()
+            .map(courtAppearance -> CourtAppearanceTransformer
+                    .courtAppearanceOf(courtAppearance).toBuilder()
                 .offenceIds(
                     ImmutableList.<String>builder()
                     .addAll(mainOffenceIds(courtAppearance))

--- a/src/main/java/uk/gov/justice/digital/delius/service/CourtReportService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/CourtReportService.java
@@ -34,7 +34,7 @@ public class CourtReportService {
             .stream()
             .filter(this::notDeleted)
             .sorted(Comparator.comparing(uk.gov.justice.digital.delius.jpa.standard.entity.CourtReport::getDateRequested).reversed())
-            .map(courtReportTransformer::courtReportOf)
+            .map(CourtReportTransformer::courtReportOf)
             .collect(toList());
     }
 
@@ -43,7 +43,7 @@ public class CourtReportService {
         Optional<uk.gov.justice.digital.delius.jpa.standard.entity.CourtReport> maybeCourtReport = courtReportRepository.findByOffenderIdAndCourtReportId(offenderId, courtReportId);
         return maybeCourtReport
                 .filter(this::notDeleted)
-                .map(courtReportTransformer::courtReportOf);
+                .map(CourtReportTransformer::courtReportOf);
     }
 
     private boolean notDeleted(uk.gov.justice.digital.delius.jpa.standard.entity.CourtReport courtReport) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/CustodyService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/CustodyService.java
@@ -92,10 +92,11 @@ public class CustodyService {
                         return maybeInstitution.map(institution -> {
                             if (currentlyAtDifferentInstitution(event, institution)) {
                                 telemetryClient.trackEvent("P2PTransferPrisonUpdated", telemetryProperties, null);
-                                return convictionTransformer.custodyOf(updateInstitutionOnEvent(offender, event, institution).getDisposal().getCustody());
+                                return ConvictionTransformer
+                                        .custodyOf(updateInstitutionOnEvent(offender, event, institution).getDisposal().getCustody());
                             } else {
                                 telemetryClient.trackEvent("P2PTransferPrisonUpdateIgnored", telemetryProperties, null);
-                                return convictionTransformer.custodyOf(event.getDisposal().getCustody());
+                                return ConvictionTransformer.custodyOf(event.getDisposal().getCustody());
                             }
                         }).orElseThrow(() -> {
                             telemetryClient.trackEvent("P2PTransferPrisonNotFound", telemetryProperties, null);
@@ -143,11 +144,12 @@ public class CustodyService {
 
         if (maybeExistingBookingNumber.filter(sameAsNewBookingNumber).isPresent()) {
             telemetryClient.trackEvent("P2PImprisonmentStatusBookingNumberAlreadySet", telemetryProperties, null);
-            return convictionTransformer.custodyOf(event.getDisposal().getCustody());
+            return ConvictionTransformer.custodyOf(event.getDisposal().getCustody());
         } else {
             final var eventName = maybeExistingBookingNumber.isPresent() ? "P2PImprisonmentStatusBookingNumberUpdated" : "P2PImprisonmentStatusBookingNumberInserted";
             telemetryClient.trackEvent(eventName, telemetryProperties, null);
-            return convictionTransformer.custodyOf(updateBookingNumberFor(offender, event, updateCustodyBookingNumber.getBookingNumber()).getDisposal().getCustody());
+            return ConvictionTransformer
+                    .custodyOf(updateBookingNumberFor(offender, event, updateCustodyBookingNumber.getBookingNumber()).getDisposal().getCustody());
         }
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/service/DocumentService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/DocumentService.java
@@ -118,69 +118,69 @@ public class DocumentService {
                                 ImmutableList.<OffenderDocumentDetail>builder()
                                         .addAll(toOffenderDocumentDetailList(eventWithCPsPack(events, eventId)))
                                         .addAll(
-                                            documentTransformer
+                                            DocumentTransformer
                                             .offenderDocumentsDetailsOfEventDocuments(
                                                     eventDocuments
                                                             .stream()
                                                             .filter(document -> eventId(document).equals(eventId))
                                                             .collect(toList())))
-                                        .addAll(documentTransformer
+                                        .addAll(DocumentTransformer
                                                 .offenderDocumentsDetailsOfCourtReportDocuments(
                                                         courtReportDocuments
                                                                 .stream()
                                                                 .filter(document -> eventId(document).equals(eventId))
                                                                 .collect(toList()))
                                         )
-                                        .addAll(documentTransformer
+                                        .addAll(DocumentTransformer
                                                 .offenderDocumentsDetailsOfInstitutionReportDocuments(
                                                         institutionReportDocuments
                                                                 .stream()
                                                                 .filter(document -> eventId(document).equals(eventId))
                                                                 .collect(toList()))
                                         )
-                                        .addAll(documentTransformer
+                                        .addAll(DocumentTransformer
                                                 .offenderDocumentsDetailsOfContactDocuments(
                                                         contactEventDocuments
                                                                 .stream()
                                                                 .filter(document -> eventId(document).equals(eventId))
                                                                 .collect(toList()))
                                         )
-                                        .addAll(documentTransformer
+                                        .addAll(DocumentTransformer
                                                 .offenderDocumentsDetailsOfApprovedPremisesReferralDocuments(
                                                         approvedPremisesReferralDocuments
                                                                 .stream()
                                                                 .filter(document -> eventId(document).equals(eventId))
                                                                 .collect(toList()))
                                         )
-                                        .addAll(documentTransformer
+                                        .addAll(DocumentTransformer
                                                 .offenderDocumentsDetailsOfAssessmentDocuments(
                                                         assessmentDocuments
                                                                 .stream()
                                                                 .filter(document -> eventId(document).equals(eventId))
                                                                 .collect(toList()))
                                         )
-                                        .addAll(documentTransformer
+                                        .addAll(DocumentTransformer
                                                 .offenderDocumentsDetailsOfCaseAllocationDocuments(
                                                         caseAllocationDocuments
                                                                 .stream()
                                                                 .filter(document -> eventId(document).equals(eventId))
                                                                 .collect(toList()))
                                         )
-                                        .addAll(documentTransformer
+                                        .addAll(DocumentTransformer
                                                 .offenderDocumentsDetailsOfReferralDocuments(
                                                         referralDocuments
                                                                 .stream()
                                                                 .filter(document -> eventId(document).equals(eventId))
                                                                 .collect(toList()))
                                         )
-                                        .addAll(documentTransformer
+                                        .addAll(DocumentTransformer
                                                 .offenderDocumentsDetailsOfNsiDocuments(
                                                         nsiEventDocuments
                                                                 .stream()
                                                                 .filter(document -> eventId(document).equals(eventId))
                                                                 .collect(toList()))
                                         )
-                                        .addAll(documentTransformer
+                                        .addAll(DocumentTransformer
                                                 .offenderDocumentsDetailsOfUPWAppointmentDocuments(
                                                         upwAppointmentDocuments
                                                                 .stream()
@@ -197,22 +197,22 @@ public class DocumentService {
                 .documents(
                         ImmutableList.<OffenderDocumentDetail>builder()
                                 .addAll(previousConvictions(offender))
-                                .addAll(documentTransformer
+                                .addAll(DocumentTransformer
                                         .offenderDocumentsDetailsOfOffenderDocuments(
                                                 offenderDocumentRepository.findByOffenderId(offenderId)))
-                                .addAll(documentTransformer
+                                .addAll(DocumentTransformer
                                         .offenderDocumentsDetailsOfAddressAssessmentDocuments(
                                                 addressAssessmentDocumentRepository.findByOffenderId(offenderId)))
-                                .addAll(documentTransformer
+                                .addAll(DocumentTransformer
                                         .offenderDocumentsDetailsOfPersonalContactDocuments(
                                                 personalContactDocumentRepository.findByOffenderId(offenderId)))
-                                .addAll(documentTransformer
+                                .addAll(DocumentTransformer
                                         .offenderDocumentsDetailsOfPersonalCircumstanceDocuments(
                                                 personalCircumstanceDocumentRepository.findByOffenderId(offenderId)))
-                                .addAll(documentTransformer
+                                .addAll(DocumentTransformer
                                         .offenderDocumentsDetailsOfContactDocuments(
                                                 allContactDocuments.stream().filter(not(this::isEventRelated)).collect(toList())))
-                                .addAll(documentTransformer
+                                .addAll(DocumentTransformer
                                         .offenderDocumentsDetailsOfNsiDocuments(
                                                 allNsiDocuments.stream().filter(not(this::isEventRelated)).collect(toList())))
                                 .build()
@@ -278,14 +278,14 @@ public class DocumentService {
 
     private List<OffenderDocumentDetail> toOffenderDocumentDetailList(Optional<Event> maybeEvent) {
         return maybeEvent
-                .map(event -> ImmutableList.of(documentTransformer.offenderDocumentDetailsOfCpsPack(event)))
+                .map(event -> ImmutableList.of(DocumentTransformer.offenderDocumentDetailsOfCpsPack(event)))
                 .orElseGet(ImmutableList::of);
     }
 
     private List<OffenderDocumentDetail> previousConvictions(Offender offender) {
         return Optional.of(offender)
                 .filter(this::hasPreviousConvictions)
-                .map(offenderWithPreCPns -> ImmutableList.of(documentTransformer.offenderDocumentDetailsOfPreviousConvictions(offenderWithPreCPns)))
+                .map(offenderWithPreCPns -> ImmutableList.of(DocumentTransformer.offenderDocumentDetailsOfPreviousConvictions(offenderWithPreCPns)))
                 .orElseGet(ImmutableList::of);
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/service/InstitutionalReportService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/InstitutionalReportService.java
@@ -34,7 +34,7 @@ public class InstitutionalReportService {
         return institutionalReports
             .stream()
             .filter(this::notDeleted)
-            .map(institutionalReportTransformer::institutionalReportOf)
+            .map(InstitutionalReportTransformer::institutionalReportOf)
             .collect(toList());
     }
 
@@ -45,7 +45,7 @@ public class InstitutionalReportService {
 
         return maybeInstitutionalReport
                 .filter(this::notDeleted)
-                .map(institutionalReportTransformer::institutionalReportOf);
+                .map(InstitutionalReportTransformer::institutionalReportOf);
     }
 
     private boolean notDeleted(uk.gov.justice.digital.delius.jpa.standard.entity.InstitutionalReport institutionalReport) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/NsiService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/NsiService.java
@@ -38,13 +38,13 @@ public class NsiService {
             .map(nsis -> nsis.stream()
                 .filter(e -> !convertToBoolean(e.getEvent().getSoftDeleted()))
                 .filter(e -> nsiCodes.contains(e.getNsiType().getCode()))
-                .map(nsiTransformer::nsiOf)
+                .map(NsiTransformer::nsiOf)
                 .collect(Collectors.toList()))
             .map(NsiWrapper::new);
     }
 
     public Optional<Nsi> getNsiById(Long nsiId) {
         return nsiRepository.findById(nsiId)
-                .map(nsiTransformer::nsiOf);
+                .map(NsiTransformer::nsiOf);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/service/OffenceService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/OffenceService.java
@@ -41,9 +41,9 @@ public class OffenceService {
 
     private ImmutableList<Offence> combineMainAndAdditionalOffences(MainOffence mainOffence) {
         List<Offence> additionalOffences =
-            additionalOffenceTransformer.offencesOf(mainOffence.getEvent().getAdditionalOffences());
+            AdditionalOffenceTransformer.offencesOf(mainOffence.getEvent().getAdditionalOffences());
         return ImmutableList.<Offence>builder()
-            .add(mainOffenceTransformer.offenceOf(mainOffence))
+            .add(MainOffenceTransformer.offenceOf(mainOffence))
             .addAll(additionalOffences)
             .build();
     }

--- a/src/main/java/uk/gov/justice/digital/delius/service/OffenderIdentifierService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/OffenderIdentifierService.java
@@ -50,7 +50,7 @@ public class OffenderIdentifierService {
         } else {
             log.warn("Update NOMS number will be ignored, this feature is switched off ");
         }
-        return offenderTransformer.idsOf(offender);
+        return OffenderTransformer.idsOf(offender);
     }
 
     private void doUpdateNomsNumber(String nomsNumber, Offender offender) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/OffenderManagerService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/OffenderManagerService.java
@@ -55,12 +55,12 @@ public class OffenderManagerService {
                         offender.getOffenderManagers()
                                 .stream()
                                 .filter(OffenderManager::isActive)
-                                .map(offenderManagerTransformer::offenderManagerOf)
+                                .map(OffenderManagerTransformer::offenderManagerOf)
                                 .collect(Collectors.toList()),
                         offender.getPrisonOffenderManagers()
                                 .stream()
                                 .filter(PrisonOffenderManager::isActive)
-                                .map(offenderManagerTransformer::offenderManagerOf)
+                                .map(OffenderManagerTransformer::offenderManagerOf)
                                 .collect(Collectors.toList())
                 ) );
     }
@@ -165,7 +165,7 @@ public class OffenderManagerService {
         }, () -> contactService.addContactForPOMAllocation(newPrisonOffenderManager));
 
 
-        return offenderManagerTransformer.offenderManagerOf(newPrisonOffenderManager);
+        return OffenderManagerTransformer.offenderManagerOf(newPrisonOffenderManager);
     }
 
     private StandardReference getAllocationReason(ProbationArea probationArea, Optional<PrisonOffenderManager> existingPrisonOffenderManager) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/OffenderService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/OffenderService.java
@@ -36,7 +36,7 @@ public class OffenderService {
 
         Optional<Offender> maybeOffender = offenderRepository.findByOffenderId(offenderId);
 
-        return maybeOffender.map(offenderTransformer::fullOffenderOf);
+        return maybeOffender.map(OffenderTransformer::fullOffenderOf);
     }
 
     @Transactional(readOnly = true)
@@ -44,7 +44,7 @@ public class OffenderService {
 
         Optional<Offender> maybeOffender = offenderRepository.findByCrn(crn);
 
-        return maybeOffender.map(offenderTransformer::fullOffenderOf);
+        return maybeOffender.map(OffenderTransformer::fullOffenderOf);
     }
 
     @Transactional(readOnly = true)
@@ -52,7 +52,7 @@ public class OffenderService {
 
         Optional<Offender> maybeOffender = offenderRepository.findByNomsNumber(nomsNumber);
 
-        return maybeOffender.map(offenderTransformer::fullOffenderOf);
+        return maybeOffender.map(OffenderTransformer::fullOffenderOf);
     }
 
     @Transactional(readOnly = true)
@@ -60,7 +60,7 @@ public class OffenderService {
 
         Optional<Offender> maybeOffender = offenderRepository.findByOffenderId(offenderId);
 
-        return maybeOffender.map(offenderTransformer::offenderSummaryOf);
+        return maybeOffender.map(OffenderTransformer::offenderSummaryOf);
     }
 
     @Transactional(readOnly = true)
@@ -68,7 +68,7 @@ public class OffenderService {
 
         Optional<Offender> maybeOffender = offenderRepository.findByCrn(crn);
 
-        return maybeOffender.map(offenderTransformer::offenderSummaryOf);
+        return maybeOffender.map(OffenderTransformer::offenderSummaryOf);
     }
 
     @Transactional(readOnly = true)
@@ -76,7 +76,7 @@ public class OffenderService {
 
         Optional<Offender> maybeOffender = offenderRepository.findByNomsNumber(nomsNumber);
 
-        return maybeOffender.map(offenderTransformer::offenderSummaryOf);
+        return maybeOffender.map(OffenderTransformer::offenderSummaryOf);
     }
 
     public Optional<String> crnOf(Long offenderId) {
@@ -118,28 +118,28 @@ public class OffenderService {
     @Transactional(readOnly = true)
     public Optional<List<OffenderManager>> getOffenderManagersForOffenderId(Long offenderId) {
         return offenderRepository.findByOffenderId(offenderId).map(
-                offender -> offenderTransformer.offenderManagersOf(offender.getOffenderManagers()));
+                offender -> OffenderTransformer.offenderManagersOf(offender.getOffenderManagers()));
 
     }
 
     @Transactional(readOnly = true)
     public Optional<List<OffenderManager>> getOffenderManagersForNomsNumber(String nomsNumber) {
         return offenderRepository.findByNomsNumber(nomsNumber).map(
-                offender -> offenderTransformer.offenderManagersOf(offender.getOffenderManagers()));
+                offender -> OffenderTransformer.offenderManagersOf(offender.getOffenderManagers()));
 
     }
 
     @Transactional(readOnly = true)
     public Optional<List<OffenderManager>> getOffenderManagersForCrn(String crn) {
         return offenderRepository.findByCrn(crn).map(
-                offender -> offenderTransformer.offenderManagersOf(offender.getOffenderManagers()));
+                offender -> OffenderTransformer.offenderManagersOf(offender.getOffenderManagers()));
 
     }
 
     @Transactional(readOnly = true)
     public Optional<List<ResponsibleOfficer>> getResponsibleOfficersForNomsNumber(String nomsNumber, boolean current) {
         return offenderRepository.findByNomsNumber(nomsNumber).map(
-                offender -> offenderTransformer.responsibleOfficersOf(offender, current));
+                offender -> OffenderTransformer.responsibleOfficersOf(offender, current));
 
     }
 
@@ -148,7 +148,7 @@ public class OffenderService {
         final var actualCustodialEvent = convictionService.getActiveCustodialEvent(offenderId);
         final var custody = findCustodyOrThrow(actualCustodialEvent);
         return custody.findLatestRelease()
-                .map(releaseTransformer::offenderLatestRecallOf)
+                .map(ReleaseTransformer::offenderLatestRecallOf)
                 .orElse(OffenderLatestRecall.NO_RELEASE);
     }
 
@@ -158,8 +158,8 @@ public class OffenderService {
 
         return OffenderIdentifiers
                 .builder()
-                .primaryIdentifiers(offenderTransformer.idsOf(offender))
-                .additionalIdentifiers(offenderTransformer.additionalIdentifiersOf(offender.getAdditionalIdentifiers()))
+                .primaryIdentifiers(OffenderTransformer.idsOf(offender))
+                .additionalIdentifiers(OffenderTransformer.additionalIdentifiersOf(offender.getAdditionalIdentifiers()))
                 .offenderId(offender.getOffenderId())
                 .build();
     }

--- a/src/main/java/uk/gov/justice/digital/delius/service/PersonalCircumstanceService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/PersonalCircumstanceService.java
@@ -29,7 +29,7 @@ public class PersonalCircumstanceService {
                 .stream()
                 .filter(personalCircumstance -> !convertToBoolean(personalCircumstance.getSoftDeleted()))
                 .sorted(Comparator.comparing(uk.gov.justice.digital.delius.jpa.standard.entity.PersonalCircumstance::getPersonalCircumstanceId).reversed())
-                .map(personalCircumstanceTransformer::personalCircumstanceOf)
+                .map(PersonalCircumstanceTransformer::personalCircumstanceOf)
                 .collect(toList());
     }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/service/ReferenceDataService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ReferenceDataService.java
@@ -58,13 +58,13 @@ public class ReferenceDataService {
     public List<ProbationArea> getProbationAreas(Optional<List<String>> maybeCodes, boolean restrictActive) {
         ProbationAreaFilter probationAreaFilter = ProbationAreaFilter.builder().probationAreaCodes(maybeCodes).restrictActive(restrictActive).build();
 
-        return probationAreaTransformer.probationAreasOf(probationAreaRepository.findAll(probationAreaFilter));
+        return ProbationAreaTransformer.probationAreasOf(probationAreaRepository.findAll(probationAreaFilter));
     }
 
     public List<ProbationArea> getProbationAreasForCode(String code, boolean restrictActive) {
         ProbationAreaFilter probationAreaFilter = ProbationAreaFilter.builder().probationAreaCodes(Optional.of(Lists.newArrayList(code))).restrictActive(restrictActive).build();
 
-        return probationAreaTransformer.probationAreasOf(probationAreaRepository.findAll(probationAreaFilter));
+        return ProbationAreaTransformer.probationAreasOf(probationAreaRepository.findAll(probationAreaFilter));
     }
 
     public StandardReference pomAllocationAutoTransferReason() {

--- a/src/main/java/uk/gov/justice/digital/delius/service/RegistrationService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/RegistrationService.java
@@ -29,7 +29,7 @@ public class RegistrationService {
                 .stream()
                 .filter(registration -> !convertToBoolean(registration.getSoftDeleted()))
                 .sorted(Comparator.comparing(uk.gov.justice.digital.delius.jpa.standard.entity.Registration::getRegistrationDate).reversed())
-                .map(registrationTransformer::registrationOf)
+                .map(RegistrationTransformer::registrationOf)
                 .collect(toList());
     }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/service/StaffService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/StaffService.java
@@ -35,7 +35,7 @@ public class StaffService {
     public Optional<List<ManagedOffender>> getManagedOffendersByStaffCode(String staffCode, boolean current) {
 
         return staffRepository.findByOfficerCode(staffCode).map(
-                staff -> offenderTransformer.managedOffenderOf(staff, current)
+                staff -> OffenderTransformer.managedOffenderOf(staff, current)
         );
     }
 
@@ -43,7 +43,7 @@ public class StaffService {
     public Optional<StaffDetails> getStaffDetails(String staffCode) {
         return staffRepository
                 .findByOfficerCode(staffCode)
-                .map(staffTransformer::staffDetailsOf)
+                .map(StaffTransformer::staffDetailsOf)
                 .map(staffDetails ->
                         Optional.ofNullable(staffDetails.getUsername())
                                 .map(username -> staffDetails
@@ -56,7 +56,7 @@ public class StaffService {
     @Transactional(readOnly = true)
     public Optional<StaffDetails> getStaffDetailsByUsername(String username) {
         return staffRepository.findByUsername(username)
-                .map(staffTransformer::staffDetailsOf)
+                .map(StaffTransformer::staffDetailsOf)
                 .map(addEmailFromLdap());
     }
 
@@ -66,7 +66,7 @@ public class StaffService {
 
         return staffRepository.findByUsernames(capitalisedUsernames)
                 .stream()
-                .map(staffTransformer::staffDetailsOf)
+                .map(StaffTransformer::staffDetailsOf)
                 .map(addEmailFromLdap())
                 .collect(Collectors.toList());
     }

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AdditionalOffenceTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AdditionalOffenceTransformer.java
@@ -23,7 +23,7 @@ public class AdditionalOffenceTransformer {
     }
 
 
-    public List<Offence> offencesOf(List<AdditionalOffence> additionalOffences) {
+    public static List<Offence> offencesOf(List<AdditionalOffence> additionalOffences) {
         return additionalOffences.stream()
             .filter(offence -> !convertToBoolean(offence.getSoftDeleted()))
             .map(additionalOffence ->

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentTransformer.java
@@ -24,15 +24,15 @@ public class AppointmentTransformer {
     }
 
 
-    public List<Appointment> appointmentsOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.Contact> contacts) {
+    public static List<Appointment> appointmentsOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.Contact> contacts) {
         return contacts.stream()
-                .map(this::appointmentOf)
+                .map(AppointmentTransformer::appointmentOf)
                 .collect(Collectors.toList());
     }
 
-    private Appointment appointmentOf(uk.gov.justice.digital.delius.jpa.standard.entity.Contact contact) {
+    private static Appointment appointmentOf(uk.gov.justice.digital.delius.jpa.standard.entity.Contact contact) {
         return Appointment.builder()
-                .eventId(contactTransformer.eventIdOf(contact.getEvent()))
+                .eventId(ContactTransformer.eventIdOf(contact.getEvent()))
                 .alertActive(ynToBoolean(contact.getAlertActive()))
                 .appointmentDate(contact.getContactDate())
                 .appointmentStartTime(contact.getContactStartTime())
@@ -41,20 +41,20 @@ public class AppointmentTransformer {
                 .appointmentOutcomeType(appointmentOutcomeTypeOf(contact.getContactOutcomeType()))
                 .appointmentType(appointmentTypeOf(contact.getContactType()))
                 .createdDateTime(contact.getCreatedDateTime())
-                .explanation(contactTransformer.explanationOf(contact.getExplanation()))
+                .explanation(ContactTransformer.explanationOf(contact.getExplanation()))
                 .lastUpdatedDateTime(contact.getLastUpdatedDateTime())
-                .licenceCondition(contactTransformer.licenceConditionOf(contact.getLicenceCondition()))
+                .licenceCondition(ContactTransformer.licenceConditionOf(contact.getLicenceCondition()))
                 .linkedContactId(contact.getLinkedContactId())
                 .notes(contact.getNotes())
-                .nsi(contactTransformer.nsiOf(contact.getNsi()))
-                .requirement(requirementTransformer.requirementOf(contact.getRequirement()))
-                .probationArea(contactTransformer.probationAreaOf(contact.getProbationArea()))
-                .providerEmployee(contactTransformer.providerEmployeeOf(contact.getProviderEmployee()))
+                .nsi(ContactTransformer.nsiOf(contact.getNsi()))
+                .requirement(RequirementTransformer.requirementOf(contact.getRequirement()))
+                .probationArea(ContactTransformer.probationAreaOf(contact.getProbationArea()))
+                .providerEmployee(ContactTransformer.providerEmployeeOf(contact.getProviderEmployee()))
                 .officeLocation(officeLocationOf(contact.getOfficeLocation()))
-                .providerLocation(contactTransformer.providerLocationOf(contact.getProviderLocation()))
-                .team(contactTransformer.teamOf(contact.getTeam()))
-                .providerTeam(contactTransformer.providerTeamOf(contact.getProviderTeam()))
-                .staff(contactTransformer.staffOf(contact.getStaff()))
+                .providerLocation(ContactTransformer.providerLocationOf(contact.getProviderLocation()))
+                .team(ContactTransformer.teamOf(contact.getTeam()))
+                .providerTeam(ContactTransformer.providerTeamOf(contact.getProviderTeam()))
+                .staff(ContactTransformer.staffOf(contact.getStaff()))
                 .hoursCredited(contact.getHoursCredited())
                 .visorContact(ynToBoolean(contact.getVisorContact()))
                 .attended(attendedOf(contact.getAttended()))
@@ -64,7 +64,7 @@ public class AppointmentTransformer {
                 .build();
     }
 
-    private KeyValue appointmentOutcomeTypeOf(ContactOutcomeType contactOutcomeType) {
+    private static KeyValue appointmentOutcomeTypeOf(ContactOutcomeType contactOutcomeType) {
         return Optional.ofNullable(contactOutcomeType).map(cot ->
                 KeyValue.builder()
                         .code(cot.getCode())
@@ -72,18 +72,18 @@ public class AppointmentTransformer {
                         .build()).orElse(null);
     }
 
-    private Appointment.Attended attendedOf(String yn) {
+    private static Appointment.Attended attendedOf(String yn) {
        return Optional.ofNullable(ynToBoolean(yn)).map(flag -> flag ? ATTENDED : UNATTENDED).orElse(NOT_RECORDED);
     }
 
-    private KeyValue appointmentTypeOf(ContactType contactType) {
+    private static KeyValue appointmentTypeOf(ContactType contactType) {
         return KeyValue.builder()
                 .code(contactType.getCode())
                 .description(contactType.getDescription())
                 .build();
     }
 
-    private KeyValue officeLocationOf(OfficeLocation officeLocation) {
+    private static KeyValue officeLocationOf(OfficeLocation officeLocation) {
         return Optional.ofNullable(officeLocation).map(
                 pl -> KeyValue.builder().code(officeLocation.getCode()).description(officeLocation.getDescription()).build()
         ).orElse(null);

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/ContactTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/ContactTransformer.java
@@ -23,18 +23,18 @@ public class ContactTransformer {
 
     private final NsiTransformer nsiTransformer = new NsiTransformer();
 
-    public List<Contact> contactsOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.Contact> contacts) {
+    public static List<Contact> contactsOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.Contact> contacts) {
         return contacts.stream()
                 .sorted(comparing(uk.gov.justice.digital.delius.jpa.standard.entity.Contact::getCreatedDateTime))
-                .map(this::contactOf)
+                .map(ContactTransformer::contactOf)
                 .collect(Collectors.toList());
     }
 
-    public Nsi nsiOf(uk.gov.justice.digital.delius.jpa.standard.entity.Nsi nsi) {
-        return nsiTransformer.nsiOf(nsi);
+    public static Nsi nsiOf(uk.gov.justice.digital.delius.jpa.standard.entity.Nsi nsi) {
+        return NsiTransformer.nsiOf(nsi);
     }
 
-    private uk.gov.justice.digital.delius.data.api.Contact contactOf(uk.gov.justice.digital.delius.jpa.standard.entity.Contact contact) {
+    private static uk.gov.justice.digital.delius.data.api.Contact contactOf(uk.gov.justice.digital.delius.jpa.standard.entity.Contact contact) {
         return uk.gov.justice.digital.delius.data.api.Contact.builder()
                 .eventId(eventIdOf(contact.getEvent()))
                 .alertActive(ynToBoolean(contact.getAlertActive()))
@@ -49,8 +49,8 @@ public class ContactTransformer {
                 .licenceCondition(licenceConditionOf(contact.getLicenceCondition()))
                 .linkedContactId(contact.getLinkedContactId())
                 .notes(contact.getNotes())
-                .nsi(nsiTransformer.nsiOf(contact.getNsi()))
-                .requirement(requirementTransformer.requirementOf(contact.getRequirement()))
+                .nsi(NsiTransformer.nsiOf(contact.getNsi()))
+                .requirement(RequirementTransformer.requirementOf(contact.getRequirement()))
                 .softDeleted(zeroOneToBoolean(contact.getSoftDeleted()))
                 .probationArea(probationAreaOf(contact.getProbationArea()))
                 .partitionArea(partitionAreaOf(contact.getPartitionArea()))
@@ -68,15 +68,15 @@ public class ContactTransformer {
                 .build();
     }
 
-    protected Long eventIdOf(Event event) {
+    protected static Long eventIdOf(Event event) {
         return Optional.ofNullable(event).map(Event::getEventId).orElse(null);
     }
 
-    public KeyValue teamOf(Team team) {
+    public static KeyValue teamOf(Team team) {
         return Optional.ofNullable(team).map(t -> KeyValue.builder().code(t.getCode()).description(t.getDescription()).build()).orElse(null);
     }
 
-    public Human staffOf(Staff staff) {
+    public static Human staffOf(Staff staff) {
         return Optional.ofNullable(staff).map(s -> Human
                 .builder()
                 .forenames(combinedForenamesOf(s.getForename(), s.getForname2()))
@@ -84,17 +84,17 @@ public class ContactTransformer {
                 .build()).orElse(null);
     }
 
-    protected KeyValue providerTeamOf(ProviderTeam providerTeam) {
+    protected static KeyValue providerTeamOf(ProviderTeam providerTeam) {
         return Optional.ofNullable(providerTeam).map(pt -> KeyValue.builder().code(pt.getCode()).description(pt.getName()).build()).orElse(null);
     }
 
-    protected KeyValue providerLocationOf(ProviderLocation providerLocation) {
+    protected static KeyValue providerLocationOf(ProviderLocation providerLocation) {
         return Optional.ofNullable(providerLocation).map(
                 pl -> KeyValue.builder().code(providerLocation.getCode()).description(providerLocation.getDescription()).build()
         ).orElse(null);
     }
 
-    public Human providerEmployeeOf(ProviderEmployee providerEmployee) {
+    public static Human providerEmployeeOf(ProviderEmployee providerEmployee) {
         return Optional.ofNullable(providerEmployee)
                 .map(pe -> Human
                         .builder()
@@ -103,7 +103,7 @@ public class ContactTransformer {
                         .build()).orElse(null);
     }
 
-    private String combinedForenamesOf(String name1, String name2) {
+    private static String combinedForenamesOf(String name1, String name2) {
         Optional<String> maybeSecondName = Optional.ofNullable(name1);
         Optional<String> maybeThirdName = Optional.ofNullable(name2);
 
@@ -113,17 +113,17 @@ public class ContactTransformer {
                 .collect(Collectors.joining(" "));
     }
 
-    protected String partitionAreaOf(PartitionArea partitionArea) {
+    protected static String partitionAreaOf(PartitionArea partitionArea) {
         return Optional.ofNullable(partitionArea).map(PartitionArea::getArea).orElse(null);
     }
 
-    protected KeyValue probationAreaOf(ProbationArea probationArea) {
+    protected static KeyValue probationAreaOf(ProbationArea probationArea) {
         return Optional.ofNullable(probationArea).map(
                 pa -> KeyValue.builder().code(pa.getCode()).description(pa.getDescription()).build()
         ).orElse(null);
     }
 
-    protected uk.gov.justice.digital.delius.data.api.LicenceCondition licenceConditionOf(LicenceCondition licenceCondition) {
+    protected static uk.gov.justice.digital.delius.data.api.LicenceCondition licenceConditionOf(LicenceCondition licenceCondition) {
         return Optional.ofNullable(licenceCondition).map(lc -> uk.gov.justice.digital.delius.data.api.LicenceCondition.builder()
                 .active(zeroOneToBoolean(lc.getActiveFlag()))
                 .commencementDate(lc.getCommencementDate())
@@ -137,7 +137,7 @@ public class ContactTransformer {
                 .build()).orElse(null);
     }
 
-    private KeyValue licenceConditionTypeMainCatOf(LicenceConditionTypeMainCat licenceConditionTypeMainCat) {
+    private static KeyValue licenceConditionTypeMainCatOf(LicenceConditionTypeMainCat licenceConditionTypeMainCat) {
         return Optional.ofNullable(licenceConditionTypeMainCat).map(lctmc ->
                 KeyValue.builder()
                         .code(lctmc.getCode())
@@ -145,7 +145,7 @@ public class ContactTransformer {
                         .build()).orElse(null);
     }
 
-    protected KeyValue explanationOf(Explanation explanation) {
+    protected static KeyValue explanationOf(Explanation explanation) {
         return Optional.ofNullable(explanation).map(e ->
                 KeyValue.builder()
                         .code(e.getCode())
@@ -153,7 +153,7 @@ public class ContactTransformer {
                         .build()).orElse(null);
     }
 
-    private uk.gov.justice.digital.delius.data.api.ContactType contactTypeOf(ContactType contactType) {
+    private static uk.gov.justice.digital.delius.data.api.ContactType contactTypeOf(ContactType contactType) {
         return uk.gov.justice.digital.delius.data.api.ContactType.builder()
                 .code(contactType.getCode())
                 .description(contactType.getDescription())
@@ -161,7 +161,7 @@ public class ContactTransformer {
                 .build();
     }
 
-    private KeyValue contactOutcomeTypeOf(ContactOutcomeType contactOutcomeType) {
+    private static KeyValue contactOutcomeTypeOf(ContactOutcomeType contactOutcomeType) {
         return Optional.ofNullable(contactOutcomeType).map(cot ->
                 KeyValue.builder()
                         .code(cot.getCode())

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceTransformer.java
@@ -27,7 +27,7 @@ public class CourtAppearanceTransformer {
         this.lookupSupplier = lookupSupplier;
     }
 
-    public CourtAppearance courtAppearanceOf(uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance courtAppearance) {
+    public static CourtAppearance courtAppearanceOf(uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance courtAppearance) {
         return CourtAppearance.builder()
             .courtAppearanceId(courtAppearance.getCourtAppearanceId())
             .appearanceDate(courtAppearance.getAppearanceDate())
@@ -37,15 +37,15 @@ public class CourtAppearanceTransformer {
             .eventId(courtAppearance.getEvent().getEventId())
             .teamId(courtAppearance.getTeamId())
             .staffId(courtAppearance.getStaffId())
-            .court(courtTransformer.courtOf(courtAppearance.getCourt()))
+            .court(CourtTransformer.courtOf(courtAppearance.getCourt()))
             .appearanceTypeId(courtAppearance.getAppearanceTypeId())
             .pleaId(courtAppearance.getPleaId())
-            .outcome(outcomeOf(courtAppearance.getOutcome()))
+            .outcome(CourtAppearanceTransformer.outcomeOf(courtAppearance.getOutcome()))
             .remandStatusId(courtAppearance.getRemandStatusId())
             .createdDatetime(courtAppearance.getCreatedDatetime())
             .lastUpdatedDatetime(courtAppearance.getLastUpdatedDatetime())
             .offenderId(courtAppearance.getOffenderId())
-            .courtReports(courtReportsOf(courtAppearance.getCourtReports()))
+            .courtReports(CourtAppearanceTransformer.courtReportsOf(courtAppearance.getCourtReports()))
             .build();
     }
 
@@ -80,7 +80,7 @@ public class CourtAppearanceTransformer {
     }
 
 
-    private KeyValue outcomeOf(StandardReference standardReference) {
+    private static KeyValue outcomeOf(StandardReference standardReference) {
         return Optional.ofNullable(standardReference)
             .map(standardReference1 -> KeyValue.builder()
                                         .code(standardReference.getCodeValue())
@@ -89,10 +89,10 @@ public class CourtAppearanceTransformer {
             .orElse(null);
     }
 
-    private List<CourtReport> courtReportsOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.CourtReport> courtReports) {
+    private static List<CourtReport> courtReportsOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.CourtReport> courtReports) {
         return courtReports.stream()
             .filter(report -> !convertToBoolean(report.getSoftDeleted()))
-            .map(courtReportTransformer::courtReportOf)
+            .map(CourtReportTransformer::courtReportOf)
             .collect(toList());
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/CourtReportTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/CourtReportTransformer.java
@@ -17,7 +17,7 @@ public class CourtReportTransformer {
     }
 
 
-    public CourtReport courtReportOf(uk.gov.justice.digital.delius.jpa.standard.entity.CourtReport report) {
+    public static CourtReport courtReportOf(uk.gov.justice.digital.delius.jpa.standard.entity.CourtReport report) {
         return CourtReport.builder()
                         .courtReportId(report.getCourtReportId())
                         .dateRequested(report.getDateRequested())
@@ -42,7 +42,7 @@ public class CourtReportTransformer {
                         .courtReportTypeId(report.getCourtReportTypeId())
                         .deliveredCourtReportTypeId(report.getDeliveredCourtReportTypeId())
                         .offenderId(report.getOffenderId())
-                        .requiredByCourt(Optional.ofNullable(report.getRequiredByCourt()).map(courtTransformer::courtOf).orElse(null))
+                        .requiredByCourt(Optional.ofNullable(report.getRequiredByCourt()).map(CourtTransformer::courtOf).orElse(null))
                         .pendingTransfer(zeroOneToBoolean(report.getPendingTransfer()))
                         .build();
     }

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/CourtTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/CourtTransformer.java
@@ -9,7 +9,7 @@ import static uk.gov.justice.digital.delius.transformers.TypesTransformer.ynToBo
 public class CourtTransformer {
 
 
-    public Court courtOf(uk.gov.justice.digital.delius.jpa.standard.entity.Court court) {
+    public static Court courtOf(uk.gov.justice.digital.delius.jpa.standard.entity.Court court) {
         return Court.builder()
             .courtId(court.getCourtId())
             .code(court.getCode())

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/CustodyKeyDateTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/CustodyKeyDateTransformer.java
@@ -18,7 +18,7 @@ public class CustodyKeyDateTransformer {
         this.lookupSupplier = lookupSupplier;
     }
 
-    private KeyValue keyValueOf(StandardReference outcome) {
+    private static KeyValue keyValueOf(StandardReference outcome) {
         return KeyValue
                 .builder()
                 .description(outcome.getCodeDescription())
@@ -42,7 +42,7 @@ public class CustodyKeyDateTransformer {
                 .build();
     }
 
-    public CustodyKeyDate custodyKeyDateOf(KeyDate keyDate) {
+    public static CustodyKeyDate custodyKeyDateOf(KeyDate keyDate) {
         return CustodyKeyDate
                 .builder()
                 .date(keyDate.getKeyDate())

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/DocumentTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/DocumentTransformer.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.ReportDocumentDates;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.data.api.OffenderDocumentDetail;
-import uk.gov.justice.digital.delius.data.api.OffenderDocumentDetail.Type;
 import uk.gov.justice.digital.delius.jpa.standard.entity.*;
 
 import java.time.LocalDate;
@@ -17,111 +16,111 @@ import static java.util.stream.Collectors.toList;
 
 @Component
 public class DocumentTransformer {
-    public List<OffenderDocumentDetail> offenderDocumentsDetailsOfOffenderDocuments(List<OffenderDocument> documents) {
+    public static List<OffenderDocumentDetail> offenderDocumentsDetailsOfOffenderDocuments(List<OffenderDocument> documents) {
         return documents
                 .stream()
-                .map(this::offenderDocumentDetailOf)
+                .map(DocumentTransformer::offenderDocumentDetailOf)
                 .collect(toList());
     }
-    public List<OffenderDocumentDetail> offenderDocumentsDetailsOfEventDocuments(List<EventDocument> documents) {
+    public static List<OffenderDocumentDetail> offenderDocumentsDetailsOfEventDocuments(List<EventDocument> documents) {
         return documents
                 .stream()
-                .map(this::offenderDocumentDetailOf)
+                .map(DocumentTransformer::offenderDocumentDetailOf)
                 .collect(toList());
     }
-    public List<OffenderDocumentDetail> offenderDocumentsDetailsOfCourtReportDocuments(List<CourtReportDocument> documents) {
+    public static List<OffenderDocumentDetail> offenderDocumentsDetailsOfCourtReportDocuments(List<CourtReportDocument> documents) {
         return documents
                 .stream()
-                .map(this::offenderDocumentDetailOf)
+                .map(DocumentTransformer::offenderDocumentDetailOf)
                 .collect(toList());
     }
-    public List<OffenderDocumentDetail> offenderDocumentsDetailsOfInstitutionReportDocuments(List<InstitutionalReportDocument> documents) {
+    public static List<OffenderDocumentDetail> offenderDocumentsDetailsOfInstitutionReportDocuments(List<InstitutionalReportDocument> documents) {
         return documents
                 .stream()
-                .map(this::offenderDocumentDetailOf)
-                .collect(toList());
-    }
-
-    public List<OffenderDocumentDetail> offenderDocumentsDetailsOfAddressAssessmentDocuments(List<AddressAssessmentDocument> documents) {
-        return documents
-                .stream()
-                .map(this::offenderDocumentDetailOf)
+                .map(DocumentTransformer::offenderDocumentDetailOf)
                 .collect(toList());
     }
 
-    public List<OffenderDocumentDetail> offenderDocumentsDetailsOfApprovedPremisesReferralDocuments(List<ApprovedPremisesReferralDocument> documents) {
+    public static List<OffenderDocumentDetail> offenderDocumentsDetailsOfAddressAssessmentDocuments(List<AddressAssessmentDocument> documents) {
         return documents
                 .stream()
-                .map(this::offenderDocumentDetailOf)
+                .map(DocumentTransformer::offenderDocumentDetailOf)
                 .collect(toList());
     }
 
-    public List<OffenderDocumentDetail> offenderDocumentsDetailsOfAssessmentDocuments(List<AssessmentDocument> documents) {
+    public static List<OffenderDocumentDetail> offenderDocumentsDetailsOfApprovedPremisesReferralDocuments(List<ApprovedPremisesReferralDocument> documents) {
         return documents
                 .stream()
-                .map(this::offenderDocumentDetailOf)
+                .map(DocumentTransformer::offenderDocumentDetailOf)
                 .collect(toList());
     }
 
-    public List<OffenderDocumentDetail> offenderDocumentsDetailsOfCaseAllocationDocuments(List<CaseAllocationDocument> documents) {
+    public static List<OffenderDocumentDetail> offenderDocumentsDetailsOfAssessmentDocuments(List<AssessmentDocument> documents) {
         return documents
                 .stream()
-                .map(this::offenderDocumentDetailOf)
+                .map(DocumentTransformer::offenderDocumentDetailOf)
                 .collect(toList());
     }
 
-
-    public List<OffenderDocumentDetail> offenderDocumentsDetailsOfPersonalContactDocuments(List<PersonalContactDocument> documents) {
+    public static List<OffenderDocumentDetail> offenderDocumentsDetailsOfCaseAllocationDocuments(List<CaseAllocationDocument> documents) {
         return documents
                 .stream()
-                .map(this::offenderDocumentDetailOf)
-                .collect(toList());
-    }
-
-    public List<OffenderDocumentDetail> offenderDocumentsDetailsOfReferralDocuments(List<ReferralDocument> documents) {
-        return documents
-                .stream()
-                .map(this::offenderDocumentDetailOf)
+                .map(DocumentTransformer::offenderDocumentDetailOf)
                 .collect(toList());
     }
 
 
-    public List<OffenderDocumentDetail> offenderDocumentsDetailsOfNsiDocuments(List<NsiDocument> documents) {
+    public static List<OffenderDocumentDetail> offenderDocumentsDetailsOfPersonalContactDocuments(List<PersonalContactDocument> documents) {
         return documents
                 .stream()
-                .map(this::offenderDocumentDetailOf)
+                .map(DocumentTransformer::offenderDocumentDetailOf)
+                .collect(toList());
+    }
+
+    public static List<OffenderDocumentDetail> offenderDocumentsDetailsOfReferralDocuments(List<ReferralDocument> documents) {
+        return documents
+                .stream()
+                .map(DocumentTransformer::offenderDocumentDetailOf)
                 .collect(toList());
     }
 
 
-    public List<OffenderDocumentDetail> offenderDocumentsDetailsOfPersonalCircumstanceDocuments(List<PersonalCircumstanceDocument> documents) {
+    public static List<OffenderDocumentDetail> offenderDocumentsDetailsOfNsiDocuments(List<NsiDocument> documents) {
         return documents
                 .stream()
-                .map(this::offenderDocumentDetailOf)
+                .map(DocumentTransformer::offenderDocumentDetailOf)
                 .collect(toList());
     }
 
 
-    public List<OffenderDocumentDetail> offenderDocumentsDetailsOfUPWAppointmentDocuments(List<UPWAppointmentDocument> documents) {
+    public static List<OffenderDocumentDetail> offenderDocumentsDetailsOfPersonalCircumstanceDocuments(List<PersonalCircumstanceDocument> documents) {
         return documents
                 .stream()
-                .map(this::offenderDocumentDetailOf)
+                .map(DocumentTransformer::offenderDocumentDetailOf)
                 .collect(toList());
     }
 
 
-    public List<OffenderDocumentDetail> offenderDocumentsDetailsOfContactDocuments(List<ContactDocument> documents) {
+    public static List<OffenderDocumentDetail> offenderDocumentsDetailsOfUPWAppointmentDocuments(List<UPWAppointmentDocument> documents) {
         return documents
                 .stream()
-                .map(this::offenderDocumentDetailOf)
+                .map(DocumentTransformer::offenderDocumentDetailOf)
                 .collect(toList());
     }
 
-    public OffenderDocumentDetail offenderDocumentDetailsOfCpsPack(Event event) {
+
+    public static List<OffenderDocumentDetail> offenderDocumentsDetailsOfContactDocuments(List<ContactDocument> documents) {
+        return documents
+                .stream()
+                .map(DocumentTransformer::offenderDocumentDetailOf)
+                .collect(toList());
+    }
+
+    public static OffenderDocumentDetail offenderDocumentDetailsOfCpsPack(Event event) {
         return OffenderDocumentDetail
                 .builder()
                 .author(Optional.ofNullable(event.getCpsCreatedByUser())
-                        .map(this::fullName)
+                        .map(DocumentTransformer::fullName)
                         .orElse(null))
                 .createdAt(event.getCpsCreatedDatetime())
                 .documentName(event.getCpsDocumentName())
@@ -136,12 +135,12 @@ public class DocumentTransformer {
 
     }
 
-    public OffenderDocumentDetail offenderDocumentDetailsOfPreviousConvictions(Offender offender) {
+    public static OffenderDocumentDetail offenderDocumentDetailsOfPreviousConvictions(Offender offender) {
 
         return OffenderDocumentDetail
                 .builder()
                 .author(Optional.ofNullable(offender.getPreviousConvictionsCreatedByUser())
-                                .map(this::fullName)
+                                .map(DocumentTransformer::fullName)
                                 .orElse(null))
                 .createdAt(offender.getPreviousConvictionsCreatedDatetime())
                 .documentName(offender.getPrevConvictionDocumentName())
@@ -155,7 +154,7 @@ public class DocumentTransformer {
                 .build();
     }
 
-    private OffenderDocumentDetail offenderDocumentDetailOf(OffenderDocument document) {
+    private static OffenderDocumentDetail offenderDocumentDetailOf(OffenderDocument document) {
         return offenderDocumentDetailBuilderOf(document)
                 .type(KeyValue
                         .builder()
@@ -164,7 +163,7 @@ public class DocumentTransformer {
                         .build())
                 .build();
     }
-    private OffenderDocumentDetail offenderDocumentDetailOf(EventDocument document) {
+    private static OffenderDocumentDetail offenderDocumentDetailOf(EventDocument document) {
         return offenderDocumentDetailBuilderOf(document)
                 .type(KeyValue
                         .builder()
@@ -174,7 +173,7 @@ public class DocumentTransformer {
                 .build();
     }
 
-    private OffenderDocumentDetail offenderDocumentDetailOf(CourtReportDocument document) {
+    private static OffenderDocumentDetail offenderDocumentDetailOf(CourtReportDocument document) {
         return offenderDocumentDetailBuilderOf(document)
                 .extendedDescription(String.format(
                         "%s requested by %s on %s",
@@ -204,7 +203,7 @@ public class DocumentTransformer {
                 .build();
     }
 
-    private OffenderDocumentDetail offenderDocumentDetailOf(AddressAssessmentDocument document) {
+    private static OffenderDocumentDetail offenderDocumentDetailOf(AddressAssessmentDocument document) {
         return offenderDocumentDetailBuilderOf(document)
                 .extendedDescription(String.format(
                         "Address assessment on %s",
@@ -218,7 +217,7 @@ public class DocumentTransformer {
                 .build();
     }
 
-    private OffenderDocumentDetail offenderDocumentDetailOf(ApprovedPremisesReferralDocument document) {
+    private static OffenderDocumentDetail offenderDocumentDetailOf(ApprovedPremisesReferralDocument document) {
         return offenderDocumentDetailBuilderOf(document)
                 .extendedDescription(String.format(
                         "Approved premises referral on %s",
@@ -232,7 +231,7 @@ public class DocumentTransformer {
                 .build();
     }
 
-    private OffenderDocumentDetail offenderDocumentDetailOf(AssessmentDocument document) {
+    private static OffenderDocumentDetail offenderDocumentDetailOf(AssessmentDocument document) {
         return offenderDocumentDetailBuilderOf(document)
                 .extendedDescription(String.format(
                         "Assessment for %s on %s",
@@ -247,7 +246,7 @@ public class DocumentTransformer {
                 .build();
     }
 
-    private OffenderDocumentDetail offenderDocumentDetailOf(CaseAllocationDocument document) {
+    private static OffenderDocumentDetail offenderDocumentDetailOf(CaseAllocationDocument document) {
         return offenderDocumentDetailBuilderOf(document)
                 .type(KeyValue
                         .builder()
@@ -257,7 +256,7 @@ public class DocumentTransformer {
                 .build();
     }
 
-    private OffenderDocumentDetail offenderDocumentDetailOf(PersonalContactDocument document) {
+    private static OffenderDocumentDetail offenderDocumentDetailOf(PersonalContactDocument document) {
         return offenderDocumentDetailBuilderOf(document)
                 .extendedDescription(String.format(
                         "Personal contact of type %s with %s",
@@ -272,7 +271,7 @@ public class DocumentTransformer {
                 .build();
     }
 
-    private OffenderDocumentDetail offenderDocumentDetailOf(ReferralDocument document) {
+    private static OffenderDocumentDetail offenderDocumentDetailOf(ReferralDocument document) {
         return offenderDocumentDetailBuilderOf(document)
                 .extendedDescription(String.format(
                         "Referral for %s on %s",
@@ -287,7 +286,7 @@ public class DocumentTransformer {
                 .build();
     }
 
-    private OffenderDocumentDetail offenderDocumentDetailOf(PersonalCircumstanceDocument document) {
+    private static OffenderDocumentDetail offenderDocumentDetailOf(PersonalCircumstanceDocument document) {
         return offenderDocumentDetailBuilderOf(document)
                 .extendedDescription(String.format(
                         "Personal circumstance of %s started on %s",
@@ -302,7 +301,7 @@ public class DocumentTransformer {
                 .build();
     }
 
-    private OffenderDocumentDetail offenderDocumentDetailOf(UPWAppointmentDocument document) {
+    private static OffenderDocumentDetail offenderDocumentDetailOf(UPWAppointmentDocument document) {
         return offenderDocumentDetailBuilderOf(document)
                 .type(KeyValue
                         .builder()
@@ -316,7 +315,7 @@ public class DocumentTransformer {
                         .build();
     }
 
-    private OffenderDocumentDetail offenderDocumentDetailOf(ContactDocument document) {
+    private static OffenderDocumentDetail offenderDocumentDetailOf(ContactDocument document) {
         return offenderDocumentDetailBuilderOf(document)
                 .type(KeyValue
                         .builder()
@@ -331,26 +330,26 @@ public class DocumentTransformer {
     }
 
 
-    private String toHumanReadable(LocalDateTime maybeDate) {
+    private static String toHumanReadable(LocalDateTime maybeDate) {
         return Optional
                 .ofNullable(maybeDate)
                 .map(date -> date.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")))
                 .orElse("");
     }
-    private String toHumanReadable(LocalDate maybeDate) {
+    private static String toHumanReadable(LocalDate maybeDate) {
         return Optional
                 .ofNullable(maybeDate)
                 .map(date -> date.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")))
                 .orElse("");
     }
 
-    private OffenderDocumentDetail offenderDocumentDetailOf(InstitutionalReportDocument document) {
+    private static OffenderDocumentDetail offenderDocumentDetailOf(InstitutionalReportDocument document) {
         return offenderDocumentDetailBuilderOf(document)
                 .extendedDescription(String.format(
                         "%s at %s requested on %s",
                         document.getInstitutionalReport().getInstitutionalReportType().getCodeDescription(),
                         document.getInstitutionalReport().getInstitution().getInstitutionName(),
-                        toHumanReadable(document.getInstitutionalReport().getDateRequested())
+                        DocumentTransformer.toHumanReadable(document.getInstitutionalReport().getDateRequested())
                 ))
                 .type(KeyValue
                         .builder()
@@ -368,12 +367,12 @@ public class DocumentTransformer {
                 .build();
     }
 
-    private OffenderDocumentDetail offenderDocumentDetailOf(NsiDocument document) {
+    private static OffenderDocumentDetail offenderDocumentDetailOf(NsiDocument document) {
         return offenderDocumentDetailBuilderOf(document)
                 .extendedDescription(String.format(
                         "Non Statutory Intervention for %s on %s",
                         document.getNsi().getNsiType().getDescription(),
-                        toHumanReadable(document.getNsi().getReferralDate())
+                        DocumentTransformer.toHumanReadable(document.getNsi().getReferralDate())
                 ))
                 .type(KeyValue
                         .builder()
@@ -383,7 +382,7 @@ public class DocumentTransformer {
                 .build();
     }
 
-    private OffenderDocumentDetail.OffenderDocumentDetailBuilder offenderDocumentDetailBuilderOf(Document document) {
+    private static OffenderDocumentDetail.OffenderDocumentDetailBuilder offenderDocumentDetailBuilderOf(Document document) {
         return OffenderDocumentDetail
                 .builder()
                 .author(authorOf(document))
@@ -393,27 +392,27 @@ public class DocumentTransformer {
                 .lastModifiedAt(document.getLastSaved());
     }
 
-    private String authorOf(Document document) {
+    private static String authorOf(Document document) {
         return Optional
                 .ofNullable(document.getCreatedByUser()) // this can be null since bug in document service is not setting this !
-                .map(this::fullName)
+                .map(DocumentTransformer::fullName)
                 .orElse(
                     Optional
                         .ofNullable(document.getLastUpdatedByUser())
-                        .map(this::fullName)
+                        .map(DocumentTransformer::fullName)
                         .orElse(null));
 
 
 
     }
 
-    private LocalDateTime createAtOf(Document document) {
+    private static LocalDateTime createAtOf(Document document) {
         return Optional
                 .ofNullable(document.getCreatedDate())
                 .orElseGet(document::getLastSaved);
     }
 
-    private String fullName(User user) {
+    private static String fullName(User user) {
         return String.format("%s %s", user.getForename(), user.getSurname());
     }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/InstitutionTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/InstitutionTransformer.java
@@ -13,7 +13,7 @@ import static uk.gov.justice.digital.delius.transformers.TypesTransformer.zeroOn
 
 @Component
 public class InstitutionTransformer {
-    public Institution institutionOf(RInstitution institution) {
+    public static Institution institutionOf(RInstitution institution) {
         return Optional.ofNullable(institution).map(inst -> Institution.builder()
                 .code(inst.getCode())
                 .description(inst.getDescription())
@@ -26,7 +26,7 @@ public class InstitutionTransformer {
                 .build()).orElse(null);
     }
 
-    private KeyValue establishmentTypeOf(StandardReference establishmentType) {
+    private static KeyValue establishmentTypeOf(StandardReference establishmentType) {
         return Optional.ofNullable(establishmentType).map(et -> KeyValue.builder()
                 .code(et.getCodeValue())
                 .description(et.getCodeDescription())

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/InstitutionalReportTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/InstitutionalReportTransformer.java
@@ -18,7 +18,7 @@ public class InstitutionalReportTransformer {
         this.convictionTransformer = convictionTransformer;
     }
 
-    public InstitutionalReport institutionalReportOf(uk.gov.justice.digital.delius.jpa.standard.entity.InstitutionalReport report) {
+    public static InstitutionalReport institutionalReportOf(uk.gov.justice.digital.delius.jpa.standard.entity.InstitutionalReport report) {
         return InstitutionalReport.builder()
             .institutionalReportId(report.getInstitutionalReportId())
             .offenderId(report.getOffenderId())
@@ -27,7 +27,7 @@ public class InstitutionalReportTransformer {
     }
 
 
-    private Conviction convictionOf(uk.gov.justice.digital.delius.jpa.standard.entity.InstitutionalReport report) {
+    private static Conviction convictionOf(uk.gov.justice.digital.delius.jpa.standard.entity.InstitutionalReport report) {
 
         return Optional.ofNullable(report.getCustody())
             .filter(custody -> !convertToBoolean(custody.getSoftDeleted()))
@@ -35,7 +35,7 @@ public class InstitutionalReportTransformer {
             .filter(disposal -> !convertToBoolean(disposal.getSoftDeleted()))
             .map(Disposal::getEvent)
             .filter(event -> !convertToBoolean(event.getSoftDeleted()))
-            .map(convictionTransformer::convictionOf)
+            .map(ConvictionTransformer::convictionOf)
             .orElse(null);
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/KeyValueTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/KeyValueTransformer.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 @Component
 public class KeyValueTransformer {
-    public KeyValue keyValueOf(StandardReference standardReference) {
+    public static KeyValue keyValueOf(StandardReference standardReference) {
         return Optional.ofNullable(standardReference).map(reason -> KeyValue.builder()
                     .description(reason.getCodeDescription())
                     .code(reason.getCodeValue()).build())

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/MainOffenceTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/MainOffenceTransformer.java
@@ -18,7 +18,7 @@ public class MainOffenceTransformer {
         this.lookupSupplier = lookupSupplier;
     }
 
-    public Offence offenceOf(MainOffence mainOffence) {
+    public static Offence offenceOf(MainOffence mainOffence) {
         return Offence.builder()
             .offenceId(OffenceIdTransformer.mainOffenceIdOf(mainOffence.getMainOffenceId()))
             .detail(detailOf(mainOffence.getOffence()))

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/NsiTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/NsiTransformer.java
@@ -40,11 +40,11 @@ public class NsiTransformer {
         this.staffTransformer = new StaffTransformer();
     }
 
-    public uk.gov.justice.digital.delius.data.api.Nsi nsiOf(Nsi nsi) {
+    public static uk.gov.justice.digital.delius.data.api.Nsi nsiOf(Nsi nsi) {
         return Optional.ofNullable(nsi).map(n ->
             uk.gov.justice.digital.delius.data.api.Nsi.builder()
                 .nsiId(n.getNsiId())
-                .requirement(requirementTransformer.requirementOf(n.getRqmnt()))
+                .requirement(RequirementTransformer.requirementOf(n.getRqmnt()))
                 .nsiType(nsiTypeOf(n.getNsiType()))
                 .nsiSubType(nsiSubtypeOf(n.getNsiSubType()))
                 .nsiStatus(nsiStatusOf(n.getNsiStatus()))
@@ -57,26 +57,26 @@ public class NsiTransformer {
                 .build()).orElse(null);
     }
 
-    private List<NsiManager> nsiManagersOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.NsiManager> nsiManagers) {
+    private static List<NsiManager> nsiManagersOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.NsiManager> nsiManagers) {
         return nsiManagers.stream()
                 .map(nsiManager -> NsiManager.builder()
                         .startDate(nsiManager.getStartDate())
                         .endDate(nsiManager.getEndDate())
-                        .probationArea(probationAreaTransformer.probationAreaOf(nsiManager.getProbationArea(), INCLUDE_PROBATION_AREA_TEAMS))
-                        .team(teamTransformer.teamOf(nsiManager.getTeam()))
-                        .staff(staffTransformer.staffDetailsOf(nsiManager.getStaff()))
+                        .probationArea(ProbationAreaTransformer.probationAreaOf(nsiManager.getProbationArea(), INCLUDE_PROBATION_AREA_TEAMS))
+                        .team(TeamTransformer.teamOf(nsiManager.getTeam()))
+                        .staff(StaffTransformer.staffDetailsOf(nsiManager.getStaff()))
                         .build())
                 .collect(Collectors.toList());
     }
 
-    private KeyValue nsiStatusOf(final NsiStatus nsiStatus) {
+    private static KeyValue nsiStatusOf(final NsiStatus nsiStatus) {
         return Optional.ofNullable(nsiStatus).map(nsis ->
             KeyValue.builder().code(nsis.getCode())
                 .description(nsis.getDescription())
                 .build()).orElse(null);
     }
 
-    private KeyValue nsiSubtypeOf(final StandardReference nsiSubType) {
+    private static KeyValue nsiSubtypeOf(final StandardReference nsiSubType) {
         return Optional.ofNullable(nsiSubType).map(nsist ->
             KeyValue.builder()
                 .code(nsist.getCodeValue())
@@ -84,7 +84,7 @@ public class NsiTransformer {
                 .build()).orElse(null);
     }
 
-    private KeyValue nsiTypeOf(final NsiType nsiType) {
+    private static KeyValue nsiTypeOf(final NsiType nsiType) {
         return Optional.ofNullable(nsiType).map(nsit -> KeyValue.builder()
             .code(nsit.getCode())
             .description(nsit.getDescription())

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/OffenderManagerTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/OffenderManagerTransformer.java
@@ -15,7 +15,7 @@ public class OffenderManagerTransformer {
     private final StaffTransformer staffTransformer;
     private final TeamTransformer teamTransformer;
     private final ProbationAreaTransformer probationAreaTransformer;
-    private final String UNALLOCATED_STAFF_CODE_SUFFIX = "U";
+    private static final String UNALLOCATED_STAFF_CODE_SUFFIX = "U";
 
     @Autowired
     public OffenderManagerTransformer(StaffTransformer staffTransformer, TeamTransformer teamTransformer, ProbationAreaTransformer probationAreaTransformer) {
@@ -24,79 +24,79 @@ public class OffenderManagerTransformer {
         this.probationAreaTransformer = probationAreaTransformer;
     }
 
-    public CommunityOrPrisonOffenderManager offenderManagerOf(OffenderManager offenderManager) {
+    public static CommunityOrPrisonOffenderManager offenderManagerOf(OffenderManager offenderManager) {
         return CommunityOrPrisonOffenderManager
                 .builder()
                 .staffCode(staffCodeOf(offenderManager))
                 .isUnallocated(isUnallocated(offenderManager))
                 .staff(Optional
                         .ofNullable(offenderManager.getStaff())
-                        .map(staffTransformer::humanOf)
+                        .map(StaffTransformer::humanOf)
                         .orElse(null))
                 .team(Optional
                         .ofNullable(offenderManager.getTeam())
-                        .map(teamTransformer::teamOf)
+                        .map(TeamTransformer::teamOf)
                         .orElse(null))
                 .isPrisonOffenderManager(false)
                 .probationArea(Optional
                         .ofNullable(offenderManager.getProbationArea())
-                        .map(probationAreaTransformer::probationAreaOf)
+                        .map(ProbationAreaTransformer::probationAreaOf)
                         .orElse(null))
                 .isResponsibleOfficer(isResponsibleOfficer(offenderManager.getResponsibleOfficer()))
                 .fromDate(offenderManager.getAllocationDate())
                 .build();
     }
 
-    public CommunityOrPrisonOffenderManager offenderManagerOf(PrisonOffenderManager offenderManager) {
+    public static CommunityOrPrisonOffenderManager offenderManagerOf(PrisonOffenderManager offenderManager) {
         return CommunityOrPrisonOffenderManager
                 .builder()
                 .staffCode(staffCodeOf(offenderManager))
                 .isUnallocated(isUnallocated(offenderManager))
                 .staff(Optional
                         .ofNullable(offenderManager.getStaff())
-                        .map(staffTransformer::humanOf)
+                        .map(StaffTransformer::humanOf)
                         .orElse(null))
                 .team(Optional
                         .ofNullable(offenderManager.getTeam())
-                        .map(teamTransformer::teamOf)
+                        .map(TeamTransformer::teamOf)
                         .orElse(null))
                 .isPrisonOffenderManager(true)
                 .probationArea(Optional
                         .ofNullable(offenderManager.getProbationArea())
-                        .map(probationAreaTransformer::probationAreaOf)
+                        .map(ProbationAreaTransformer::probationAreaOf)
                         .orElse(null))
                 .isResponsibleOfficer(isResponsibleOfficer(offenderManager.getResponsibleOfficer()))
                 .fromDate(offenderManager.getAllocationDate())
                 .build();
     }
 
-    private String staffCodeOf(OffenderManager offenderManager) {
+    private static String staffCodeOf(OffenderManager offenderManager) {
         return Optional
                 .ofNullable(offenderManager.getStaff())
                 .map(Staff::getOfficerCode)
                 .orElse(null);
     }
 
-    private String staffCodeOf(PrisonOffenderManager offenderManager) {
+    private static String staffCodeOf(PrisonOffenderManager offenderManager) {
         return Optional
                 .ofNullable(offenderManager.getStaff())
                 .map(Staff::getOfficerCode)
                 .orElse(null);
     }
 
-    private boolean isUnallocated(OffenderManager offenderManager) {
-        return Optional.ofNullable(staffCodeOf(offenderManager))
+    private static boolean isUnallocated(OffenderManager offenderManager) {
+        return Optional.ofNullable(OffenderManagerTransformer.staffCodeOf(offenderManager))
                 .map(staffCode -> staffCode.endsWith(UNALLOCATED_STAFF_CODE_SUFFIX))
                 .orElse(false);
     }
 
-    private boolean isUnallocated(PrisonOffenderManager offenderManager) {
-        return Optional.ofNullable(staffCodeOf(offenderManager))
+    private static boolean isUnallocated(PrisonOffenderManager offenderManager) {
+        return Optional.ofNullable(OffenderManagerTransformer.staffCodeOf(offenderManager))
                 .map(staffCode -> staffCode.endsWith(UNALLOCATED_STAFF_CODE_SUFFIX))
                 .orElse(false);
     }
 
-    private boolean isResponsibleOfficer(ResponsibleOfficer responsibleOfficer) {
+    private static boolean isResponsibleOfficer(ResponsibleOfficer responsibleOfficer) {
         return Optional
                 .ofNullable(responsibleOfficer)
                 .filter(officer -> officer.getEndDateTime() == null)

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/OffenderTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/OffenderTransformer.java
@@ -54,14 +54,14 @@ public class OffenderTransformer {
         this.contactTransformer = contactTransformer;
     }
 
-    private List<PhoneNumber> phoneNumbersOf(Offender offender) {
+    private static List<PhoneNumber> phoneNumbersOf(Offender offender) {
         return ImmutableList.of(
                 PhoneNumber.builder().number(Optional.ofNullable(offender.getTelephoneNumber())).type(PhoneNumber.PhoneTypes.TELEPHONE).build(),
                 PhoneNumber.builder().number(Optional.ofNullable(offender.getMobileNumber())).type(PhoneNumber.PhoneTypes.MOBILE).build()
         ).stream().filter(phoneNumber -> phoneNumber.getNumber().isPresent()).collect(toList());
     }
 
-    private OffenderLanguages languagesOf(Offender offender) {
+    private static OffenderLanguages languagesOf(Offender offender) {
         return OffenderLanguages.builder()
                 .primaryLanguage(Optional.ofNullable(offender.getLanguage()).map(StandardReference::getCodeDescription).orElse(null))
                 .languageConcerns(Optional.ofNullable(offender.getLanguageConcerns()).orElse(null))
@@ -69,14 +69,14 @@ public class OffenderTransformer {
                 .build();
     }
 
-    private PreviousConviction previousConvictionOf(Offender offender) {
+    private static PreviousConviction previousConvictionOf(Offender offender) {
         return PreviousConviction.builder()
                 .convictionDate(offender.getPreviousConvictionDate())
                 .detail(Optional.ofNullable(offender.getPrevConvictionDocumentName()).map(doc -> ImmutableMap.of("documentName", doc)).orElse(null))
                 .build();
     }
 
-    private OffenderProfile offenderProfileOf(Offender offender) {
+    private static OffenderProfile offenderProfileOf(Offender offender) {
         return OffenderProfile.builder()
                 .ethnicity(Optional.ofNullable(offender.getEthnicity()).map(StandardReference::getCodeDescription).orElse(null))
                 .immigrationStatus(Optional.ofNullable(offender.getImmigrationStatus()).map(StandardReference::getCodeDescription).orElse(null))
@@ -93,7 +93,7 @@ public class OffenderTransformer {
                 .build();
     }
 
-    public IDs idsOf(Offender offender) {
+    public static IDs idsOf(Offender offender) {
         return IDs.builder()
                 .crn(offender.getCrn())
                 .croNumber(offender.getCroNumber())
@@ -105,7 +105,7 @@ public class OffenderTransformer {
                 .build();
     }
 
-    private Address addressOf(OffenderAddress address) {
+    private static Address addressOf(OffenderAddress address) {
         return Address.builder()
                 .addressNumber(address.getAddressNumber())
                 .buildingName(address.getBuildingName())
@@ -127,33 +127,33 @@ public class OffenderTransformer {
                 .build();
     }
 
-    private ContactDetails contactDetailsOf(Offender offender) {
+    private static ContactDetails contactDetailsOf(Offender offender) {
         return ContactDetails.builder()
                 .allowSMS(ynToBoolean(offender.getAllowSMS()))
-                .emailAddresses(emailAddressesOf(offender))
+                .emailAddresses(OffenderTransformer.emailAddressesOf(offender))
                 .phoneNumbers(phoneNumbersOf(offender))
-                .addresses(addressesOf(offender))
+                .addresses(OffenderTransformer.addressesOf(offender))
                 .build();
     }
 
-    private ContactDetailsSummary contactDetailsSummaryOf(Offender offender) {
+    private static ContactDetailsSummary contactDetailsSummaryOf(Offender offender) {
         return ContactDetailsSummary.builder()
                 .allowSMS(ynToBoolean(offender.getAllowSMS()))
-                .emailAddresses(emailAddressesOf(offender))
+                .emailAddresses(OffenderTransformer.emailAddressesOf(offender))
                 .phoneNumbers(phoneNumbersOf(offender))
                 .build();
     }
 
-    private List<String> emailAddressesOf(Offender offender) {
+    private static List<String> emailAddressesOf(Offender offender) {
         return Optional.ofNullable(offender.getEmailAddress()).map(Arrays::asList).orElse(Collections.emptyList());
     }
 
-    private List<Address> addressesOf(Offender offender) {
+    private static List<Address> addressesOf(Offender offender) {
         return offender.getOffenderAddresses().stream().map(
-                this::addressOf).collect(toList());
+                OffenderTransformer::addressOf).collect(toList());
     }
 
-    private uk.gov.justice.digital.delius.data.api.OffenderAlias aliasOf(OffenderAlias alias) {
+    private static uk.gov.justice.digital.delius.data.api.OffenderAlias aliasOf(OffenderAlias alias) {
         return uk.gov.justice.digital.delius.data.api.OffenderAlias.builder()
                 .dateOfBirth(alias.getDateOfBirth())
                 .firstName(alias.getFirstName())
@@ -163,12 +163,12 @@ public class OffenderTransformer {
                 .build();
     }
 
-    private List<uk.gov.justice.digital.delius.data.api.OffenderAlias> offenderAliasesOf(List<OffenderAlias> offenderAliases) {
-        return offenderAliases.stream().map(this::aliasOf).collect(toList());
+    private static List<uk.gov.justice.digital.delius.data.api.OffenderAlias> offenderAliasesOf(List<OffenderAlias> offenderAliases) {
+        return offenderAliases.stream().map(OffenderTransformer::aliasOf).collect(toList());
 
     }
 
-    public OffenderDetail fullOffenderOf(Offender offender) {
+    public static OffenderDetail fullOffenderOf(Offender offender) {
         return OffenderDetail.builder()
                 .offenderId(offender.getOffenderId())
                 .dateOfBirth(offender.getDateOfBirthDate())
@@ -189,11 +189,11 @@ public class OffenderTransformer {
                 .exclusionMessage(offender.getExclusionMessage())
                 .currentRestriction(zeroOneToBoolean(offender.getCurrentRestriction()))
                 .restrictionMessage(offender.getRestrictionMessage())
-                .offenderManagers(offenderManagersOf(offender.getOffenderManagers()))
+                .offenderManagers(OffenderTransformer.offenderManagersOf(offender.getOffenderManagers()))
                 .build();
     }
 
-    public OffenderDetailSummary offenderSummaryOf(Offender offender) {
+    public static OffenderDetailSummary offenderSummaryOf(Offender offender) {
         return OffenderDetailSummary.builder()
                 .offenderId(offender.getOffenderId())
                 .dateOfBirth(offender.getDateOfBirthDate())
@@ -214,7 +214,7 @@ public class OffenderTransformer {
                 .build();
     }
 
-    private List<String> combinedMiddleNamesOf(String secondName, String thirdName) {
+    private static List<String> combinedMiddleNamesOf(String secondName, String thirdName) {
         Optional<String> maybeSecondName = Optional.ofNullable(secondName);
         Optional<String> maybeThirdName = Optional.ofNullable(thirdName);
 
@@ -224,34 +224,34 @@ public class OffenderTransformer {
                 .collect(toList());
     }
 
-    public List<OffenderManager> offenderManagersOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.OffenderManager> offenderManagers) {
+    public static List<OffenderManager> offenderManagersOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.OffenderManager> offenderManagers) {
         return offenderManagers.stream()
                 .sorted(Comparator.comparing(uk.gov.justice.digital.delius.jpa.standard.entity.OffenderManager::getAllocationDate)
                         .reversed())
-                .map(this::offenderManagerOf).collect(toList());
+                .map(OffenderTransformer::offenderManagerOf).collect(toList());
     }
 
-    private OffenderManager offenderManagerOf(uk.gov.justice.digital.delius.jpa.standard.entity.OffenderManager offenderManager) {
+    private static OffenderManager offenderManagerOf(uk.gov.justice.digital.delius.jpa.standard.entity.OffenderManager offenderManager) {
         return OffenderManager.builder()
                 .partitionArea(partitionAreaOf(offenderManager))
                 .softDeleted(zeroOneToBoolean(offenderManager.getSoftDeleted()))
                 .trustOfficer(Optional.ofNullable(offenderManager.getOfficer())
                         .map(o -> humanOf(o.getForename(), o.getForename2(), o.getSurname()))
                         .orElse(null))
-                .staff(contactTransformer.staffOf(offenderManager.getStaff()))
-                .providerEmployee(contactTransformer.providerEmployeeOf(offenderManager.getProviderEmployee()))
+                .staff(ContactTransformer.staffOf(offenderManager.getStaff()))
+                .providerEmployee(ContactTransformer.providerEmployeeOf(offenderManager.getProviderEmployee()))
                 .team(teamOf(offenderManager))
                 .probationArea(probationAreaOf(offenderManager.getProbationArea()))
                 .active(zeroOneToBoolean(offenderManager.getActiveFlag()))
                 .fromDate(offenderManager.getAllocationDate())
                 .toDate(offenderManager.getEndDate())
                 .allocationReason(Optional.ofNullable(offenderManager.getAllocationReason())
-                        .map(this::allocationReasonOf)
+                        .map(OffenderTransformer::allocationReasonOf)
                         .orElse(null))
                 .build();
     }
 
-    private KeyValue allocationReasonOf(StandardReference allocationReason) {
+    private static KeyValue allocationReasonOf(StandardReference allocationReason) {
         return KeyValue
                 .builder()
                 .code(allocationReason.getCodeValue())
@@ -259,7 +259,7 @@ public class OffenderTransformer {
                 .build();
     }
 
-    private uk.gov.justice.digital.delius.data.api.ProbationArea probationAreaOf(ProbationArea probationArea) {
+    private static uk.gov.justice.digital.delius.data.api.ProbationArea probationAreaOf(ProbationArea probationArea) {
         return uk.gov.justice.digital.delius.data.api.ProbationArea.builder()
                 .code(probationArea.getCode())
                 .description(probationArea.getDescription())
@@ -271,7 +271,7 @@ public class OffenderTransformer {
         return Optional.ofNullable(zeroOrOne).map(value -> value == 0).orElse(null);
     }
 
-    private Team teamOf(uk.gov.justice.digital.delius.jpa.standard.entity.OffenderManager offenderManager) {
+    private static Team teamOf(uk.gov.justice.digital.delius.jpa.standard.entity.OffenderManager offenderManager) {
         /*
          * This only populates a subset of team data - this is currently indexed in elasticsearch so if this is modified
          * then it will lead to inconsistent data and the index will need to be rebuilt.
@@ -296,28 +296,28 @@ public class OffenderTransformer {
                 .orElse(null);
     }
 
-    private String partitionAreaOf(uk.gov.justice.digital.delius.jpa.standard.entity.OffenderManager offenderManager) {
+    private static String partitionAreaOf(uk.gov.justice.digital.delius.jpa.standard.entity.OffenderManager offenderManager) {
         return Optional.ofNullable(offenderManager.getPartitionArea())
                 .map(PartitionArea::getArea)
                 .orElse(null);
     }
 
-    private Human humanOf(String forename, String forename2, String surname) {
+    private static Human humanOf(String forename, String forename2, String surname) {
         return Human.builder()
                 .surname(surname)
-                .forenames(String.join(" ", combinedMiddleNamesOf(forename, forename2)))
+                .forenames(String.join(" ", OffenderTransformer.combinedMiddleNamesOf(forename, forename2)))
                 .build();
     }
 
-    private List<uk.gov.justice.digital.delius.data.api.Disability> disabilitiesOf(List<Disability> disabilities) {
+    private static List<uk.gov.justice.digital.delius.data.api.Disability> disabilitiesOf(List<Disability> disabilities) {
         return disabilities.stream()
                 .filter(disability -> disability.getSoftDeleted() == 0)
                 .sorted(Comparator.comparing(uk.gov.justice.digital.delius.jpa.standard.entity.Disability::getStartDate)
                         .reversed())
-                .map(this::disabilityOf).collect(toList());
+                .map(OffenderTransformer::disabilityOf).collect(toList());
     }
 
-    private uk.gov.justice.digital.delius.data.api.Disability disabilityOf(Disability disability) {
+    private static uk.gov.justice.digital.delius.data.api.Disability disabilityOf(Disability disability) {
         return uk.gov.justice.digital.delius.data.api.Disability
                 .builder()
                 .disabilityId(disability.getDisabilityId())
@@ -331,7 +331,7 @@ public class OffenderTransformer {
                 .build();
     }
 
-    private ResponsibleOfficer convertToResponsibleOfficer(uk.gov.justice.digital.delius.jpa.standard.entity.OffenderManager om, Offender offender) {
+    private static ResponsibleOfficer convertToResponsibleOfficer(uk.gov.justice.digital.delius.jpa.standard.entity.OffenderManager om, Offender offender) {
 
         return ResponsibleOfficer
                 .builder()
@@ -341,7 +341,8 @@ public class OffenderTransformer {
                 .prisonOffenderManagerId(null)
                 .staffCode(Optional.ofNullable(om.getStaff()).map(Staff::getOfficerCode).orElse(null))
                 .surname(Optional.ofNullable(om.getStaff()).map(Staff::getSurname).orElse(null))
-                .forenames(String.join(" ", combinedMiddleNamesOf(om.getStaff().getForename(), om.getStaff().getForname2())))
+                .forenames(String.join(" ", OffenderTransformer
+                        .combinedMiddleNamesOf(om.getStaff().getForename(), om.getStaff().getForname2())))
                 .providerTeamCode(Optional.ofNullable(om.getProviderTeam()).map(ProviderTeam::getCode).orElse(null))
                 .providerTeamDescription(Optional.ofNullable(om.getProviderTeam()).map(ProviderTeam::getName).orElse(null))
                 .lduCode(Optional.ofNullable(om.getTeam()).map(team -> team.getLocalDeliveryUnit().getCode()).orElse(null))
@@ -356,7 +357,7 @@ public class OffenderTransformer {
                 .build();
     }
 
-    private ResponsibleOfficer convertToResponsibleOfficer(uk.gov.justice.digital.delius.jpa.standard.entity.PrisonOffenderManager pom, Offender offender) {
+    private static ResponsibleOfficer convertToResponsibleOfficer(uk.gov.justice.digital.delius.jpa.standard.entity.PrisonOffenderManager pom, Offender offender) {
 
         return ResponsibleOfficer
                 .builder()
@@ -365,7 +366,8 @@ public class OffenderTransformer {
                 .prisonOffenderManagerId(pom.getPrisonOffenderManagerId())
                 .staffCode(Optional.ofNullable(pom.getStaff()).map(Staff::getOfficerCode).orElse(null))
                 .surname(Optional.ofNullable(pom.getStaff()).map(Staff::getSurname).orElse(null))
-                .forenames(String.join(" ", combinedMiddleNamesOf(pom.getStaff().getForename(), pom.getStaff().getForname2())))
+                .forenames(String.join(" ", OffenderTransformer
+                        .combinedMiddleNamesOf(pom.getStaff().getForename(), pom.getStaff().getForname2())))
                 .providerTeamCode(Optional.ofNullable(pom.getTeam()).map(uk.gov.justice.digital.delius.jpa.standard.entity.Team::getCode).orElse(null))
                 .providerTeamDescription(Optional.ofNullable(pom.getTeam()).map(uk.gov.justice.digital.delius.jpa.standard.entity.Team::getDescription).orElse(null))
                 .lduCode(Optional.ofNullable(pom.getTeam()).map(team -> team.getLocalDeliveryUnit().getCode()).orElse(null))
@@ -380,21 +382,22 @@ public class OffenderTransformer {
                 .build();
     }
 
-    public List<uk.gov.justice.digital.delius.data.api.ResponsibleOfficer> responsibleOfficersOf(Offender offender, boolean current) {
+    public static List<uk.gov.justice.digital.delius.data.api.ResponsibleOfficer> responsibleOfficersOf(Offender offender, boolean current) {
 
         List<ResponsibleOfficer> responsibleOfficers = new ArrayList<>();
 
         if (offender.getOffenderManagers() != null && !offender.getOffenderManagers().isEmpty()) {
             responsibleOfficers.addAll(
                     offender.getOffenderManagers().stream()
-                            .map(offMgr -> convertToResponsibleOfficer(offMgr, offender))
+                            .map(offMgr -> OffenderTransformer.convertToResponsibleOfficer(offMgr, offender))
                             .collect(toList()));
         }
 
         if (offender.getPrisonOffenderManagers() != null && !offender.getPrisonOffenderManagers().isEmpty()) {
             responsibleOfficers.addAll(
                     offender.getPrisonOffenderManagers().stream()
-                            .map(prisonOffenderManager -> convertToResponsibleOfficer(prisonOffenderManager, offender))
+                            .map(prisonOffenderManager -> OffenderTransformer
+                                    .convertToResponsibleOfficer(prisonOffenderManager, offender))
                             .collect(toList()));
         }
 
@@ -409,7 +412,7 @@ public class OffenderTransformer {
         return responsibleOfficers;
     }
 
-    private ManagedOffender convertToManagedOffender(uk.gov.justice.digital.delius.jpa.standard.entity.OffenderManager om, Staff staff) {
+    private static ManagedOffender convertToManagedOffender(uk.gov.justice.digital.delius.jpa.standard.entity.OffenderManager om, Staff staff) {
 
         return ManagedOffender.builder()
                 .staffCode(staff.getOfficerCode())
@@ -425,7 +428,7 @@ public class OffenderTransformer {
                 .build();
     }
 
-    private ManagedOffender convertToManagedOffender(uk.gov.justice.digital.delius.jpa.standard.entity.PrisonOffenderManager pom, Staff staff) {
+    private static ManagedOffender convertToManagedOffender(uk.gov.justice.digital.delius.jpa.standard.entity.PrisonOffenderManager pom, Staff staff) {
 
         return ManagedOffender.builder()
                 .staffCode(staff.getOfficerCode())
@@ -441,7 +444,7 @@ public class OffenderTransformer {
                 .build();
     }
 
-    public List<uk.gov.justice.digital.delius.data.api.ManagedOffender> managedOffenderOf(Staff staff, boolean current) {
+    public static List<uk.gov.justice.digital.delius.data.api.ManagedOffender> managedOffenderOf(Staff staff, boolean current) {
 
         List<ManagedOffender> managedOffenders = new ArrayList<>();
 
@@ -471,7 +474,7 @@ public class OffenderTransformer {
         return managedOffenders;
     }
 
-    public List<AdditionalIdentifier> additionalIdentifiersOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.AdditionalIdentifier> additionalIdentifiers) {
+    public static List<AdditionalIdentifier> additionalIdentifiersOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.AdditionalIdentifier> additionalIdentifiers) {
         return Optional.ofNullable(additionalIdentifiers)
                 .map(identifiers -> identifiers
                         .stream()
@@ -490,7 +493,7 @@ public class OffenderTransformer {
                 .orElse(List.of());
     }
 
-    private boolean isCurrentRo(uk.gov.justice.digital.delius.jpa.standard.entity.ResponsibleOfficer ro) {
+    private static boolean isCurrentRo(uk.gov.justice.digital.delius.jpa.standard.entity.ResponsibleOfficer ro) {
         boolean result = false;
         if (ro != null && ro.getEndDateTime() == null) {
             result = true;
@@ -498,7 +501,7 @@ public class OffenderTransformer {
         return result;
     }
 
-    private boolean isCurrentManager(Long activeFlag, LocalDate endDate) {
+    private static boolean isCurrentManager(Long activeFlag, LocalDate endDate) {
         boolean result = false;
         if (activeFlag.intValue() == 1 && endDate == null) {
             result = true;

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformer.java
@@ -13,12 +13,12 @@ import static uk.gov.justice.digital.delius.transformers.TypesTransformer.ynToBo
 
 @Component
 public class PersonalCircumstanceTransformer {
-    public PersonalCircumstance personalCircumstanceOf(uk.gov.justice.digital.delius.jpa.standard.entity.PersonalCircumstance personalCircumstance) {
+    public static PersonalCircumstance personalCircumstanceOf(uk.gov.justice.digital.delius.jpa.standard.entity.PersonalCircumstance personalCircumstance) {
         return PersonalCircumstance.builder()
                 .personalCircumstanceType(circumstanceTypeOf(personalCircumstance.getCircumstanceType()))
                 .personalCircumstanceSubType(circumstanceSubTypeOf(personalCircumstance.getCircumstanceSubType()))
                 .personalCircumstanceId(personalCircumstance.getPersonalCircumstanceId())
-                .probationArea(Optional.ofNullable(personalCircumstance.getProbationArea()).map(this::probationAreaOf).orElse(null))
+                .probationArea(Optional.ofNullable(personalCircumstance.getProbationArea()).map(PersonalCircumstanceTransformer::probationAreaOf).orElse(null))
                 .endDate(personalCircumstance.getEndDate())
                 .startDate(personalCircumstance.getStartDate())
                 .offenderId(personalCircumstance.getOffenderId())
@@ -27,21 +27,21 @@ public class PersonalCircumstanceTransformer {
             .build();
     }
 
-    private KeyValue probationAreaOf(ProbationArea probationArea) {
+    private static KeyValue probationAreaOf(ProbationArea probationArea) {
         return KeyValue.builder()
                 .code(probationArea.getCode())
                 .description(probationArea.getDescription())
                 .build();
     }
 
-    private KeyValue circumstanceTypeOf(CircumstanceType circumstanceType) {
+    private static KeyValue circumstanceTypeOf(CircumstanceType circumstanceType) {
         return KeyValue.builder()
                 .code(circumstanceType.getCodeValue())
                 .description(circumstanceType.getCodeDescription())
                 .build();
     }
 
-    private KeyValue circumstanceSubTypeOf(CircumstanceSubType circumstanceSubType) {
+    private static KeyValue circumstanceSubTypeOf(CircumstanceSubType circumstanceSubType) {
         return KeyValue.builder()
                 .code(circumstanceSubType.getCodeValue())
                 .description(circumstanceSubType.getCodeDescription())

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/ProbationAreaTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/ProbationAreaTransformer.java
@@ -25,26 +25,26 @@ public class ProbationAreaTransformer {
         this.institutionTransformer = new InstitutionTransformer();
     }
 
-    public List<ProbationArea> probationAreasOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea> probationAreas) {
-        return probationAreas.stream().map(this::probationAreaOf).collect(Collectors.toList());
+    public static List<ProbationArea> probationAreasOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea> probationAreas) {
+        return probationAreas.stream().map(ProbationAreaTransformer::probationAreaOf).collect(Collectors.toList());
     }
 
-    public ProbationArea probationAreaOf(uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea probationArea) {
+    public static ProbationArea probationAreaOf(uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea probationArea) {
         return probationAreaOf(probationArea, true);
     }
 
-    public ProbationArea probationAreaOf(uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea probationArea, boolean includeTeams) {
+    public static ProbationArea probationAreaOf(uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea probationArea, boolean includeTeams) {
         return ProbationArea.builder()
                 .code(probationArea.getCode())
                 .description(probationArea.getDescription())
                 .organisation(organisationOf(probationArea.getOrganisation()))
-                .institution(institutionTransformer.institutionOf(probationArea.getInstitution()))
+                .institution(InstitutionTransformer.institutionOf(probationArea.getInstitution()))
                 .probationAreaId(probationArea.getProbationAreaId())
                 .teams(includeTeams ? teamsOf(probationArea) : null)
                 .build();
     }
 
-    private List<AllTeam> teamsOf(uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea probationArea) {
+    private static List<AllTeam> teamsOf(uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea probationArea) {
         List<AllTeam> teams = probationArea.getTeams().stream().map(team -> AllTeam.builder()
                 .code(team.getCode())
                 .description(team.getDescription())
@@ -66,7 +66,7 @@ public class ProbationAreaTransformer {
         return Stream.concat(teams.stream(), providerTeams.stream()).collect(Collectors.toList());
     }
 
-    private KeyValue externalProviderOf(ExternalProvider externalProvider) {
+    private static KeyValue externalProviderOf(ExternalProvider externalProvider) {
         return Optional.ofNullable(externalProvider)
                 .map(ep -> KeyValue.builder()
                         .code(ep.getCode())
@@ -75,7 +75,7 @@ public class ProbationAreaTransformer {
                 .orElse(null);
     }
 
-    private KeyValue scProviderOf(Team team) {
+    private static KeyValue scProviderOf(Team team) {
         return Optional.ofNullable(team)
                 .map(t -> KeyValue.builder()
                         .code(t.getCode())
@@ -84,7 +84,7 @@ public class ProbationAreaTransformer {
                 .orElse(null);
     }
 
-    private KeyValue localDeliveryUnitOf(LocalDeliveryUnit localDeliveryUnit) {
+    private static KeyValue localDeliveryUnitOf(LocalDeliveryUnit localDeliveryUnit) {
         return Optional.ofNullable(localDeliveryUnit)
                 .map(ldu -> KeyValue.builder()
                         .code(ldu.getCode())
@@ -93,7 +93,7 @@ public class ProbationAreaTransformer {
                 .orElse(null);
     }
 
-    private KeyValue boroughOf(District district) {
+    private static KeyValue boroughOf(District district) {
         Optional<Borough> maybeBorough = Optional.ofNullable(district).map(District::getBorough);
         return maybeBorough
                 .map(b -> KeyValue.builder()
@@ -103,7 +103,7 @@ public class ProbationAreaTransformer {
                 .orElse(null);
     }
 
-    private KeyValue districtOf(District district) {
+    private static KeyValue districtOf(District district) {
         return Optional.ofNullable(district)
                 .map(d -> KeyValue.builder()
                         .code(d.getCode())
@@ -112,7 +112,7 @@ public class ProbationAreaTransformer {
                 .orElse(null);
     }
 
-    private KeyValue organisationOf(Organisation organisation) {
+    private static KeyValue organisationOf(Organisation organisation) {
         return Optional.ofNullable(organisation)
                 .map(org -> KeyValue.builder()
                         .code(org.getCode())

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/RecallTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/RecallTransformer.java
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.Recall;
 @Component
 public class RecallTransformer {
 
-    public OffenderRecall offenderRecallOf(Recall recall) {
+    public static OffenderRecall offenderRecallOf(Recall recall) {
         final var reason = KeyValue.builder()
                 .code(recall.getReason().getCodeValue())
                 .description(recall.getReason().getCodeDescription())

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/RegistrationTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/RegistrationTransformer.java
@@ -19,7 +19,7 @@ public class RegistrationTransformer {
         this.contactTransformer = contactTransformer;
     }
 
-    public Registration registrationOf(uk.gov.justice.digital.delius.jpa.standard.entity.Registration registration) {
+    public static Registration registrationOf(uk.gov.justice.digital.delius.jpa.standard.entity.Registration registration) {
         final Predicate<Deregistration> hasDeregistered = notUsed -> convertToBoolean(registration.getDeregistered());
 
         return Registration.builder()
@@ -36,21 +36,21 @@ public class RegistrationTransformer {
                 .register(keyValueOf(registration.getRegisterType().getRegisterTypeFlag()))
                 .type(typeOf(registration.getRegisterType()))
                 .riskColour(registration.getRegisterType().getColour())
-                .registeringOfficer(contactTransformer.staffOf(registration.getRegisteringStaff()))
-                .registeringTeam(contactTransformer.teamOf(registration.getRegisteringTeam()))
+                .registeringOfficer(ContactTransformer.staffOf(registration.getRegisteringStaff()))
+                .registeringTeam(ContactTransformer.teamOf(registration.getRegisteringTeam()))
                 .registeringProbationArea(probationAreaOf(registration.getRegisteringTeam().getProbationArea()))
                 .notes(registration.getRegistrationNotes())
-                .registerLevel(Optional.ofNullable(registration.getRegisterLevel()).map(this::keyValueOf).orElse(null))
-                .registerCategory(Optional.ofNullable(registration.getRegisterCategory()).map(this::keyValueOf).orElse(null))
+                .registerLevel(Optional.ofNullable(registration.getRegisterLevel()).map(RegistrationTransformer::keyValueOf).orElse(null))
+                .registerCategory(Optional.ofNullable(registration.getRegisterCategory()).map(RegistrationTransformer::keyValueOf).orElse(null))
                 .warnUser(Optional.ofNullable(ynToBoolean(registration.getRegisterType().getAlertMessage())).orElse(false))
                 .active(!convertToBoolean(registration.getDeregistered()))
                 .deregisteringOfficer(Optional.ofNullable(registration.getDeregistration())
                         .filter(hasDeregistered)
-                        .map(deregistration -> contactTransformer.staffOf(deregistration.getDeregisteringStaff()))
+                        .map(deregistration -> ContactTransformer.staffOf(deregistration.getDeregisteringStaff()))
                         .orElse(null))
                 .deregisteringTeam(Optional.ofNullable(registration.getDeregistration())
                         .filter(hasDeregistered)
-                        .map(deregistration -> contactTransformer.teamOf(deregistration.getDeregisteringTeam()))
+                        .map(deregistration -> ContactTransformer.teamOf(deregistration.getDeregisteringTeam()))
                         .orElse(null))
                 .deregisteringProbationArea(Optional.ofNullable(registration.getDeregistration())
                         .filter(hasDeregistered)
@@ -63,14 +63,14 @@ public class RegistrationTransformer {
             .build();
     }
 
-    private KeyValue keyValueOf(StandardReference register) {
+    private static KeyValue keyValueOf(StandardReference register) {
         return KeyValue.builder().code(register.getCodeValue()).description(register.getCodeDescription()).build();
     }
-    private KeyValue typeOf(RegisterType registerType) {
+    private static KeyValue typeOf(RegisterType registerType) {
         return KeyValue.builder().code(registerType.getCode()).description(registerType.getDescription()).build();
     }
 
-    private KeyValue probationAreaOf(ProbationArea probationArea) {
+    private static KeyValue probationAreaOf(ProbationArea probationArea) {
         return KeyValue.builder()
                 .code(probationArea.getCode())
                 .description(probationArea.getDescription())

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/ReleaseTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/ReleaseTransformer.java
@@ -14,24 +14,24 @@ public class ReleaseTransformer {
     private InstitutionTransformer institutionTransformer;
     private RecallTransformer recallTransformer;
 
-    public OffenderRelease offenderReleaseOf(Release release) {
+    public static OffenderRelease offenderReleaseOf(Release release) {
         final var releaseType = KeyValue.builder()
                 .code(release.getReleaseType().getCodeValue())
                 .description(release.getReleaseType().getCodeDescription())
                 .build();
         return OffenderRelease.builder()
                 .date(release.getActualReleaseDate().toLocalDate())
-                .institution(institutionTransformer.institutionOf(release.getInstitution()))
+                .institution(InstitutionTransformer.institutionOf(release.getInstitution()))
                 .notes(release.getNotes())
                 .reason(releaseType)
                 .build();
     }
 
-    public OffenderLatestRecall offenderLatestRecallOf(Release release) {
-        final var offenderRelease = offenderReleaseOf(release);
+    public static OffenderLatestRecall offenderLatestRecallOf(Release release) {
+        final var offenderRelease = ReleaseTransformer.offenderReleaseOf(release);
         final var offenderRecall =
                 release.findLatestRecall()
-                        .map(latestRecall -> recallTransformer.offenderRecallOf(latestRecall))
+                        .map(RecallTransformer::offenderRecallOf)
                         .orElse(null);
         return OffenderLatestRecall.builder()
                 .lastRelease(offenderRelease)

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/RequirementTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/RequirementTransformer.java
@@ -14,36 +14,34 @@ import static uk.gov.justice.digital.delius.transformers.TypesTransformer.zeroOn
 @Component
 public class RequirementTransformer {
 
-    private KeyValueTransformer keyValueTransformer = new KeyValueTransformer();
-
-    public uk.gov.justice.digital.delius.data.api.Requirement requirementOf(Requirement requirement) {
+    public static uk.gov.justice.digital.delius.data.api.Requirement requirementOf(Requirement requirement) {
         return Optional.ofNullable(requirement).map(req -> uk.gov.justice.digital.delius.data.api.Requirement.builder()
                 .active(zeroOneToBoolean(req.getActiveFlag()))
                 .adRequirementTypeMainCategory(adRequirementMainCategoryOf(req.getAdRequirementTypeMainCategory()))
-                .adRequirementTypeSubCategory(keyValueTransformer.keyValueOf(req.getAdRequirementTypeSubCategory()))
+                .adRequirementTypeSubCategory(KeyValueTransformer.keyValueOf(req.getAdRequirementTypeSubCategory()))
                 .commencementDate(req.getCommencementDate())
                 .expectedEndDate(req.getExpectedEndDate())
                 .expectedStartDate(req.getExpectedStartDate())
                 .requirementId(req.getRequirementId())
                 .requirementNotes(req.getRequirementNotes())
                 .requirementTypeMainCategory(requirementTypeMainCategoryOf(req.getRequirementTypeMainCategory()))
-                .requirementTypeSubCategory(keyValueTransformer.keyValueOf(req.getRequirementTypeSubCategory()))
+                .requirementTypeSubCategory(KeyValueTransformer.keyValueOf(req.getRequirementTypeSubCategory()))
                 .startDate(req.getStartDate())
                 .terminationDate(req.getTerminationDate())
-                .terminationReason(keyValueTransformer.keyValueOf(req.getTerminationReason()))
+                .terminationReason(KeyValueTransformer.keyValueOf(req.getTerminationReason()))
                 .length(req.getLength())
                 .lengthUnit(lengthUnitOf(req))
                 .build()).orElse(null);
     }
 
-    private String lengthUnitOf(Requirement req) {
+    private static String lengthUnitOf(Requirement req) {
         return Optional.ofNullable(req.getRequirementTypeMainCategory())
                 .map(RequirementTypeMainCategory::getUnits)
                 .map(StandardReference::getCodeDescription)
                 .orElse(null);
     }
 
-    private KeyValue requirementTypeMainCategoryOf(RequirementTypeMainCategory requirementTypeMainCategory) {
+    private static KeyValue requirementTypeMainCategoryOf(RequirementTypeMainCategory requirementTypeMainCategory) {
         return Optional.ofNullable(requirementTypeMainCategory).map(mainCat ->
                 KeyValue.builder()
                         .code(mainCat.getCode())
@@ -51,7 +49,7 @@ public class RequirementTransformer {
                         .build()).orElse(null);
     }
 
-    private KeyValue adRequirementMainCategoryOf(AdRequirementTypeMainCategory adRequirementTypeMainCategory) {
+    private static KeyValue adRequirementMainCategoryOf(AdRequirementTypeMainCategory adRequirementTypeMainCategory) {
         return Optional.ofNullable(adRequirementTypeMainCategory).map(mainCat ->
                 KeyValue.builder()
                         .code(mainCat.getCode())

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/StaffTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/StaffTransformer.java
@@ -22,19 +22,19 @@ public class StaffTransformer {
         this.teamTransformer = new TeamTransformer();
     }
 
-    public StaffDetails staffDetailsOf(Staff staff) {                    
+    public static StaffDetails staffDetailsOf(Staff staff) {
         return StaffDetails.builder()
                 .staff(humanOf(staff))
                 .staffCode(staff.getOfficerCode())
                 .username(
                     Optional.ofNullable(staff.getUser()).map(User::getDistinguishedName).orElse(null))
                 .teams(staff.getTeams().stream()
-                        .map(teamTransformer::teamOf)
+                        .map(TeamTransformer::teamOf)
                         .collect(Collectors.toList()))
                 .build();
     }
 
-    public String combinedMiddleNamesOf(String secondName, String thirdName) {
+    public static String combinedMiddleNamesOf(String secondName, String thirdName) {
         Optional<String> maybeSecondName = Optional.ofNullable(secondName);
         Optional<String> maybeThirdName = Optional.ofNullable(thirdName);
 
@@ -43,7 +43,7 @@ public class StaffTransformer {
                 .collect(Collectors.joining(" "));
     }
 
-    Human humanOf(Staff staff) {
+    static Human humanOf(Staff staff) {
         return Human.builder()
                 .forenames(combinedMiddleNamesOf(staff.getForename(), staff.getForname2()))
                 .surname(staff.getSurname()).build();

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/TeamTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/TeamTransformer.java
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.LocalDeliveryUnit;
 
 @Component
 public class TeamTransformer {
-    public Team teamOf(uk.gov.justice.digital.delius.jpa.standard.entity.Team team) {
+    public static Team teamOf(uk.gov.justice.digital.delius.jpa.standard.entity.Team team) {
         return Team.builder().code(team.getCode()).description(team.getDescription())
                 .telephone(team.getTelephone())
                 .borough(keyValueOf(team.getDistrict().getBorough()))
@@ -21,7 +21,7 @@ public class TeamTransformer {
                 .build();
     }
 
-    private KeyValue keyValueOf(LocalDeliveryUnit localDeliveryUnit) {
+    private static KeyValue keyValueOf(LocalDeliveryUnit localDeliveryUnit) {
         return KeyValue
             .builder()
             .code(localDeliveryUnit.getCode())
@@ -29,7 +29,7 @@ public class TeamTransformer {
             .build();
     }
 
-    private KeyValue keyValueOf(District district) {
+    private static KeyValue keyValueOf(District district) {
         return KeyValue
             .builder()
             .code(district.getCode())
@@ -37,7 +37,7 @@ public class TeamTransformer {
             .build();
     }
 
-    private KeyValue keyValueOf(Borough borough) {
+    private static KeyValue keyValueOf(Borough borough) {
         return KeyValue
             .builder()
             .code(borough.getCode())

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AdditionalOffenceTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AdditionalOffenceTransformerTest.java
@@ -55,7 +55,7 @@ public class AdditionalOffenceTransformerTest {
                 .build()
         );
 
-        assertThat(additionalOffenceTransformer.offencesOf(additionalOffences))
+        assertThat(AdditionalOffenceTransformer.offencesOf(additionalOffences))
             .extracting("offenceId").containsOnly("A1", "A3");
     }
 
@@ -71,7 +71,7 @@ public class AdditionalOffenceTransformerTest {
                 .build()
         );
 
-        assertThat(additionalOffenceTransformer.offencesOf(additionalOffences).get(0).getOffenceId())
+        assertThat(AdditionalOffenceTransformer.offencesOf(additionalOffences).get(0).getOffenceId())
             .isEqualTo("A92");
     }
 
@@ -85,7 +85,7 @@ public class AdditionalOffenceTransformerTest {
                 .build()
         );
 
-        assertThat(additionalOffenceTransformer.offencesOf(additionalOffences).get(0).getMainOffence()).isFalse();
+        assertThat(AdditionalOffenceTransformer.offencesOf(additionalOffences).get(0).getMainOffence()).isFalse();
     }
 
 

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentTransformerTest.java
@@ -18,7 +18,7 @@ public class AppointmentTransformerTest {
 
     @Test
     public void appointmentOutcomeMappedFromContactOutcomeType() {
-        assertThat(transformer.appointmentsOf(ImmutableList.of(
+        assertThat(AppointmentTransformer.appointmentsOf(ImmutableList.of(
                 aContact()
                     .toBuilder()
                     .contactOutcomeType(ContactOutcomeType
@@ -34,7 +34,7 @@ public class AppointmentTransformerTest {
 
     @Test
     public void appointmentTypeMappedFromContactType() {
-        assertThat(transformer.appointmentsOf(ImmutableList.of(
+        assertThat(AppointmentTransformer.appointmentsOf(ImmutableList.of(
                 aContact()
                     .toBuilder()
                     .contactType(ContactType
@@ -49,7 +49,7 @@ public class AppointmentTransformerTest {
     }
     @Test
     public void officeLocationMappedFromOfficeLocation() {
-        assertThat(transformer.appointmentsOf(ImmutableList.of(
+        assertThat(AppointmentTransformer.appointmentsOf(ImmutableList.of(
                 aContact()
                     .toBuilder()
                     .officeLocation(OfficeLocation
@@ -65,7 +65,7 @@ public class AppointmentTransformerTest {
 
     @Test
     public void attendedMappedToNotRecordedWhenNull() {
-        assertThat(transformer.appointmentsOf(ImmutableList.of(
+        assertThat(AppointmentTransformer.appointmentsOf(ImmutableList.of(
                 aContact()
                         .toBuilder()
                         .attended(null)
@@ -76,7 +76,7 @@ public class AppointmentTransformerTest {
 
     @Test
     public void attendedMappedToAttendedWhenY() {
-        assertThat(transformer.appointmentsOf(ImmutableList.of(
+        assertThat(AppointmentTransformer.appointmentsOf(ImmutableList.of(
                 aContact()
                         .toBuilder()
                         .attended("Y")
@@ -87,7 +87,7 @@ public class AppointmentTransformerTest {
 
     @Test
     public void attendedMappedToNotAttendedWhenN() {
-        assertThat(transformer.appointmentsOf(ImmutableList.of(
+        assertThat(AppointmentTransformer.appointmentsOf(ImmutableList.of(
                 aContact()
                         .toBuilder()
                         .attended("N")

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformerTest.java
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.delius.data.api.UnpaidWork;
 import uk.gov.justice.digital.delius.jpa.national.entity.User;
 import uk.gov.justice.digital.delius.jpa.standard.entity.*;
 import uk.gov.justice.digital.delius.service.LookupSupplier;
+import uk.gov.justice.digital.delius.util.EntityHelper;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -63,7 +64,7 @@ public class ConvictionTransformerTest {
 
     @Test
     public void convictionIdMappedFromEventId() {
-        assertThat(transformer.convictionOf(
+        assertThat(ConvictionTransformer.convictionOf(
                 anEvent()
                     .toBuilder()
                     .eventId(99L)
@@ -81,7 +82,7 @@ public class ConvictionTransformerTest {
                 lookupSupplier,
                 institutionTransformer);
 
-        assertThat(transformer.convictionOf(
+        assertThat(ConvictionTransformer.convictionOf(
                 anEvent()
                         .toBuilder()
                         .eventId(99L)
@@ -93,28 +94,28 @@ public class ConvictionTransformerTest {
 
     @Test
     public void activeMappedForZeroOneActiveFlag() {
-        assertThat((transformer.convictionOf(anEvent().toBuilder().activeFlag(1L).build()).getActive())).isTrue();
-        assertThat((transformer.convictionOf(anEvent().toBuilder().activeFlag(0L).build()).getActive())).isFalse();
+        assertThat((ConvictionTransformer.convictionOf(anEvent().toBuilder().activeFlag(1L).build()).getActive())).isTrue();
+        assertThat((ConvictionTransformer.convictionOf(anEvent().toBuilder().activeFlag(0L).build()).getActive())).isFalse();
 
     }
 
     @Test
     public void inBreachMappedForZeroOneInBreach() {
-        assertThat((transformer.convictionOf(anEvent().toBuilder().inBreach(1L).build()).getInBreach())).isTrue();
-        assertThat((transformer.convictionOf(anEvent().toBuilder().inBreach(0L).build()).getInBreach())).isFalse();
+        assertThat((ConvictionTransformer.convictionOf(anEvent().toBuilder().inBreach(1L).build()).getInBreach())).isTrue();
+        assertThat((ConvictionTransformer.convictionOf(anEvent().toBuilder().inBreach(0L).build()).getInBreach())).isFalse();
 
     }
 
     @Test
     public void sentenceIsMappedWhenEvenHasDisposal() {
-        assertThat((transformer.convictionOf(anEvent().toBuilder().disposal(null).build()).getSentence())).isNull();
-        assertThat((transformer.convictionOf(anEvent().toBuilder().disposal(aDisposal()).build()).getSentence())).isNotNull();
+        assertThat((ConvictionTransformer.convictionOf(anEvent().toBuilder().disposal(null).build()).getSentence())).isNull();
+        assertThat((ConvictionTransformer.convictionOf(anEvent().toBuilder().disposal(aDisposal()).build()).getSentence())).isNotNull();
 
     }
 
     @Test
     public void outcomeMappedFromLastCourtAppearance() {
-        assertThat(transformer.convictionOf(
+        assertThat(ConvictionTransformer.convictionOf(
                 anEvent()
                         .toBuilder()
                         .courtAppearances(ImmutableList.of(
@@ -131,13 +132,13 @@ public class ConvictionTransformerTest {
 
     @Test
     public void indexMappedFromEventNumberString() {
-        assertThat((transformer.convictionOf(anEvent().toBuilder().eventNumber("5").build()).getIndex())).isEqualTo("5");
+        assertThat((ConvictionTransformer.convictionOf(anEvent().toBuilder().eventNumber("5").build()).getIndex())).isEqualTo("5");
     }
 
     @Test
     public void custodyNotSetWhenDisposalNotPresent() {
         assertThat(
-                transformer.convictionOf(
+                ConvictionTransformer.convictionOf(
                         anEvent()
                                 .toBuilder()
                                 .disposal(null)
@@ -149,7 +150,7 @@ public class ConvictionTransformerTest {
     @Test
     public void custodyNotSetWhenCustodyNotPresentInDisposal() {
         assertThat(
-                transformer.convictionOf(
+                ConvictionTransformer.convictionOf(
                         anEvent()
                                 .toBuilder()
                                 .disposal(Disposal
@@ -164,7 +165,7 @@ public class ConvictionTransformerTest {
     @Test
     public void custodySetWhenCustodyPresentInDisposal() {
         assertThat(
-                transformer.convictionOf(
+                ConvictionTransformer.convictionOf(
                         anEvent()
                                 .toBuilder()
                                 .disposal(Disposal
@@ -179,7 +180,7 @@ public class ConvictionTransformerTest {
     @Test
     public void bookingNumberCopiedFromCustodyPrisonerNumber() {
         assertThat(
-                transformer.convictionOf(
+                ConvictionTransformer.convictionOf(
                         anEvent()
                                 .toBuilder()
                                 .disposal(Disposal
@@ -198,10 +199,8 @@ public class ConvictionTransformerTest {
 
     @Test
     public void institutionCopiedFromCustodyWhenPresent() {
-        when(institutionTransformer.institutionOf(any())).thenReturn(Institution.builder().build());
-
         assertThat(
-                transformer.convictionOf(
+                ConvictionTransformer.convictionOf(
                         anEvent()
                                 .toBuilder()
                                 .disposal(Disposal
@@ -223,7 +222,7 @@ public class ConvictionTransformerTest {
     public void institutionNotCopiedFromCustodyWhenNotPresent() {
 
         assertThat(
-                transformer.convictionOf(
+                ConvictionTransformer.convictionOf(
                         anEvent()
                                 .toBuilder()
                                 .disposal(Disposal
@@ -331,7 +330,7 @@ public class ConvictionTransformerTest {
     @Test
     public void unpaidWorkMappedWherePresent() {
 
-        Event event = Event.builder()
+        Event event = EntityHelper.anEvent().toBuilder()
                 .disposal(Disposal.builder()
                         .unpaidWorkDetails(UpwDetails.builder()
                                 .upwLengthMinutes(120L)
@@ -372,7 +371,7 @@ public class ConvictionTransformerTest {
                                 .build())
                         .build())
                 .build();
-        UnpaidWork unpaidWork = transformer.convictionOf(event)
+        UnpaidWork unpaidWork = ConvictionTransformer.convictionOf(event)
                 .getSentence()
                 .getUnpaidWork();
 
@@ -389,24 +388,24 @@ public class ConvictionTransformerTest {
 
     @Test
     public void unpaidWorkIsNullWhereNonePresent() {
-        Event event = Event.builder()
+        Event event = EntityHelper.anEvent().toBuilder()
                 .disposal(Disposal.builder()
                         .unpaidWorkDetails(null)
                         .build())
                 .build();
-        Conviction conviction = transformer.convictionOf(event);
+        Conviction conviction = ConvictionTransformer.convictionOf(event);
         UnpaidWork unpaidWork = conviction.getSentence().getUnpaidWork();
         assertThat(unpaidWork).isNull();
     }
 
     @Test
     public void sentenceStartDateCopiedWhenPresent() {
-        Event event = Event.builder()
+        Event event = EntityHelper.anEvent().toBuilder()
                 .disposal(Disposal.builder()
                         .startDate(LocalDate.of(2020, 2, 22))
                         .build())
                 .build();
-        final var conviction = transformer.convictionOf(event);
+        final var conviction = ConvictionTransformer.convictionOf(event);
         assertThat(conviction.getSentence().getStartDate()).isEqualTo(LocalDate.of(2020, 2, 22));
     }
 
@@ -419,13 +418,13 @@ public class ConvictionTransformerTest {
                                                     .codeDescription("Auto Terminated")
                                                     .build();
 
-        Event event = Event.builder()
+        Event event = EntityHelper.anEvent().toBuilder()
             .disposal(Disposal.builder()
                 .terminationDate(LocalDate.of(2020, 2, 22))
                 .terminationReason(standardReference)
                 .build())
             .build();
-        final var conviction = transformer.convictionOf(event);
+        final var conviction = ConvictionTransformer.convictionOf(event);
         assertThat(conviction.getSentence().getTerminationDate()).isEqualTo(LocalDate.of(2020, 2, 22));
         assertThat(conviction.getSentence().getTerminationReason()).isEqualTo("Auto Terminated");
     }
@@ -434,7 +433,7 @@ public class ConvictionTransformerTest {
     class CustodyRelatedKeyDatesOf {
         @Test
         void willSetNothingIfNoneExist() {
-            final var keyDates = transformer.custodyOf(aCustody().toBuilder().keyDates(List.of()).build())
+            final var keyDates = ConvictionTransformer.custodyOf(aCustody().toBuilder().keyDates(List.of()).build())
                     .getKeyDates();
 
             assertThat(keyDates.getConditionalReleaseDate()).isNull();
@@ -450,7 +449,7 @@ public class ConvictionTransformerTest {
 
         @Test
         void willSetNothingIfNoneOfTheOnesWeAreInterestedInExist() {
-            final var keyDates = transformer.custodyOf(aCustody().toBuilder()
+            final var keyDates = ConvictionTransformer.custodyOf(aCustody().toBuilder()
                     .keyDates(List.of(aKeyDate("XX", "Whatever", LocalDate
                             .now()))).build())
                     .getKeyDates();
@@ -468,7 +467,7 @@ public class ConvictionTransformerTest {
 
         @Test
         void willSetAllIfAllAreSet() {
-            final var keyDates = transformer.custodyOf(aCustody().toBuilder()
+            final var keyDates = ConvictionTransformer.custodyOf(aCustody().toBuilder()
                     .keyDates(List.of(
                             aKeyDate("LED", "LicenceExpiryDate", LocalDate.of(2030, 1, 1)),
                             aKeyDate("POM2", "ExpectedPrisonOffenderManagerHandoverDate", LocalDate.of(2030, 1, 2)),

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceTransformerTest.java
@@ -59,7 +59,8 @@ public class CourtAppearanceTransformerTest {
             ))
             .build();
 
-        List<CourtReport> courtReports = courtAppearanceTransformer.courtAppearanceOf(courtAppearance).getCourtReports();
+        List<CourtReport> courtReports = CourtAppearanceTransformer
+                .courtAppearanceOf(courtAppearance).getCourtReports();
         assertThat(courtReports)
             .extracting("courtReportId").containsOnly(1L, 3L);
     }

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/DocumentTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/DocumentTransformerTest.java
@@ -27,8 +27,8 @@ public class DocumentTransformerTest {
         offenderDocument.setCreatedDate(LocalDateTime.of(1965, 7, 19, 0, 0, 0));
         offenderDocument.setLastSaved(LocalDateTime.of(1985, 7, 19, 0, 0, 0));
 
-        assertThat(documentTransformer.offenderDocumentsDetailsOfOffenderDocuments(ImmutableList.of(offenderDocument))).hasSize(1);
-        assertThat(documentTransformer.offenderDocumentsDetailsOfOffenderDocuments(ImmutableList.of(offenderDocument)).get(0).getCreatedAt()).isEqualTo(LocalDateTime.of(1965, 7, 19, 0, 0, 0));
+        assertThat(DocumentTransformer.offenderDocumentsDetailsOfOffenderDocuments(ImmutableList.of(offenderDocument))).hasSize(1);
+        assertThat(DocumentTransformer.offenderDocumentsDetailsOfOffenderDocuments(ImmutableList.of(offenderDocument)).get(0).getCreatedAt()).isEqualTo(LocalDateTime.of(1965, 7, 19, 0, 0, 0));
     }
 
     @Test
@@ -37,8 +37,8 @@ public class DocumentTransformerTest {
         offenderDocument.setCreatedDate(null);
         offenderDocument.setLastSaved(LocalDateTime.of(1985, 7, 19, 0, 0, 0));
 
-        assertThat(documentTransformer.offenderDocumentsDetailsOfOffenderDocuments(ImmutableList.of(offenderDocument))).hasSize(1);
-        assertThat(documentTransformer.offenderDocumentsDetailsOfOffenderDocuments(ImmutableList.of(offenderDocument)).get(0).getCreatedAt()).isEqualTo(LocalDateTime.of(1985, 7, 19, 0, 0, 0));
+        assertThat(DocumentTransformer.offenderDocumentsDetailsOfOffenderDocuments(ImmutableList.of(offenderDocument))).hasSize(1);
+        assertThat(DocumentTransformer.offenderDocumentsDetailsOfOffenderDocuments(ImmutableList.of(offenderDocument)).get(0).getCreatedAt()).isEqualTo(LocalDateTime.of(1985, 7, 19, 0, 0, 0));
     }
     @Test
     public void authorNameUsesCreatedByWhenPresent() {
@@ -58,8 +58,8 @@ public class DocumentTransformerTest {
                         .build()
         );
 
-        assertThat(documentTransformer.offenderDocumentsDetailsOfOffenderDocuments(ImmutableList.of(offenderDocument))).hasSize(1);
-        assertThat(documentTransformer.offenderDocumentsDetailsOfOffenderDocuments(ImmutableList.of(offenderDocument)).get(0).getAuthor()).isEqualTo("Bobby Bread");
+        assertThat(DocumentTransformer.offenderDocumentsDetailsOfOffenderDocuments(ImmutableList.of(offenderDocument))).hasSize(1);
+        assertThat(DocumentTransformer.offenderDocumentsDetailsOfOffenderDocuments(ImmutableList.of(offenderDocument)).get(0).getAuthor()).isEqualTo("Bobby Bread");
     }
     @Test
     public void authorNameUsesLastUpdatedByWhenCreatedByNotPresent() {
@@ -73,8 +73,8 @@ public class DocumentTransformerTest {
                         .build()
         );
 
-        assertThat(documentTransformer.offenderDocumentsDetailsOfOffenderDocuments(ImmutableList.of(offenderDocument))).hasSize(1);
-        assertThat(documentTransformer.offenderDocumentsDetailsOfOffenderDocuments(ImmutableList.of(offenderDocument))
+        assertThat(DocumentTransformer.offenderDocumentsDetailsOfOffenderDocuments(ImmutableList.of(offenderDocument))).hasSize(1);
+        assertThat(DocumentTransformer.offenderDocumentsDetailsOfOffenderDocuments(ImmutableList.of(offenderDocument))
                 .get(0).getAuthor()).isEqualTo("Lardy Lump");
     }
 
@@ -156,9 +156,10 @@ public class DocumentTransformerTest {
         document.getCourtReport().setDateRequested(LocalDateTime.of(1965, 7, 19, 0, 0));
         document.getCourtReport().getCourtAppearance().getCourt().setCourtName("Sheffield Crown Court");
 
-        assertThat(documentTransformer.offenderDocumentsDetailsOfCourtReportDocuments(ImmutableList.of(document))).hasSize(1);
+        assertThat(DocumentTransformer.offenderDocumentsDetailsOfCourtReportDocuments(ImmutableList.of(document))).hasSize(1);
 
-        final OffenderDocumentDetail offenderDocumentDetail = documentTransformer.offenderDocumentsDetailsOfCourtReportDocuments(ImmutableList.of(document)).get(0);
+        final OffenderDocumentDetail offenderDocumentDetail = DocumentTransformer
+                .offenderDocumentsDetailsOfCourtReportDocuments(ImmutableList.of(document)).get(0);
 
         assertThat(offenderDocumentDetail.getType().getCode()).isEqualTo("COURT_REPORT_DOCUMENT");
         assertThat(offenderDocumentDetail.getType().getDescription()).isEqualTo("Court report");
@@ -173,9 +174,11 @@ public class DocumentTransformerTest {
         document.getInstitutionalReport().setDateRequested(LocalDateTime.of(1965, 7, 19, 0, 0));
         document.getInstitutionalReport().getInstitution().setInstitutionName("Sheffield jail");
 
-        assertThat(documentTransformer.offenderDocumentsDetailsOfInstitutionReportDocuments(ImmutableList.of(document))).hasSize(1);
+        assertThat(DocumentTransformer
+                .offenderDocumentsDetailsOfInstitutionReportDocuments(ImmutableList.of(document))).hasSize(1);
 
-        final OffenderDocumentDetail offenderDocumentDetail = documentTransformer.offenderDocumentsDetailsOfInstitutionReportDocuments(ImmutableList.of(document)).get(0);
+        final OffenderDocumentDetail offenderDocumentDetail = DocumentTransformer
+                .offenderDocumentsDetailsOfInstitutionReportDocuments(ImmutableList.of(document)).get(0);
 
         assertThat(offenderDocumentDetail.getType().getCode()).isEqualTo("INSTITUTION_REPORT_DOCUMENT");
         assertThat(offenderDocumentDetail.getType().getDescription()).isEqualTo("Institution report");
@@ -191,9 +194,11 @@ public class DocumentTransformerTest {
 
         document.getAddressAssessment().setAssessmentDate(LocalDateTime.of(1965, 7, 19, 0, 0));
 
-        assertThat(documentTransformer.offenderDocumentsDetailsOfAddressAssessmentDocuments(ImmutableList.of(document))).hasSize(1);
+        assertThat(DocumentTransformer
+                .offenderDocumentsDetailsOfAddressAssessmentDocuments(ImmutableList.of(document))).hasSize(1);
 
-        final OffenderDocumentDetail offenderDocumentDetail = documentTransformer.offenderDocumentsDetailsOfAddressAssessmentDocuments(ImmutableList.of(document)).get(0);
+        final OffenderDocumentDetail offenderDocumentDetail = DocumentTransformer
+                .offenderDocumentsDetailsOfAddressAssessmentDocuments(ImmutableList.of(document)).get(0);
 
         assertThat(offenderDocumentDetail.getType().getCode()).isEqualTo("ADDRESS_ASSESSMENT_DOCUMENT");
         assertThat(offenderDocumentDetail.getType().getDescription()).isEqualTo("Address assessment related document");
@@ -206,9 +211,11 @@ public class DocumentTransformerTest {
 
         document.getApprovedPremisesReferral().setReferralDate(LocalDateTime.of(1965, 7, 19, 0, 0));
 
-        assertThat(documentTransformer.offenderDocumentsDetailsOfApprovedPremisesReferralDocuments(ImmutableList.of(document))).hasSize(1);
+        assertThat(DocumentTransformer
+                .offenderDocumentsDetailsOfApprovedPremisesReferralDocuments(ImmutableList.of(document))).hasSize(1);
 
-        final OffenderDocumentDetail offenderDocumentDetail = documentTransformer.offenderDocumentsDetailsOfApprovedPremisesReferralDocuments(ImmutableList.of(document)).get(0);
+        final OffenderDocumentDetail offenderDocumentDetail = DocumentTransformer
+                .offenderDocumentsDetailsOfApprovedPremisesReferralDocuments(ImmutableList.of(document)).get(0);
 
         assertThat(offenderDocumentDetail.getType().getCode()).isEqualTo("APPROVED_PREMISES_REFERRAL_DOCUMENT");
         assertThat(offenderDocumentDetail.getType().getDescription()).isEqualTo("Approved premises referral related document");
@@ -222,9 +229,10 @@ public class DocumentTransformerTest {
         document.getAssessment().setAssessmentDate(LocalDateTime.of(1965, 7, 19, 0, 0));
         document.getAssessment().getAssessmentType().setDescription("Drugs testing");
 
-        assertThat(documentTransformer.offenderDocumentsDetailsOfAssessmentDocuments(ImmutableList.of(document))).hasSize(1);
+        assertThat(DocumentTransformer.offenderDocumentsDetailsOfAssessmentDocuments(ImmutableList.of(document))).hasSize(1);
 
-        final OffenderDocumentDetail offenderDocumentDetail = documentTransformer.offenderDocumentsDetailsOfAssessmentDocuments(ImmutableList.of(document)).get(0);
+        final OffenderDocumentDetail offenderDocumentDetail = DocumentTransformer
+                .offenderDocumentsDetailsOfAssessmentDocuments(ImmutableList.of(document)).get(0);
 
         assertThat(offenderDocumentDetail.getType().getCode()).isEqualTo("ASSESSMENT_DOCUMENT");
         assertThat(offenderDocumentDetail.getType().getDescription()).isEqualTo("Assessment document");
@@ -236,9 +244,11 @@ public class DocumentTransformerTest {
         final CaseAllocationDocument document = aCaseAllocationDocument(1L);
 
 
-        assertThat(documentTransformer.offenderDocumentsDetailsOfCaseAllocationDocuments(ImmutableList.of(document))).hasSize(1);
+        assertThat(DocumentTransformer
+                .offenderDocumentsDetailsOfCaseAllocationDocuments(ImmutableList.of(document))).hasSize(1);
 
-        final OffenderDocumentDetail offenderDocumentDetail = documentTransformer.offenderDocumentsDetailsOfCaseAllocationDocuments(ImmutableList.of(document)).get(0);
+        final OffenderDocumentDetail offenderDocumentDetail = DocumentTransformer
+                .offenderDocumentsDetailsOfCaseAllocationDocuments(ImmutableList.of(document)).get(0);
 
         assertThat(offenderDocumentDetail.getType().getCode()).isEqualTo("CASE_ALLOCATION_DOCUMENT");
         assertThat(offenderDocumentDetail.getType().getDescription()).isEqualTo("Case allocation document");
@@ -249,9 +259,11 @@ public class DocumentTransformerTest {
         final PersonalContactDocument document = aPersonalContactDocument();
 
 
-        assertThat(documentTransformer.offenderDocumentsDetailsOfPersonalContactDocuments(ImmutableList.of(document))).hasSize(1);
+        assertThat(DocumentTransformer
+                .offenderDocumentsDetailsOfPersonalContactDocuments(ImmutableList.of(document))).hasSize(1);
 
-        final OffenderDocumentDetail offenderDocumentDetail = documentTransformer.offenderDocumentsDetailsOfPersonalContactDocuments(ImmutableList.of(document)).get(0);
+        final OffenderDocumentDetail offenderDocumentDetail = DocumentTransformer
+                .offenderDocumentsDetailsOfPersonalContactDocuments(ImmutableList.of(document)).get(0);
 
         assertThat(offenderDocumentDetail.getType().getCode()).isEqualTo("PERSONAL_CONTACT_DOCUMENT");
         assertThat(offenderDocumentDetail.getExtendedDescription()).isEqualTo("Personal contact of type GP with Father");
@@ -266,9 +278,10 @@ public class DocumentTransformerTest {
         document.getReferral().setReferralDate(LocalDateTime.of(1965, 7, 19, 0, 0));
 
 
-        assertThat(documentTransformer.offenderDocumentsDetailsOfReferralDocuments(ImmutableList.of(document))).hasSize(1);
+        assertThat(DocumentTransformer.offenderDocumentsDetailsOfReferralDocuments(ImmutableList.of(document))).hasSize(1);
 
-        final OffenderDocumentDetail offenderDocumentDetail = documentTransformer.offenderDocumentsDetailsOfReferralDocuments(ImmutableList.of(document)).get(0);
+        final OffenderDocumentDetail offenderDocumentDetail = DocumentTransformer
+                .offenderDocumentsDetailsOfReferralDocuments(ImmutableList.of(document)).get(0);
 
         assertThat(offenderDocumentDetail.getType().getCode()).isEqualTo("REFERRAL_DOCUMENT");
         assertThat(offenderDocumentDetail.getExtendedDescription()).isEqualTo("Referral for Mental Health on 19/07/1965");
@@ -283,9 +296,10 @@ public class DocumentTransformerTest {
         document.getNsi().setReferralDate(LocalDate.of(1965, 7, 19));
 
 
-        assertThat(documentTransformer.offenderDocumentsDetailsOfNsiDocuments(ImmutableList.of(document))).hasSize(1);
+        assertThat(DocumentTransformer.offenderDocumentsDetailsOfNsiDocuments(ImmutableList.of(document))).hasSize(1);
 
-        final OffenderDocumentDetail offenderDocumentDetail = documentTransformer.offenderDocumentsDetailsOfNsiDocuments(ImmutableList.of(document)).get(0);
+        final OffenderDocumentDetail offenderDocumentDetail = DocumentTransformer
+                .offenderDocumentsDetailsOfNsiDocuments(ImmutableList.of(document)).get(0);
 
         assertThat(offenderDocumentDetail.getType().getCode()).isEqualTo("NSI_DOCUMENT");
         assertThat(offenderDocumentDetail.getExtendedDescription()).isEqualTo("Non Statutory Intervention for Custody - Accredited Programme on 19/07/1965");
@@ -300,9 +314,9 @@ public class DocumentTransformerTest {
         document.getPersonalCircumstance().setStartDate(LocalDate.of(1965, 7, 19));
 
 
-        assertThat(documentTransformer.offenderDocumentsDetailsOfPersonalCircumstanceDocuments(ImmutableList.of(document))).hasSize(1);
+        assertThat(DocumentTransformer.offenderDocumentsDetailsOfPersonalCircumstanceDocuments(ImmutableList.of(document))).hasSize(1);
 
-        final OffenderDocumentDetail offenderDocumentDetail = documentTransformer.offenderDocumentsDetailsOfPersonalCircumstanceDocuments(ImmutableList.of(document)).get(0);
+        final OffenderDocumentDetail offenderDocumentDetail = DocumentTransformer.offenderDocumentsDetailsOfPersonalCircumstanceDocuments(ImmutableList.of(document)).get(0);
 
         assertThat(offenderDocumentDetail.getType().getCode()).isEqualTo("PERSONAL_CIRCUMSTANCE_DOCUMENT");
         assertThat(offenderDocumentDetail.getExtendedDescription()).isEqualTo("Personal circumstance of AP - Medication in Posession - Assessment started on 19/07/1965");
@@ -317,9 +331,9 @@ public class DocumentTransformerTest {
         document.getUpwAppointment().setAppointmentDate(LocalDateTime.of(1965, 7, 19, 0, 0));
 
 
-        assertThat(documentTransformer.offenderDocumentsDetailsOfUPWAppointmentDocuments(ImmutableList.of(document))).hasSize(1);
+        assertThat(DocumentTransformer.offenderDocumentsDetailsOfUPWAppointmentDocuments(ImmutableList.of(document))).hasSize(1);
 
-        final OffenderDocumentDetail offenderDocumentDetail = documentTransformer.offenderDocumentsDetailsOfUPWAppointmentDocuments(ImmutableList.of(document)).get(0);
+        final OffenderDocumentDetail offenderDocumentDetail = DocumentTransformer.offenderDocumentsDetailsOfUPWAppointmentDocuments(ImmutableList.of(document)).get(0);
 
         assertThat(offenderDocumentDetail.getType().getCode()).isEqualTo("UPW_APPOINTMENT_DOCUMENT");
         assertThat(offenderDocumentDetail.getExtendedDescription()).isEqualTo("Unpaid work appointment on 19/07/1965 for Cutting grass");
@@ -334,9 +348,9 @@ public class DocumentTransformerTest {
         document.getContact().setContactDate(LocalDate.of(1965, 7, 19));
 
 
-        assertThat(documentTransformer.offenderDocumentsDetailsOfContactDocuments(ImmutableList.of(document))).hasSize(1);
+        assertThat(DocumentTransformer.offenderDocumentsDetailsOfContactDocuments(ImmutableList.of(document))).hasSize(1);
 
-        final OffenderDocumentDetail offenderDocumentDetail = documentTransformer.offenderDocumentsDetailsOfContactDocuments(ImmutableList.of(document)).get(0);
+        final OffenderDocumentDetail offenderDocumentDetail = DocumentTransformer.offenderDocumentsDetailsOfContactDocuments(ImmutableList.of(document)).get(0);
 
         assertThat(offenderDocumentDetail.getType().getCode()).isEqualTo("CONTACT_DOCUMENT");
         assertThat(offenderDocumentDetail.getExtendedDescription()).isEqualTo("Contact on 19/07/1965 for Meet up");

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/MainOffenceTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/MainOffenceTransformerTest.java
@@ -40,7 +40,7 @@ public class MainOffenceTransformerTest {
                 .build())
             .build();
 
-        assertThat(mainOffenceTransformer.offenceOf(mainOffence).getOffenceId()).isEqualTo("M92");
+        assertThat(MainOffenceTransformer.offenceOf(mainOffence).getOffenceId()).isEqualTo("M92");
     }
 
     @Test
@@ -51,7 +51,7 @@ public class MainOffenceTransformerTest {
                 .build())
             .build();
 
-        assertThat(mainOffenceTransformer.offenceOf(mainOffence).getMainOffence()).isTrue();
+        assertThat(MainOffenceTransformer.offenceOf(mainOffence).getMainOffence()).isTrue();
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/NsiTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/NsiTransformerTest.java
@@ -2,70 +2,54 @@ package uk.gov.justice.digital.delius.transformers;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.data.api.Nsi;
-import uk.gov.justice.digital.delius.jpa.standard.entity.*;
+import uk.gov.justice.digital.delius.jpa.standard.entity.NsiStatus;
+import uk.gov.justice.digital.delius.jpa.standard.entity.NsiType;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Requirement;
+import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
+import uk.gov.justice.digital.delius.util.EntityHelper;
 
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class NsiTransformerTest {
 
-    @Mock
-    private uk.gov.justice.digital.delius.data.api.ProbationArea probationArea1;
-    @Mock
-    private uk.gov.justice.digital.delius.data.api.ProbationArea probationArea2;
-    @Mock
-    private uk.gov.justice.digital.delius.data.api.Team mockTeam1;
-    @Mock
-    private uk.gov.justice.digital.delius.data.api.Team mockTeam2;
-    @Mock
-    private uk.gov.justice.digital.delius.data.api.StaffDetails mockStaff1;
-    @Mock
-    private uk.gov.justice.digital.delius.data.api.StaffDetails mockStaff2;
-
-    @Mock
-    private ProbationAreaTransformer probationAreaTransformer;
-    @Mock
-    private TeamTransformer teamTransformer;
-    @Mock
-    private StaffTransformer staffTransformer;
-
-    private NsiManager nsiManager2;
-    private Staff expectedStaff2;
-    private Team expectedTeam2;
-    private ProbationArea expectedProbationArea2;
-    private NsiManager nsiManager1;
-    private Staff expectedStaff1;
-    private Team expectedTeam1;
-    private ProbationArea expectedProbationArea1;
-
     @Test
     void testTransform() {
-        NsiTransformer transformer = new NsiTransformer(new RequirementTransformer(), probationAreaTransformer, teamTransformer, staffTransformer);
         final LocalDate expectedStartDate = LocalDate.of(2020, Month.APRIL, 1);
         final LocalDate actualStartDate = LocalDate.of(2020, Month.APRIL, 1);
         final LocalDate referralDate = LocalDate.of(2020, Month.FEBRUARY, 1);
 
-        buildNsiManagers();
+        final var nsiEntity = buildNsiEntity(expectedStartDate, actualStartDate, referralDate)
+                .toBuilder()
+                .nsiManagers(List.of(
+                        EntityHelper.aNsiManager()
+                                .toBuilder()
+                                .startDate(LocalDate.of(2020, 5, 4))
+                                .endDate(LocalDate.of(2021, 5, 4))
+                                .probationArea(EntityHelper.aProbationArea().toBuilder().code("N01").build())
+                                .team(EntityHelper.aTeam().toBuilder().code("N01AAA").build())
+                                .staff(EntityHelper.aStaff("N01AAA001"))
+                                .build(),
+                        EntityHelper.aNsiManager()
+                                .toBuilder()
+                                .startDate(LocalDate.of(2019, 5, 4))
+                                .endDate(LocalDate.of(2020, 5, 3))
+                                .probationArea(EntityHelper.aProbationArea().toBuilder().code("N02").build())
+                                .team(EntityHelper.aTeam().toBuilder().code("N02AAA").build())
+                                .staff(EntityHelper.aStaff("N02AAA001"))
+                                .build()
+                ))
+                .build();
 
-        when(probationAreaTransformer.probationAreaOf(expectedProbationArea1, false)).thenReturn(probationArea1);
-        when(probationAreaTransformer.probationAreaOf(expectedProbationArea2, false)).thenReturn(probationArea2);
-        when(teamTransformer.teamOf(expectedTeam1)).thenReturn(mockTeam1);
-        when(teamTransformer.teamOf(expectedTeam2)).thenReturn(mockTeam2);
-        when(staffTransformer.staffDetailsOf(expectedStaff1)).thenReturn(mockStaff1);
-        when(staffTransformer.staffDetailsOf(expectedStaff2)).thenReturn(mockStaff2);
-
-        final var nsiEntity = buildNsiEntity(expectedStartDate, actualStartDate, referralDate);
-
-        final Nsi nsi = transformer.nsiOf(nsiEntity);
+        final Nsi nsi = NsiTransformer.nsiOf(nsiEntity);
 
         assertThat(nsi.getNsiId()).isEqualTo(100L);
         assertThat(nsi.getActualStartDate()).isEqualTo(actualStartDate);
@@ -84,20 +68,20 @@ class NsiTransformerTest {
         var manager1 = nsi.getNsiManagers().get(0);
         assertThat(manager1.getStartDate()).isEqualTo(LocalDate.of(2020, 5, 4));
         assertThat(manager1.getEndDate()).isEqualTo(LocalDate.of(2021, 5, 4));
-        assertThat(manager1.getProbationArea()).isEqualTo(probationArea1);
-        assertThat(manager1.getTeam()).isEqualTo(mockTeam1);
-        assertThat(manager1.getStaff()).isEqualTo(mockStaff1);
+        assertThat(manager1.getProbationArea().getCode()).isEqualTo("N01");
+        assertThat(manager1.getTeam().getCode()).isEqualTo("N01AAA");
+        assertThat(manager1.getStaff().getStaffCode()).isEqualTo("N01AAA001");
 
         var manager2 = nsi.getNsiManagers().get(1);
         assertThat(manager2.getStartDate()).isEqualTo(LocalDate.of(2019, 5, 4));
         assertThat(manager2.getEndDate()).isEqualTo(LocalDate.of(2020, 5, 3));
-        assertThat(manager2.getProbationArea()).isEqualTo(probationArea2);
-        assertThat(manager2.getTeam()).isEqualTo(mockTeam2);
-        assertThat(manager2.getStaff()).isEqualTo(mockStaff2);
+        assertThat(manager2.getProbationArea().getCode()).isEqualTo("N02");
+        assertThat(manager2.getTeam().getCode()).isEqualTo("N02AAA");
+        assertThat(manager2.getStaff().getStaffCode()).isEqualTo("N02AAA001");
 
     }
 
-    private uk.gov.justice.digital.delius.jpa.standard.entity.Nsi buildNsiEntity(LocalDate expectedStartDate, LocalDate actualStartDate, LocalDate referralDate) {
+   private uk.gov.justice.digital.delius.jpa.standard.entity.Nsi buildNsiEntity(LocalDate expectedStartDate, LocalDate actualStartDate, LocalDate referralDate) {
         return uk.gov.justice.digital.delius.jpa.standard.entity.Nsi.builder()
                 .nsiId(100L)
                 .nsiStatus(NsiStatus.builder().code("STX").description("").build())
@@ -106,44 +90,10 @@ class NsiTransformerTest {
                 .actualStartDate(actualStartDate)
                 .expectedStartDate(expectedStartDate)
                 .referralDate(referralDate)
-                .nsiManagers(Arrays.asList(nsiManager1, nsiManager2))
+                .nsiManagers(Arrays.asList(EntityHelper.aNsiManager(), EntityHelper.aNsiManager()))
                 .length(12L)
+                .nsiManagers(List.of(EntityHelper.aNsiManager(), EntityHelper.aNsiManager()))
                 .rqmnt(Requirement.builder().activeFlag(1L).build()).build();
     }
 
-    private void buildNsiManagers() {
-        expectedProbationArea1 = ProbationArea.builder()
-                .probationAreaId(1L)
-                .build();
-        expectedTeam1 = Team.builder()
-                .teamId(1L)
-                .build();
-        expectedStaff1 = Staff.builder()
-                .staffId(1L)
-                .build();
-        nsiManager1 = NsiManager.builder()
-                .startDate(LocalDate.of(2020,5,4))
-                .endDate(LocalDate.of(2021,5,4))
-                .probationArea(expectedProbationArea1)
-                .team(expectedTeam1)
-                .staff(expectedStaff1)
-                .build();
-
-        expectedProbationArea2 = ProbationArea.builder()
-                .probationAreaId(2L)
-                .build();
-        expectedTeam2 = Team.builder()
-                .teamId(2L)
-                .build();
-        expectedStaff2 = Staff.builder()
-                .staffId(2L)
-                .build();
-        nsiManager2 = NsiManager.builder()
-                .startDate(LocalDate.of(2019,5,4))
-                .endDate(LocalDate.of(2020,5,3))
-                .probationArea(expectedProbationArea2)
-                .team(expectedTeam2)
-                .staff(expectedStaff2)
-                .build();
-    }
 }

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/OffenderManagerTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/OffenderManagerTransformerTest.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import uk.gov.justice.digital.delius.data.api.Human;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,7 +20,7 @@ public class OffenderManagerTransformerTest {
 
     @Test
     public void staffNameDetailsTakenFromStaffInOffenderManager() {
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 anOffenderManager(
                         aStaff()
                                 .toBuilder()
@@ -37,7 +36,7 @@ public class OffenderManagerTransformerTest {
 
     @Test
     public void staffCodeTakenFromStaffInOffenderManager() {
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 anOffenderManager(
                         aStaff()
                                 .toBuilder()
@@ -51,7 +50,7 @@ public class OffenderManagerTransformerTest {
 
     @Test
     public void teamsTakenFromTeamInOffenderManager() {
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 anOffenderManager(
                         aStaff()
                                 .toBuilder()
@@ -63,7 +62,7 @@ public class OffenderManagerTransformerTest {
 
     @Test
     public void staffNameDetailsTakenFromStaffInPrisonOffenderManager() {
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 aPrisonOffenderManager(
                         aStaff()
                                 .toBuilder()
@@ -79,7 +78,7 @@ public class OffenderManagerTransformerTest {
 
     @Test
     public void staffCodeTakenFromStaffInPrisonOffenderManager() {
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 aPrisonOffenderManager(
                         aStaff()
                                 .toBuilder()
@@ -93,7 +92,7 @@ public class OffenderManagerTransformerTest {
 
     @Test
     public void teamsTakenFromTeamInPrisonOffenderManager() {
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 aPrisonOffenderManager(
                         aStaff()
                                 .toBuilder()
@@ -105,7 +104,7 @@ public class OffenderManagerTransformerTest {
 
     @Test
     public void unallocatedSetWhenStaffCodeEndsInLetterU() {
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 anOffenderManager(
                         aStaff()
                                 .toBuilder()
@@ -114,7 +113,7 @@ public class OffenderManagerTransformerTest {
                         aTeam()
                 )
         ).getIsUnallocated()).isFalse();
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 anOffenderManager(
                         aStaff()
                                 .toBuilder()
@@ -127,7 +126,7 @@ public class OffenderManagerTransformerTest {
 
     @Test
     public void unallocatedSetWhenStaffCodeEndsInLetterUForPrisonOffenderManager() {
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 aPrisonOffenderManager(
                         aStaff()
                                 .toBuilder()
@@ -136,7 +135,7 @@ public class OffenderManagerTransformerTest {
                         aTeam()
                 )
         ).getIsUnallocated()).isFalse();
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 aPrisonOffenderManager(
                         aStaff()
                                 .toBuilder()
@@ -149,16 +148,17 @@ public class OffenderManagerTransformerTest {
 
     @Test
     public void willSetPrisonOffenderManagerIndicator() {
-        assertThat(offenderManagerTransformer.offenderManagerOf(anActivePrisonOffenderManager())
+        assertThat(OffenderManagerTransformer
+                .offenderManagerOf(anActivePrisonOffenderManager())
                 .getIsPrisonOffenderManager()).isTrue();
-        assertThat(offenderManagerTransformer.offenderManagerOf(anActiveOffenderManager())
+        assertThat(OffenderManagerTransformer.offenderManagerOf(anActiveOffenderManager())
                 .getIsPrisonOffenderManager()).isFalse();
 
     }
 
     @Test
     public void probationAreaCopiedFromOffenderManager() {
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 anActiveOffenderManager()
                         .toBuilder()
                         .probationArea(
@@ -174,7 +174,7 @@ public class OffenderManagerTransformerTest {
 
     @Test
     public void probationAreaCopiedFromPrisonOffenderManager() {
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 anActivePrisonOffenderManager()
                         .toBuilder()
                         .probationArea(
@@ -190,7 +190,7 @@ public class OffenderManagerTransformerTest {
 
     @Test
     public void institutionCopiedFromPrisonOffenderManagerProbationArea() {
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 anActivePrisonOffenderManager()
                         .toBuilder()
                         .probationArea(
@@ -209,7 +209,7 @@ public class OffenderManagerTransformerTest {
 
     @Test
     public void OffenderManagerMarkedAsResponsibleOfficerWhenLinkedAndNotEndDated() {
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 anActiveOffenderManager()
                         .toBuilder()
                         .responsibleOfficer(
@@ -220,7 +220,7 @@ public class OffenderManagerTransformerTest {
                         .build()
         ).getIsResponsibleOfficer()).isTrue();
 
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 anActiveOffenderManager()
                         .toBuilder()
                         .responsibleOfficer(
@@ -231,7 +231,7 @@ public class OffenderManagerTransformerTest {
                         .build()
         ).getIsResponsibleOfficer()).isFalse();
 
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 anActiveOffenderManager()
                         .toBuilder()
                         .responsibleOfficer(null)
@@ -241,7 +241,7 @@ public class OffenderManagerTransformerTest {
     }
     @Test
     public void prisonerOffenderManagerMarkedAsResponsibleOfficerWhenLinkedAndNotEndDated() {
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 anActivePrisonOffenderManager()
                         .toBuilder()
                         .responsibleOfficer(
@@ -252,7 +252,7 @@ public class OffenderManagerTransformerTest {
                         .build()
         ).getIsResponsibleOfficer()).isTrue();
 
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 anActivePrisonOffenderManager()
                         .toBuilder()
                         .responsibleOfficer(
@@ -263,7 +263,7 @@ public class OffenderManagerTransformerTest {
                         .build()
         ).getIsResponsibleOfficer()).isFalse();
 
-        assertThat(offenderManagerTransformer.offenderManagerOf(
+        assertThat(OffenderManagerTransformer.offenderManagerOf(
                 anActivePrisonOffenderManager()
                         .toBuilder()
                         .responsibleOfficer(null)

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/OffenderTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/OffenderTransformerTest.java
@@ -32,7 +32,7 @@ public class OffenderTransformerTest {
 
     @Test
     public void offenderManagerAllocationReasonMappedFromAllocationReasonInOffenderTransfer() {
-        assertThat(offenderTransformer.offenderManagersOf(ImmutableList.of(aOffenderManager())).get(0).getAllocationReason())
+        assertThat(OffenderTransformer.offenderManagersOf(ImmutableList.of(aOffenderManager())).get(0).getAllocationReason())
                 .isNotNull()
                 .hasFieldOrPropertyWithValue("code", "1984")
                 .hasFieldOrPropertyWithValue("description", "Reallocation - Inactive Offender");
@@ -41,7 +41,7 @@ public class OffenderTransformerTest {
 
     @Test
     public void offenderManagerAllocationReasonNullWhenOffenderTransferAbsent() {
-        assertThat(offenderTransformer.offenderManagersOf(
+        assertThat(OffenderTransformer.offenderManagersOf(
                 ImmutableList.of(
                         aOffenderManager()
                                 .toBuilder()
@@ -54,7 +54,7 @@ public class OffenderTransformerTest {
 
     @Test
     public void disabilitiesCopiedWithLatestFirst() {
-        assertThat(offenderTransformer.fullOffenderOf(anOffender()
+        assertThat(OffenderTransformer.fullOffenderOf(anOffender()
                 .toBuilder()
                 .disabilities(ImmutableList.of(
                         uk.gov.justice.digital.delius.jpa.standard.entity.Disability
@@ -101,7 +101,7 @@ public class OffenderTransformerTest {
 
     @Test
     public void deletedDisabilitiesNotCopied() {
-        assertThat(offenderTransformer.fullOffenderOf(anOffender()
+        assertThat(OffenderTransformer.fullOffenderOf(anOffender()
                 .toBuilder()
                 .disabilities(ImmutableList.of(
                         uk.gov.justice.digital.delius.jpa.standard.entity.Disability
@@ -139,7 +139,7 @@ public class OffenderTransformerTest {
     public void currentlyManagedOffenders() {
 
         // Get currently managed offenders for this officer
-        assertThat(offenderTransformer.managedOffenderOf(anOfficerWithOffenderManagers(), true)
+        assertThat(OffenderTransformer.managedOffenderOf(anOfficerWithOffenderManagers(), true)
                 .get(0))
                 .hasFieldOrPropertyWithValue("nomsNumber", "A1111")
                 .hasFieldOrPropertyWithValue("offenderSurname", "SMITH")
@@ -150,7 +150,7 @@ public class OffenderTransformerTest {
     public void allManagedOffenders() {
 
         // Get current and past managed offenders for this officer
-        assertThat(offenderTransformer.managedOffenderOf(anOfficerWithOffenderManagers(), false)
+        assertThat(OffenderTransformer.managedOffenderOf(anOfficerWithOffenderManagers(), false)
                 .stream()
                 .collect(Collectors.toList()))
                 .hasSize(2);
@@ -160,7 +160,7 @@ public class OffenderTransformerTest {
     public void currentResponsibleOfficer() {
 
         // Get the current responsible officers for an offender
-        assertThat(offenderTransformer.responsibleOfficersOf(anOffenderWithManagers(), true)
+        assertThat(OffenderTransformer.responsibleOfficersOf(anOffenderWithManagers(), true)
                 .stream()
                 .map(ro -> ro.getOffenderManagerId())
                 .collect(Collectors.toList()))
@@ -172,7 +172,7 @@ public class OffenderTransformerTest {
     public void allResponsibleOfficers() {
 
         // Get the current and previous reponsible officers assignments for this offender
-        assertThat(offenderTransformer.responsibleOfficersOf(anOffenderWithManagers(), false)
+        assertThat(OffenderTransformer.responsibleOfficersOf(anOffenderWithManagers(), false)
                 .stream()
                 .map(ro -> ro.getOffenderManagerId())
                 .collect(Collectors.toList()))
@@ -182,7 +182,7 @@ public class OffenderTransformerTest {
 
     @Test
     public void ProbationAreaNPSPrivateSectorTransformedToTrue() {
-        assertThat(offenderTransformer.offenderManagersOf(ImmutableList.of(
+        assertThat(OffenderTransformer.offenderManagersOf(ImmutableList.of(
                 aOffenderManager()
                         .toBuilder()
                         .probationArea(npsProbationArea())
@@ -192,7 +192,7 @@ public class OffenderTransformerTest {
 
     @Test
     public void ProbationAreaNPSPrivateSectorTransformedToFalse() {
-        assertThat(offenderTransformer.offenderManagersOf(ImmutableList.of(
+        assertThat(OffenderTransformer.offenderManagersOf(ImmutableList.of(
                 aOffenderManager()
                         .toBuilder()
                         .probationArea(crcProbationArea())
@@ -352,7 +352,7 @@ public class OffenderTransformerTest {
                     .mostRecentPrisonerNumber("G12345")
                     .build();
 
-            final var ids = offenderTransformer.idsOf(offender);
+            final var ids = OffenderTransformer.idsOf(offender);
 
             assertThat(ids.getNomsNumber()).isEqualTo("A1234CR");
             assertThat(ids.getPncNumber()).isEqualTo("2004/0712343H");
@@ -393,7 +393,7 @@ public class OffenderTransformerTest {
                     ))
                     .build();
 
-            final var additionalIdentifiers = offenderTransformer
+            final var additionalIdentifiers = OffenderTransformer
                     .additionalIdentifiersOf(offender.getAdditionalIdentifiers());
 
             assertThat(additionalIdentifiers)
@@ -453,7 +453,7 @@ public class OffenderTransformerTest {
                     ))
                     .build();
 
-            final var additionalIdentifiers = offenderTransformer
+            final var additionalIdentifiers = OffenderTransformer
                     .additionalIdentifiersOf(offender.getAdditionalIdentifiers());
 
             assertThat(additionalIdentifiers).hasSize(1);

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformerTest.java
@@ -20,14 +20,14 @@ public class PersonalCircumstanceTransformerTest {
     @Test
     public void probationAreasMappedOnlyWhenNotNull() {
 
-        assertThat(transformer.personalCircumstanceOf(
+        assertThat(PersonalCircumstanceTransformer.personalCircumstanceOf(
                 aPersonalCircumstance()
                         .toBuilder()
                         .probationArea(null)
                         .build()).getProbationArea())
                 .isNull();
 
-        assertThat(transformer.personalCircumstanceOf(
+        assertThat(PersonalCircumstanceTransformer.personalCircumstanceOf(
                 aPersonalCircumstance()
                         .toBuilder()
                         .probationArea(ProbationArea.builder().code("X").description("Description").build())
@@ -39,7 +39,7 @@ public class PersonalCircumstanceTransformerTest {
 
     @Test
     public void typeMappedFromCircumstanceType() {
-        assertThat(transformer.personalCircumstanceOf(
+        assertThat(PersonalCircumstanceTransformer.personalCircumstanceOf(
                 aPersonalCircumstance()
                         .toBuilder()
                         .circumstanceType(CircumstanceType.builder().codeValue("X").codeDescription("Description").build())
@@ -52,7 +52,7 @@ public class PersonalCircumstanceTransformerTest {
 
     @Test
     public void subTypeMappedFromCircumstanceSubType() {
-        assertThat(transformer.personalCircumstanceOf(
+        assertThat(PersonalCircumstanceTransformer.personalCircumstanceOf(
                 aPersonalCircumstance()
                         .toBuilder()
                         .circumstanceSubType(CircumstanceSubType.builder().codeValue("X").codeDescription("Description").build())
@@ -65,9 +65,12 @@ public class PersonalCircumstanceTransformerTest {
 
     @Test
     public void evidencedConvertedToBoolean() {
-        assertThat(transformer.personalCircumstanceOf(aPersonalCircumstance().toBuilder().evidenced("Y").build()).getEvidenced()).isTrue();
-        assertThat(transformer.personalCircumstanceOf(aPersonalCircumstance().toBuilder().evidenced("N").build()).getEvidenced()).isFalse();
-        assertThat(transformer.personalCircumstanceOf(aPersonalCircumstance().toBuilder().evidenced(null).build()).getEvidenced()).isNull();
+        assertThat(PersonalCircumstanceTransformer
+                .personalCircumstanceOf(aPersonalCircumstance().toBuilder().evidenced("Y").build()).getEvidenced()).isTrue();
+        assertThat(PersonalCircumstanceTransformer
+                .personalCircumstanceOf(aPersonalCircumstance().toBuilder().evidenced("N").build()).getEvidenced()).isFalse();
+        assertThat(PersonalCircumstanceTransformer
+                .personalCircumstanceOf(aPersonalCircumstance().toBuilder().evidenced(null).build()).getEvidenced()).isNull();
     }
 
     private PersonalCircumstance aPersonalCircumstance() {

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/ProbationAreaTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/ProbationAreaTransformerTest.java
@@ -49,7 +49,7 @@ class ProbationAreaTransformerTest {
         when(team.getCode()).thenReturn("team");
         when(providerTeam.getCode()).thenReturn("providerteam");
 
-        var result = probationAreaTransformer.probationAreaOf(probationArea, true);
+        var result = ProbationAreaTransformer.probationAreaOf(probationArea, true);
         assertThat(result.getTeams()).hasSize(2);
         assertThat(result.getTeams().get(0).getCode()).isEqualTo("team");
         assertThat(result.getTeams().get(1).getCode()).isEqualTo("providerteam");
@@ -57,7 +57,7 @@ class ProbationAreaTransformerTest {
 
     @Test
     public void whenIncludeTeamsIsFalseThenDontMapTeams() {
-        var result = probationAreaTransformer.probationAreaOf(probationArea, false);
+        var result = ProbationAreaTransformer.probationAreaOf(probationArea, false);
         assertThat(result.getTeams()).isNull();
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/RecallTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/RecallTransformerTest.java
@@ -28,7 +28,7 @@ public class RecallTransformerTest {
                 .notes(SOME_NOTES)
                 .build();
 
-        OffenderRecall offenderRecall = recallTransformer.offenderRecallOf(recall);
+        OffenderRecall offenderRecall = RecallTransformer.offenderRecallOf(recall);
 
         assertThat(offenderRecall.getDate()).isEqualTo(SOME_DATE);
         assertThat(offenderRecall.getReason().getCode()).isEqualTo(SOME_REASON_CODE);

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/RegistrationTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/RegistrationTransformerTest.java
@@ -18,7 +18,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void registerMappedFromRegisterTypeFlagReferenceData() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .registerType(
@@ -42,7 +42,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void typeMappedFromRegisterType() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .registerType(
@@ -62,7 +62,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void registeringOfficerMappedFromStaff() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .registeringStaff(
@@ -82,7 +82,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void registeringTeamMappedFromTeam() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .registeringTeam(
@@ -103,7 +103,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void registeringProbationAreaMappedFromTeamsProbationArea() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .registeringTeam(
@@ -123,7 +123,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void reviewPeriodMonthsMappedFromRegisterTypeReviewPeriod() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .registerType(
@@ -141,7 +141,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void registerLevelMappedFromRegisterLevelWhenPresent() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .registerLevel(StandardReference
@@ -159,7 +159,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void registerLevelNotMappedFromRegisterLevelWhenAbsent() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .registerLevel(null)
@@ -171,7 +171,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void registerCategoryMappedFromRegisterLevelWhenPresent() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .registerCategory(StandardReference
@@ -189,7 +189,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void registerCategoryNotMappedFromRegisterLevelWhenAbsent() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .registerCategory(null)
@@ -201,7 +201,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void warnUserMappedFromRegisterTypeAlertMessage_Yes() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .registerType(
@@ -217,7 +217,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void warnUserMappedFromRegisterTypeAlertMessage_No() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .registerType(
@@ -233,7 +233,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void warnUserMappedFromRegisterTypeAlertMessage_Absent() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .registerType(
@@ -249,7 +249,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void activeMappedFromDeregisteredReversed_1() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .deregistered(1L)
@@ -260,7 +260,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void activeMappedFromDeregisteredReversed_0() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .deregistered(0L)
@@ -271,7 +271,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void activeMappedFromDeregisteredReversed_null() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .deregistered(null)
@@ -283,7 +283,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void endDateMappedFromDeregistrationWhenDeregistered() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .deregistered(1L)
@@ -300,7 +300,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void endDateWillBeBullWhenNotDeregistered() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .deregistered(0L)
@@ -319,7 +319,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void deregisteringOfficerMappedFromStaff() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .deregistered(1L)
@@ -347,7 +347,7 @@ public class RegistrationTransformerTest {
 
     @Test
     public void deregisteringTeamMappedFromTeam() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .deregistered(1L)
@@ -374,7 +374,7 @@ public class RegistrationTransformerTest {
     }
     @Test
     public void deregisteringProbationAreaMappedFromTeamArea() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .deregistered(1L)
@@ -400,7 +400,7 @@ public class RegistrationTransformerTest {
     }
     @Test
     public void deregisteringNotesMappedFromDeregistration() {
-        assertThat(transformer.registrationOf(
+        assertThat(RegistrationTransformer.registrationOf(
                 aRegistration()
                         .toBuilder()
                         .deregistered(1L)

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/ReleaseTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/ReleaseTransformerTest.java
@@ -29,18 +29,12 @@ public class ReleaseTransformerTest {
     private static final Long SOME_RELEASE_ID = 123L;
     private final LocalDateTime SOME_DATE_TIME = LocalDateTime.now();
     private final LocalDate SOME_DATE = SOME_DATE_TIME.toLocalDate();
-    private final RInstitution SOME_R_INSTITUTION = RInstitution.builder().build();
-    private final Institution SOME_INSTITUTION = Institution.builder().build();
+    private final RInstitution SOME_R_INSTITUTION = RInstitution.builder().code("MDI").description("HMP Moorland").build();
     private final String SOME_NOTES = "These are notes";
     private final StandardReference SOME_REASON = StandardReference.builder().codeValue("CODE_VALUE").codeDescription("Code description").build();
     private final OffenderRecall SOME_OFFENDER_RECALL = OffenderRecall.builder().date(SOME_DATE).build();
     private final String SOME_RELEASE_TYPE_CODE = "The release type code";
     private final String SOME_RELEASE_TYPE = "The release type";
-
-    @Mock
-    private InstitutionTransformer mockInstitutionTransformer;
-    @Mock
-    private RecallTransformer mockRecallTransformer;
 
     @InjectMocks
     private ReleaseTransformer releaseTransformer;
@@ -49,7 +43,7 @@ public class ReleaseTransformerTest {
     public void offenderReleaseOf_valuesMappedCorrectly() {
         Release release = getDefaultRelease();
 
-        OffenderRelease offenderRelease = releaseTransformer.offenderReleaseOf(release);
+        OffenderRelease offenderRelease = ReleaseTransformer.offenderReleaseOf(release);
 
         assertThat(offenderRelease.getDate()).isEqualTo(SOME_DATE);
         assertThat(offenderRelease.getNotes()).isEqualTo(SOME_NOTES);
@@ -60,19 +54,19 @@ public class ReleaseTransformerTest {
     @Test
     public void offenderReleaseOf_institutionTakenFromTransformer() {
         Release release = getDefaultRelease();
-        given(mockInstitutionTransformer.institutionOf(SOME_R_INSTITUTION)).willReturn(SOME_INSTITUTION);
 
-        OffenderRelease offenderRelease = releaseTransformer.offenderReleaseOf(release);
+        OffenderRelease offenderRelease = ReleaseTransformer.offenderReleaseOf(release);
 
-        then(mockInstitutionTransformer).should().institutionOf(SOME_R_INSTITUTION);
-        assertThat(offenderRelease.getInstitution()).isEqualTo(SOME_INSTITUTION);
+        assertThat(offenderRelease.getInstitution().getCode()).isEqualTo("MDI");
+        assertThat(offenderRelease.getInstitution().getDescription()).isEqualTo("HMP Moorland");
     }
 
     @Test
     public void offenderLatestRecallOf_noRecalls_recallNull() {
         Release release = getDefaultRelease();
 
-        OffenderLatestRecall offenderLatestRecall = releaseTransformer.offenderLatestRecallOf(release);
+        OffenderLatestRecall offenderLatestRecall = ReleaseTransformer
+                .offenderLatestRecallOf(release);
 
         assertThat(offenderLatestRecall.getLastRecall()).isNull();
     }
@@ -80,11 +74,10 @@ public class ReleaseTransformerTest {
     @Test
     public void offenderLatestRecallOf_recallExists_recallIsReturned() {
         Release release = getDefaultReleaseBuilder().recalls(List.of(getDefaultRecall(SOME_DATE_TIME))).build();
-        given(mockRecallTransformer.offenderRecallOf(any(Recall.class))).willReturn(SOME_OFFENDER_RECALL);
 
-        OffenderLatestRecall offenderLatestRecall = releaseTransformer.offenderLatestRecallOf(release);
+        OffenderLatestRecall offenderLatestRecall = ReleaseTransformer
+                .offenderLatestRecallOf(release);
 
-        assertThat(offenderLatestRecall.getLastRecall()).isEqualTo(SOME_OFFENDER_RECALL);
         assertThat(offenderLatestRecall.getLastRecall().getDate()).isEqualTo(SOME_DATE);
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/StaffTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/StaffTransformerTest.java
@@ -14,7 +14,7 @@ public class StaffTransformerTest {
 
     @Test
     public void staffNameDetailsTakenFromStaff() {
-        assertThat(staffTransformer.staffDetailsOf(
+        assertThat(StaffTransformer.staffDetailsOf(
                                         aStaff()
                                             .toBuilder()
                                             .forename("John")
@@ -26,7 +26,7 @@ public class StaffTransformerTest {
 
     @Test
     public void staffCodeTakenFromStaff() {
-        assertThat(staffTransformer.staffDetailsOf(
+        assertThat(StaffTransformer.staffDetailsOf(
                                         aStaff()
                                             .toBuilder()
                                             .forename("John")
@@ -38,7 +38,7 @@ public class StaffTransformerTest {
 
     @Test
     public void teamsTakenFromStaff() {
-        assertThat(staffTransformer.staffDetailsOf(
+        assertThat(StaffTransformer.staffDetailsOf(
                                         aStaff()
                                         .toBuilder()
                                         .teams(ImmutableList.of(aTeam(), aTeam()))
@@ -48,7 +48,7 @@ public class StaffTransformerTest {
 
     @Test
     public void usernameCopiedWhenLinkedToUser() {
-        assertThat(staffTransformer.staffDetailsOf(
+        assertThat(StaffTransformer.staffDetailsOf(
                                         aStaff()
                                         .toBuilder()
                                         .user(User.builder().distinguishedName("username").build())
@@ -58,7 +58,7 @@ public class StaffTransformerTest {
 
     @Test
     public void usernameNotCopiedWhenNotLinkedToUser() {
-        assertThat(staffTransformer.staffDetailsOf(aStaff()
+        assertThat(StaffTransformer.staffDetailsOf(aStaff()
                                                     .toBuilder()
                                                     .user(null)
                                                     .build()).getUsername())

--- a/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
+++ b/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
@@ -108,6 +108,7 @@ public class EntityHelper {
                 .softDeleted(0L)
                 .activeFlag(1L)
                 .orderManagers(List.of(anOrderManager()))
+                .additionalOffences(List.of())
                 .build();
     }
 
@@ -355,7 +356,7 @@ public class EntityHelper {
                 .build();
     }
 
-    private static Nsi aNsi() {
+    public static Nsi aNsi() {
         return Nsi
                 .builder()
                 .nsiType(NsiType
@@ -367,6 +368,7 @@ public class EntityHelper {
                         .codeDescription("Healthy Sex Programme (HCP)")
                         .build())
                 .referralDate(LocalDate.now())
+                .nsiManagers(List.of(aNsiManager()))
                 .build();
     }
 
@@ -714,4 +716,38 @@ public class EntityHelper {
                 .build();
     }
 
+    public static Release aRelease() {
+        return Release
+                .builder()
+                .actualReleaseDate(LocalDateTime.now())
+                .institution(EntityHelper.aPrisonInstitution())
+                .releaseId(99L)
+                .releaseType(StandardReference.builder().build())
+                .notes("Released for geed behaviour")
+                .softDeleted(0L)
+                .build();
+    }
+
+    public static Recall aRecall() {
+        return Recall
+                .builder()
+                .notes("Naughty")
+                .reason(StandardReference.builder().build())
+                .recallDate(LocalDateTime.now())
+                .releaseId(99L)
+                .softDeleted(0L)
+                .build();
+    }
+
+    public static NsiManager aNsiManager() {
+        return NsiManager
+                .builder()
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusMonths(12))
+                .probationArea(aProbationArea())
+                .staff(aStaff())
+                .team(aTeam())
+                .nsiManagerId(99L)
+                .build();
+    }
 }


### PR DESCRIPTION
The eventual aim is to convert Transformers from spring components to utility classes with pure functions. This is so that 

1. We have a tree of transformer objects which makes testing  hard
2. Forcing some services to be slow SpringBoot tests with MockBeans when they could be pure unit tests

This PR just converts methods that can be static.
This required fixing handful of tests that relied on them being mocked.
To limit the changes in the PR this leaves a lot of warnings when the Spring components could be removed completed.

Further work
1. Remove components when no longer required
2. Split Transformers that required the reference data supplier to "update" versions of transformers

