### PR TITLE
DT-835 junit 5 + tightly control flyway clean

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/AttendanceResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/AttendanceResource.java
@@ -1,13 +1,10 @@
 package uk.gov.justice.digital.delius.controller.secure;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
-import java.time.LocalDate;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -24,6 +21,10 @@ import uk.gov.justice.digital.delius.data.api.Attendance;
 import uk.gov.justice.digital.delius.data.api.Attendances;
 import uk.gov.justice.digital.delius.service.AttendanceService;
 import uk.gov.justice.digital.delius.service.OffenderService;
+
+import java.time.LocalDate;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Api(tags = "Attendance resources (Secure)", authorizations = {@Authorization("ROLE_COMMUNITY")})
 @RestController

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/api/DeliusOffenderAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/api/DeliusOffenderAPITest.java
@@ -2,22 +2,23 @@ package uk.gov.justice.digital.delius.controller.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import org.assertj.core.util.Lists;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.justice.digital.delius.controller.wiremock.DeliusExtension;
+import uk.gov.justice.digital.delius.controller.wiremock.DeliusMockServer;
 import uk.gov.justice.digital.delius.data.api.AccessLimitation;
 import uk.gov.justice.digital.delius.data.api.Address;
 import uk.gov.justice.digital.delius.data.api.Count;
@@ -47,7 +48,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static java.util.Arrays.asList;
@@ -57,10 +57,13 @@ import static org.mockito.ArgumentMatchers.eq;
 import static uk.gov.justice.digital.delius.OffenderHelper.anOffender;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {"offender.ids.pagesize=5"})
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 public class DeliusOffenderAPITest {
-    @Rule
-    public WireMockRule wireMock = new WireMockRule(wireMockConfig().port(8088).usingFilesUnderDirectory("src/testIntegration/resources").jettyStopTimeout(10000L));
+
+    private static DeliusMockServer deliusMockServer = new DeliusMockServer(8088, "src/testIntegration/resources");
+
+    @RegisterExtension
+    static DeliusExtension deliusExtension = new DeliusExtension(deliusMockServer);
 
     @LocalServerPort
     int port;
@@ -77,7 +80,7 @@ public class DeliusOffenderAPITest {
     @Autowired
     private Jwt jwt;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/api";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/api/LogonAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/api/LogonAPITest.java
@@ -4,14 +4,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.jpa.national.entity.User;
 import uk.gov.justice.digital.delius.jwt.Jwt;
 import uk.gov.justice.digital.delius.service.wrapper.UserRepositoryWrapper;
@@ -22,7 +20,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@RunWith(SpringJUnit4ClassRunner.class)
 public class LogonAPITest {
 
     @LocalServerPort
@@ -37,7 +34,7 @@ public class LogonAPITest {
     @MockBean
     private UserRepositoryWrapper userRepositoryWrapper;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/api";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/api/ManagedOffenderAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/api/ManagedOffenderAPITest.java
@@ -5,15 +5,13 @@ import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.parsing.Parser;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.data.api.ManagedOffender;
 import uk.gov.justice.digital.delius.jwt.Jwt;
 import uk.gov.justice.digital.delius.user.UserData;
@@ -27,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev-seed")
-@RunWith(SpringJUnit4ClassRunner.class)
 public class ManagedOffenderAPITest {
 
     @LocalServerPort
@@ -43,7 +40,7 @@ public class ManagedOffenderAPITest {
     private Jwt jwt;
 
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/api";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/api/OffenderDeltaAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/api/OffenderDeltaAPITest.java
@@ -4,17 +4,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.jpa.dao.OffenderDelta;
 import uk.gov.justice.digital.delius.jwt.Jwt;
 import uk.gov.justice.digital.delius.service.OffenderDeltaService;
@@ -33,9 +30,7 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {"offender.ids.pagesize=5"})
-@ActiveProfiles("dev-schema")
-@RunWith(SpringJUnit4ClassRunner.class)
-@DirtiesContext
+@ActiveProfiles("dev-seed")
 public class OffenderDeltaAPITest {
 
     @LocalServerPort
@@ -50,7 +45,7 @@ public class OffenderDeltaAPITest {
     @Autowired
     private Jwt jwt;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/api";
@@ -59,7 +54,7 @@ public class OffenderDeltaAPITest {
         ));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         jdbcTemplate.execute("DELETE FROM OFFENDER_DELTA");
     }

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/api/ResponsibleOfficerAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/api/ResponsibleOfficerAPITest.java
@@ -5,15 +5,13 @@ import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.parsing.Parser;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.data.api.ResponsibleOfficer;
 import uk.gov.justice.digital.delius.jwt.Jwt;
 import uk.gov.justice.digital.delius.user.UserData;
@@ -27,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev-seed")
-@RunWith(SpringJUnit4ClassRunner.class)
 public class ResponsibleOfficerAPITest {
 
     @LocalServerPort
@@ -42,7 +39,7 @@ public class ResponsibleOfficerAPITest {
     @Autowired
     private Jwt jwt;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/api";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AttendanceResourceAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AttendanceResourceAPITest.java
@@ -4,16 +4,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.data.api.Attendances;
 
 import static io.restassured.RestAssured.given;
@@ -23,7 +21,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev-seed")
-@RunWith(SpringJUnit4ClassRunner.class)
 public class AttendanceResourceAPITest {
 
     private static final Long KNOWN_EVENT_ID = 2500295343L;
@@ -40,7 +37,7 @@ public class AttendanceResourceAPITest {
     @Value("${test.token.good}")
     private String validOauthToken;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/secure";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AuthenticationAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AuthenticationAPITest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import uk.gov.justice.digital.delius.controller.advice.ErrorResponse;
 import uk.gov.justice.digital.delius.data.api.AuthPassword;
@@ -219,6 +220,7 @@ public class AuthenticationAPITest {
     }
 
     @Test
+    @DirtiesContext
     public void addRole() {
 
         given()

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AuthenticationAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AuthenticationAPITest.java
@@ -4,16 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.controller.advice.ErrorResponse;
 import uk.gov.justice.digital.delius.data.api.AuthPassword;
 import uk.gov.justice.digital.delius.data.api.AuthUser;
@@ -26,7 +23,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev-seed")
-@RunWith(SpringJUnit4ClassRunner.class)
 public class AuthenticationAPITest {
 
     @LocalServerPort
@@ -38,7 +34,7 @@ public class AuthenticationAPITest {
     @Value("${test.token.auth}")
     private String validOauthToken;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/secure";
@@ -223,7 +219,6 @@ public class AuthenticationAPITest {
     }
 
     @Test
-    @DirtiesContext
     public void addRole() {
 
         given()

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CaseNoteAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CaseNoteAPITest.java
@@ -2,16 +2,17 @@ package uk.gov.justice.digital.delius.controller.secure;
 
 import io.restassured.RestAssured;
 import org.apache.http.entity.ContentType;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.justice.digital.delius.JwtAuthenticationHelper;
+import uk.gov.justice.digital.delius.controller.wiremock.DeliusExtension;
 import uk.gov.justice.digital.delius.controller.wiremock.DeliusMockServer;
 
 import java.time.Duration;
@@ -23,8 +24,13 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 public class CaseNoteAPITest {
+
+    private static final DeliusMockServer deliusMockServer = new DeliusMockServer(8999);
+
+    @RegisterExtension
+    static DeliusExtension deliusExtension = new DeliusExtension(deliusMockServer);
 
     @LocalServerPort
     int port;
@@ -32,12 +38,8 @@ public class CaseNoteAPITest {
     @Autowired
     protected JwtAuthenticationHelper jwtAuthenticationHelper;
 
-    @ClassRule
-    public static final DeliusMockServer deliusMockServer = new DeliusMockServer();
-
-    @Before
+    @BeforeEach
     public void setup() {
-        deliusMockServer.resetAll();
         RestAssured.port = port;
         RestAssured.basePath = "/secure";
     }

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyKeyDatesAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyKeyDatesAPITest.java
@@ -18,7 +18,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.jdbc.core.ColumnMapRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.justice.digital.delius.JwtAuthenticationHelper;
@@ -39,7 +38,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ExtendWith(SpringExtension.class)
 @ActiveProfiles("dev-seed")
-@DirtiesContext
 public class CustodyKeyDatesAPITest {
     private static final String OFFENDER_ID = "2500343964";
     private static final String CRN = "X320741";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyUpdateBookingNumberAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyUpdateBookingNumberAPITest.java
@@ -7,17 +7,16 @@ import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import org.flywaydb.core.Flyway;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.jdbc.core.ColumnMapRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.justice.digital.delius.JwtAuthenticationHelper;
@@ -43,7 +42,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ExtendWith(SpringExtension.class)
 @ActiveProfiles("dev-seed")
-@DirtiesContext
 public class CustodyUpdateBookingNumberAPITest {
     private static final String NOMS_NUMBER = "G9542VP";
     private static final String OFFENDER_ID = "2500343964";
@@ -56,6 +54,7 @@ public class CustodyUpdateBookingNumberAPITest {
 
     @Autowired
     private Flyway flyway;
+    private static Flyway flywayInstance;
 
     @Autowired
     JdbcTemplate jdbcTemplate;
@@ -63,7 +62,7 @@ public class CustodyUpdateBookingNumberAPITest {
     @Autowired
     protected JwtAuthenticationHelper jwtAuthenticationHelper;
 
-    @MockBean
+    @SpyBean
     private TelemetryClient telemetryClient;
 
     @BeforeEach
@@ -74,12 +73,13 @@ public class CustodyUpdateBookingNumberAPITest {
                 new ObjectMapperConfig().jackson2ObjectMapperFactory((aClass, s) -> objectMapper));
         //noinspection SqlWithoutWhere
         jdbcTemplate.execute("DELETE FROM CONTACT");
+        flywayInstance = flyway;
     }
 
-    @AfterEach
-    public void after() {
-        flyway.clean();
-        flyway.migrate();
+    @AfterAll
+    public static void cleanDatabase() {
+        flywayInstance.clean();
+        flywayInstance.migrate();
     }
 
     @Test

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyUpdateNomsNumberAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyUpdateNomsNumberAPITest.java
@@ -2,22 +2,19 @@ package uk.gov.justice.digital.delius.controller.secure;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.microsoft.applicationinsights.TelemetryClient;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import org.flywaydb.core.Flyway;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.jdbc.core.ColumnMapRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.justice.digital.delius.JwtAuthenticationHelper;
@@ -34,7 +31,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ExtendWith(SpringExtension.class)
 @ActiveProfiles("dev-seed")
-@DirtiesContext
 public class CustodyUpdateNomsNumberAPITest {
 
     @Autowired
@@ -45,10 +41,9 @@ public class CustodyUpdateNomsNumberAPITest {
     private ObjectMapper objectMapper;
     @Autowired
     private Flyway flyway;
+    private static Flyway flywayInstance;
     @Autowired
     private JdbcTemplate jdbcTemplate;
-    @MockBean
-    private TelemetryClient telemetryClient;
 
     @BeforeEach
     public void setup() {
@@ -56,12 +51,13 @@ public class CustodyUpdateNomsNumberAPITest {
         RestAssured.basePath = "/secure";
         RestAssured.config = RestAssuredConfig.config().objectMapperConfig(
                 new ObjectMapperConfig().jackson2ObjectMapperFactory((aClass, s) -> objectMapper));
+        flywayInstance = flyway;
     }
 
-    @AfterEach
-    public void after() {
-        flyway.clean();
-        flyway.migrate();
+    @AfterAll
+    public static void cleanDatabase() {
+        flywayInstance.clean();
+        flywayInstance.migrate();
     }
 
     @Test

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_AllocatePrisonOffenderManagerIT.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_AllocatePrisonOffenderManagerIT.java
@@ -6,17 +6,14 @@ import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import org.flywaydb.core.Flyway;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.data.api.CommunityOrPrisonOffenderManager;
 import uk.gov.justice.digital.delius.data.api.Contact;
 import uk.gov.justice.digital.delius.data.api.CreatePrisonOffenderManager;
@@ -37,8 +34,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev-seed")
-@DirtiesContext
-@RunWith(SpringJUnit4ClassRunner.class)
 public class OffendersResource_AllocatePrisonOffenderManagerIT {
 
     @LocalServerPort
@@ -49,6 +44,7 @@ public class OffendersResource_AllocatePrisonOffenderManagerIT {
 
     @Autowired
     private Flyway flyway;
+    private static Flyway flywayInstance;
 
     @Autowired
     private Jwt jwt;
@@ -57,18 +53,19 @@ public class OffendersResource_AllocatePrisonOffenderManagerIT {
     @Value("${test.token.good}")
     private String validOauthToken;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/secure";
         RestAssured.config = RestAssuredConfig.config().objectMapperConfig(
                 new ObjectMapperConfig().jackson2ObjectMapperFactory((aClass, s) -> objectMapper));
+        flywayInstance = flyway;
     }
 
-    @After
-    public void after() {
-        flyway.clean();
-        flyway.migrate();
+    @AfterAll
+    public static void cleanDatabase() {
+        flywayInstance.clean();
+        flywayInstance.migrate();
     }
 
     @Test
@@ -261,7 +258,7 @@ public class OffendersResource_AllocatePrisonOffenderManagerIT {
                 .contentType("application/json")
                 .body(createPrisonOffenderManagerOf("BWIA010", "BWI"))
                 .when()
-                .put("/offenders/nomsNumber/G0560UO/prisonOffenderManager")
+                .put("/offenders/nomsNumber/G4106UN/prisonOffenderManager")
                 .then()
                 .statusCode(200)
                 .extract()
@@ -275,7 +272,7 @@ public class OffendersResource_AllocatePrisonOffenderManagerIT {
                 .header("Authorization", aValidToken())
                 .queryParam("from", justBeforeAllocation.toString())
                 .basePath("/api")
-                .get("/offenders/nomsNumber/G0560UO/contacts")
+                .get("/offenders/nomsNumber/G4106UN/contacts")
                 .then()
                 .statusCode(200)
                 .extract()

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_AllocatePrisonOffenderManagerTest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_AllocatePrisonOffenderManagerTest.java
@@ -34,7 +34,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev-seed")
-public class OffendersResource_AllocatePrisonOffenderManagerIT {
+public class OffendersResource_AllocatePrisonOffenderManagerTest {
 
     @LocalServerPort
     int port;

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_GetAllOffenderManagersAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_GetAllOffenderManagersAPITest.java
@@ -4,15 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.data.api.CommunityOrPrisonOffenderManager;
 
 import java.util.stream.Stream;
@@ -24,7 +22,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev-seed")
-@RunWith(SpringJUnit4ClassRunner.class)
 public class OffendersResource_GetAllOffenderManagersAPITest {
 
     @LocalServerPort
@@ -36,7 +33,7 @@ public class OffendersResource_GetAllOffenderManagersAPITest {
     @Value("${test.token.good}")
     private String validOauthToken;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/secure";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_GetLatestRecallAndReleaseForOffenderIT.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_GetLatestRecallAndReleaseForOffenderIT.java
@@ -27,7 +27,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @RunWith(SpringJUnit4ClassRunner.class)
-@ActiveProfiles("dev,dev-seed")
+@ActiveProfiles("dev-seed")
 public class OffendersResource_GetLatestRecallAndReleaseForOffenderIT {
 
     @LocalServerPort

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_GetLatestRecallAndReleaseForOffenderTest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_GetLatestRecallAndReleaseForOffenderTest.java
@@ -4,9 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,9 +25,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@RunWith(SpringJUnit4ClassRunner.class)
 @ActiveProfiles("dev-seed")
-public class OffendersResource_GetLatestRecallAndReleaseForOffenderIT {
+public class OffendersResource_GetLatestRecallAndReleaseForOffenderTest {
 
     @LocalServerPort
     int port;
@@ -39,7 +37,7 @@ public class OffendersResource_GetLatestRecallAndReleaseForOffenderIT {
     @Value("${test.token.good}")
     private String validOauthToken;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/secure";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_GetLatestRecallAndReleaseForOffenderTest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_GetLatestRecallAndReleaseForOffenderTest.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.data.api.Institution;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.data.api.OffenderLatestRecall;

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderByCrn.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderByCrn.java
@@ -4,9 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,7 +22,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev-seed")
-@RunWith(SpringJUnit4ClassRunner.class)
 public class OffendersResource_getOffenderByCrn {
 
     @LocalServerPort
@@ -35,7 +33,7 @@ public class OffendersResource_getOffenderByCrn {
     @Value("${test.token.good}")
     private String validOauthToken;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/secure";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderByCrn.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderByCrn.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.data.api.OffenderDetail;
 import uk.gov.justice.digital.delius.data.api.OffenderDetailSummary;
 import uk.gov.justice.digital.delius.data.api.OffenderManager;

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderByNomsNumber.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderByNomsNumber.java
@@ -4,9 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -22,7 +21,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev-seed")
-@RunWith(SpringJUnit4ClassRunner.class)
 public class OffendersResource_getOffenderByNomsNumber {
 
     @LocalServerPort
@@ -34,7 +32,7 @@ public class OffendersResource_getOffenderByNomsNumber {
     @Value("${test.token.good}")
     private String validOauthToken;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/secure";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderByNomsNumber.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderByNomsNumber.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.data.api.OffenderDetail;
 import uk.gov.justice.digital.delius.data.api.OffenderManager;
 

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderConvictionsByCrn.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderConvictionsByCrn.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.data.api.Conviction;
 import uk.gov.justice.digital.delius.data.api.Offence;
 

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderConvictionsByCrn.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderConvictionsByCrn.java
@@ -4,9 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,7 +24,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev-seed")
-@RunWith(SpringJUnit4ClassRunner.class)
 public class OffendersResource_getOffenderConvictionsByCrn {
 
     @LocalServerPort
@@ -37,7 +35,7 @@ public class OffendersResource_getOffenderConvictionsByCrn {
     @Value("${test.token.good}")
     private String validOauthToken;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/secure";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderDocumentsByCrn.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderDocumentsByCrn.java
@@ -1,38 +1,37 @@
 package uk.gov.justice.digital.delius.controller.secure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import uk.gov.justice.digital.delius.controller.wiremock.DeliusExtension;
+import uk.gov.justice.digital.delius.controller.wiremock.DeliusMockServer;
 import uk.gov.justice.digital.delius.data.api.ConvictionDocuments;
 import uk.gov.justice.digital.delius.data.api.OffenderDocumentDetail;
 import uk.gov.justice.digital.delius.data.api.OffenderDocuments;
 
 import java.time.LocalDate;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev-seed")
-@RunWith(SpringJUnit4ClassRunner.class)
 public class OffendersResource_getOffenderDocumentsByCrn {
-    @Rule
-    public WireMockRule wireMock = new WireMockRule(wireMockConfig().port(8088).usingFilesUnderDirectory("src/testIntegration/resources").jettyStopTimeout(10000L));
+
+    private static final DeliusMockServer deliusMockServer = new DeliusMockServer(8088, "src/testIntegration/resources");
+    @RegisterExtension
+    static DeliusExtension deliusExtension = new DeliusExtension(deliusMockServer);
 
     private static final String GROUPED_DOCS_PATH_FORMAT = "/offenders/crn/%s/documents/grouped";
     private static final String SINGLE_DOC_PATH_FORMAT = "/offenders/crn/%s/documents/%s";
@@ -47,7 +46,7 @@ public class OffendersResource_getOffenderDocumentsByCrn {
     @Value("${test.token.good}")
     private String validOauthToken;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/secure";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderNsisByCrn.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderNsisByCrn.java
@@ -4,9 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,7 +22,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev-seed")
-@RunWith(SpringJUnit4ClassRunner.class)
 public class OffendersResource_getOffenderNsisByCrn {
 
     private static final String OFFENDERS_PATH = "/offenders/crn/%s/convictions/%s/nsis?";
@@ -50,7 +48,7 @@ public class OffendersResource_getOffenderNsisByCrn {
     @Value("${test.token.good}")
     private String validOauthToken;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/secure";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderNsisByCrn.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderNsisByCrn.java
@@ -12,7 +12,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.data.api.Nsi;
 import uk.gov.justice.digital.delius.data.api.NsiWrapper;
 

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/PersonalCircumstancesAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/PersonalCircumstancesAPITest.java
@@ -24,7 +24,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev-seed")
-@DirtiesContext
 public class PersonalCircumstancesAPITest {
     private static final String NOMS_NUMBER = "G9542VP";
     private static final String OFFENDER_ID = "2500343964";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/RegistrationsAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/RegistrationsAPITest.java
@@ -24,7 +24,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dev-seed")
-@DirtiesContext
 public class RegistrationsAPITest {
     private static final String NOMS_NUMBER = "G9542VP";
     private static final String OFFENDER_ID = "2500343964";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/StaffResource_StaffDetailsAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/StaffResource_StaffDetailsAPITest.java
@@ -6,9 +6,8 @@ import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import lombok.val;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@RunWith(SpringJUnit4ClassRunner.class)
 @ActiveProfiles("dev-seed")
 public class StaffResource_StaffDetailsAPITest {
 
@@ -38,7 +36,7 @@ public class StaffResource_StaffDetailsAPITest {
     @Value("${test.token.good}")
     private String validOauthToken;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/secure";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/StaffResource_StaffDetailsAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/StaffResource_StaffDetailsAPITest.java
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.data.api.StaffDetails;
 
 import java.util.Arrays;

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/UserAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/UserAPITest.java
@@ -7,9 +7,8 @@ import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import lombok.val;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@RunWith(SpringJUnit4ClassRunner.class)
 @ActiveProfiles("dev-seed")
 public class UserAPITest {
 
@@ -38,7 +36,7 @@ public class UserAPITest {
     @Value("${test.token.auth}")
     private String validOauthToken;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/secure";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/UserAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/UserAPITest.java
@@ -14,7 +14,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.data.api.UserDetailsWrapper;
 
 import java.util.Set;

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/wiremock/DeliusExtension.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/wiremock/DeliusExtension.java
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.delius.controller.wiremock;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class DeliusExtension implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
+
+    private DeliusMockServer deliusMockServer;
+
+    public DeliusExtension(DeliusMockServer deliusMockServer) {
+        this.deliusMockServer = deliusMockServer;
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) {
+        deliusMockServer.start();
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        deliusMockServer.stop();
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) {
+        deliusMockServer.resetRequests();
+    }
+
+}

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/wiremock/DeliusMockServer.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/wiremock/DeliusMockServer.java
@@ -1,19 +1,21 @@
 package uk.gov.justice.digital.delius.controller.wiremock;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 
-public class DeliusMockServer extends WireMockRule {
+public class DeliusMockServer extends WireMockServer {
 
-    private static final int WIREMOCK_PORT = 8999;
-
-    public DeliusMockServer() {
-        super(WIREMOCK_PORT);
+    public DeliusMockServer(final int port) {
+        super(WireMockConfiguration.wireMockConfig().port(port));
     }
 
+    public DeliusMockServer(final int port, final String fileDirectory) {
+        super(WireMockConfiguration.wireMockConfig().port(port).usingFilesUnderDirectory(fileDirectory).jettyStopTimeout(10000L));
+    }
     public void stubPutCaseNoteToDeliusCreated(final String nomisId, final Long caseNotesId) {
         final String putCaseNote = "/nomisCaseNotes/" + nomisId + "/" + caseNotesId;
         stubFor(put(urlPathMatching(putCaseNote)).willReturn(aResponse()

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/info/PingEndpointTest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/info/PingEndpointTest.java
@@ -1,25 +1,22 @@
 package uk.gov.justice.digital.delius.info;
 
 import io.restassured.RestAssured;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@RunWith(SpringJUnit4ClassRunner.class)
 public class PingEndpointTest {
 
     @LocalServerPort
     int port;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RestAssured.port = port;
         RestAssured.basePath = "/";

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/jpa/standard/repository/OffenderRepositoryTest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/jpa/standard/repository/OffenderRepositoryTest.java
@@ -1,21 +1,18 @@
 package uk.gov.justice.digital.delius.jpa.standard.repository;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Offender;
 
 import java.util.Optional;
 
-@Ignore
+@Disabled
 @ActiveProfiles("oracle")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@RunWith(SpringJUnit4ClassRunner.class)
 public class OffenderRepositoryTest {
 
     @LocalServerPort

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/jpa/standard/repository/StaffRepositoryTest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/jpa/standard/repository/StaffRepositoryTest.java
@@ -1,12 +1,10 @@
 package uk.gov.justice.digital.delius.jpa.standard.repository;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Staff;
 
 import javax.transaction.Transactional;
@@ -15,7 +13,6 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@RunWith(SpringJUnit4ClassRunner.class)
 @ActiveProfiles("dev-seed")
 @Transactional
 public class StaffRepositoryTest {

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/ldap/repository/LdapRepositoryTest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/ldap/repository/LdapRepositoryTest.java
@@ -1,12 +1,10 @@
 package uk.gov.justice.digital.delius.ldap.repository;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.ldap.NameNotFoundException;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.justice.digital.delius.ldap.repository.entity.NDeliusRole;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,7 +13,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 import static org.springframework.test.annotation.DirtiesContext.MethodMode.AFTER_METHOD;
 
 @SpringBootTest(webEnvironment = NONE)
-@RunWith(SpringRunner.class)
 public class LdapRepositoryTest {
     @Autowired
     private LdapRepository ldapRepository;


### PR DESCRIPTION
We now only do a flyway clean/migrate where absolutely necessary and after each test class rather than after each test.  Also converted everything that's left to junit 5.