### PR TITLE
DT-864 Convert transformers that are stateless as not Spring beans

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
@@ -16,12 +16,10 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 public class AppointmentService {
 
     private final ContactRepository contactRepository;
-    private final AppointmentTransformer appointmentTransformer;
 
     @Autowired
-    public AppointmentService(ContactRepository contactRepository, AppointmentTransformer appointmentTransformer) {
+    public AppointmentService(ContactRepository contactRepository) {
         this.contactRepository = contactRepository;
-        this.appointmentTransformer = appointmentTransformer;
     }
 
     public List<Appointment> appointmentsFor(Long offenderId, AppointmentFilter filter) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/ContactService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ContactService.java
@@ -29,13 +29,11 @@ public class ContactService {
     private static final String CUSTODY_AUTO_UPDATE_CONTACT_TYPE = "EDSS";
     private final ContactRepository contactRepository;
     private final ContactTypeRepository contactTypeRepository;
-    private final ContactTransformer contactTransformer;
 
     @Autowired
-    public ContactService(ContactRepository contactRepository, ContactTypeRepository contactTypeRepository, ContactTransformer contactTransformer) {
+    public ContactService(ContactRepository contactRepository, ContactTypeRepository contactTypeRepository) {
         this.contactRepository = contactRepository;
         this.contactTypeRepository = contactTypeRepository;
-        this.contactTransformer = contactTransformer;
     }
 
     public List<Contact> contactsFor(Long offenderId, ContactFilter filter) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/ConvictionService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ConvictionService.java
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.delius.jpa.standard.repository.EventRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
 import uk.gov.justice.digital.delius.transformers.ConvictionTransformer;
 import uk.gov.justice.digital.delius.transformers.CustodyKeyDateTransformer;
+import uk.gov.justice.digital.delius.transformers.EventTransformer;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -37,7 +38,7 @@ public class ConvictionService {
     private final Boolean updateCustodyKeyDatesFeatureSwitch;
     private final EventRepository eventRepository;
     private final OffenderRepository offenderRepository;
-    private final ConvictionTransformer convictionTransformer;
+    private final EventTransformer eventTransformer;
     private final CustodyKeyDateTransformer custodyKeyDateTransformer;
     private final IAPSNotificationService iapsNotificationService;
     private final SpgNotificationService spgNotificationService;
@@ -85,7 +86,8 @@ public class ConvictionService {
             @Value("${features.noms.update.keydates}")
                     Boolean updateCustodyKeyDatesFeatureSwitch,
             EventRepository eventRepository,
-            OffenderRepository offenderRepository, ConvictionTransformer convictionTransformer,
+            OffenderRepository offenderRepository,
+            EventTransformer eventTransformer,
             SpgNotificationService spgNotificationService,
             LookupSupplier lookupSupplier,
             CustodyKeyDateTransformer custodyKeyDateTransformer,
@@ -94,7 +96,7 @@ public class ConvictionService {
         this.updateCustodyKeyDatesFeatureSwitch = updateCustodyKeyDatesFeatureSwitch;
         this.eventRepository = eventRepository;
         this.offenderRepository = offenderRepository;
-        this.convictionTransformer = convictionTransformer;
+        this.eventTransformer = eventTransformer;
         this.spgNotificationService = spgNotificationService;
         this.lookupSupplier = lookupSupplier;
         this.custodyKeyDateTransformer = custodyKeyDateTransformer;
@@ -125,7 +127,7 @@ public class ConvictionService {
 
     @Transactional
     public Conviction addCourtCaseFor(Long offenderId, CourtCase courtCase) {
-        val event = convictionTransformer.eventOf(
+        val event = eventTransformer.eventOf(
                 offenderId,
                 courtCase,
                 calculateNextEventNumber(offenderId));

--- a/src/main/java/uk/gov/justice/digital/delius/service/CourtAppearanceService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/CourtAppearanceService.java
@@ -20,14 +20,11 @@ import static uk.gov.justice.digital.delius.transformers.TypesTransformer.conver
 public class CourtAppearanceService {
 
     private final CourtAppearanceRepository courtAppearanceRepository;
-    private final CourtAppearanceTransformer courtAppearanceTransformer;
 
     @Autowired
-    public CourtAppearanceService(CourtAppearanceRepository courtAppearanceRepository,
-                                  CourtAppearanceTransformer courtAppearanceTransformer) {
+    public CourtAppearanceService(CourtAppearanceRepository courtAppearanceRepository) {
 
         this.courtAppearanceRepository = courtAppearanceRepository;
-        this.courtAppearanceTransformer = courtAppearanceTransformer;
     }
 
     public List<CourtAppearance> courtAppearancesFor(Long offenderId) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/CourtReportService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/CourtReportService.java
@@ -17,14 +17,11 @@ import static uk.gov.justice.digital.delius.transformers.TypesTransformer.conver
 public class CourtReportService {
 
     private final CourtReportRepository courtReportRepository;
-    private final CourtReportTransformer courtReportTransformer;
 
     @Autowired
-    public CourtReportService(CourtReportRepository courtReportRepository,
-                              CourtReportTransformer courtAppearanceTransformer) {
+    public CourtReportService(CourtReportRepository courtReportRepository) {
 
         this.courtReportRepository = courtReportRepository;
-        this.courtReportTransformer = courtAppearanceTransformer;
     }
 
     public List<CourtReport> courtReportsFor(Long offenderId) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/CustodyService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/CustodyService.java
@@ -34,7 +34,6 @@ public class CustodyService {
     private final OffenderRepository offenderRepository;
     private final ConvictionService convictionService;
     private final InstitutionRepository institutionRepository;
-    private final ConvictionTransformer convictionTransformer;
     private final CustodyHistoryRepository custodyHistoryRepository;
     private final ReferenceDataService referenceDataService;
     private final SpgNotificationService spgNotificationService;
@@ -51,7 +50,6 @@ public class CustodyService {
             OffenderRepository offenderRepository,
             ConvictionService convictionService,
             InstitutionRepository institutionRepository,
-            ConvictionTransformer convictionTransformer,
             CustodyHistoryRepository custodyHistoryRepository,
             ReferenceDataService referenceDataService,
             SpgNotificationService spgNotificationService,
@@ -63,7 +61,6 @@ public class CustodyService {
         this.offenderRepository = offenderRepository;
         this.convictionService = convictionService;
         this.institutionRepository = institutionRepository;
-        this.convictionTransformer = convictionTransformer;
         this.custodyHistoryRepository = custodyHistoryRepository;
         this.referenceDataService = referenceDataService;
         this.spgNotificationService = spgNotificationService;

--- a/src/main/java/uk/gov/justice/digital/delius/service/DocumentService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/DocumentService.java
@@ -45,7 +45,6 @@ public class DocumentService {
     private final PersonalCircumstanceDocumentRepository personalCircumstanceDocumentRepository;
     private final UPWAppointmentDocumentRepository upwAppointmentDocumentRepository;
     private final ContactDocumentRepository contactDocumentRepository;
-    private final DocumentTransformer documentTransformer;
 
 
     @NationalUserOverride

--- a/src/main/java/uk/gov/justice/digital/delius/service/InstitutionalReportService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/InstitutionalReportService.java
@@ -16,14 +16,11 @@ import static uk.gov.justice.digital.delius.transformers.TypesTransformer.conver
 public class InstitutionalReportService {
 
     private final InstitutionalReportRepository institutionalReportRepository;
-    private final InstitutionalReportTransformer institutionalReportTransformer;
 
     @Autowired
-    public InstitutionalReportService(InstitutionalReportRepository institutionalReportRepository,
-                                      InstitutionalReportTransformer institutionalAppearanceTransformer) {
+    public InstitutionalReportService(InstitutionalReportRepository institutionalReportRepository) {
 
         this.institutionalReportRepository = institutionalReportRepository;
-        this.institutionalReportTransformer = institutionalAppearanceTransformer;
     }
 
     public List<InstitutionalReport> institutionalReportsFor(Long offenderId) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/NsiService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/NsiService.java
@@ -20,13 +20,11 @@ import static uk.gov.justice.digital.delius.transformers.TypesTransformer.conver
 public class NsiService {
     private final NsiRepository nsiRepository;
 
-    private final NsiTransformer nsiTransformer;
     private final ConvictionService convictionService;
 
     @Autowired
-    public NsiService(final NsiRepository nsiRepository, final NsiTransformer nsiTransformer, final ConvictionService convictionService) {
+    public NsiService(final NsiRepository nsiRepository, final ConvictionService convictionService) {
         this.nsiRepository = nsiRepository;
-        this.nsiTransformer = nsiTransformer;
         this.convictionService = convictionService;
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/service/OffenceService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/OffenceService.java
@@ -6,8 +6,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.justice.digital.delius.data.api.Offence;
 import uk.gov.justice.digital.delius.jpa.standard.entity.MainOffence;
 import uk.gov.justice.digital.delius.jpa.standard.repository.MainOffenceRepository;
-import uk.gov.justice.digital.delius.transformers.AdditionalOffenceTransformer;
-import uk.gov.justice.digital.delius.transformers.MainOffenceTransformer;
+import uk.gov.justice.digital.delius.transformers.OffenceTransformer;
 
 import java.util.List;
 
@@ -18,15 +17,10 @@ import static uk.gov.justice.digital.delius.transformers.TypesTransformer.conver
 public class OffenceService {
 
     private final MainOffenceRepository mainOffenceRepository;
-    private final MainOffenceTransformer mainOffenceTransformer;
-    private final AdditionalOffenceTransformer additionalOffenceTransformer;
 
     @Autowired
-    public OffenceService(MainOffenceRepository mainOffenceRepository,
-                          MainOffenceTransformer mainOffenceTransformer, AdditionalOffenceTransformer additionalOffenceTransformer) {
+    public OffenceService(MainOffenceRepository mainOffenceRepository) {
         this.mainOffenceRepository = mainOffenceRepository;
-        this.mainOffenceTransformer = mainOffenceTransformer;
-        this.additionalOffenceTransformer = additionalOffenceTransformer;
     }
 
     public List<Offence> offencesFor(Long offenderId) {
@@ -41,9 +35,9 @@ public class OffenceService {
 
     private ImmutableList<Offence> combineMainAndAdditionalOffences(MainOffence mainOffence) {
         List<Offence> additionalOffences =
-            AdditionalOffenceTransformer.offencesOf(mainOffence.getEvent().getAdditionalOffences());
+            OffenceTransformer.offencesOf(mainOffence.getEvent().getAdditionalOffences());
         return ImmutableList.<Offence>builder()
-            .add(MainOffenceTransformer.offenceOf(mainOffence))
+            .add(OffenceTransformer.offenceOf(mainOffence))
             .addAll(additionalOffences)
             .build();
     }

--- a/src/main/java/uk/gov/justice/digital/delius/service/OffenderIdentifierService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/OffenderIdentifierService.java
@@ -18,19 +18,16 @@ import java.util.Optional;
 @Slf4j
 public class OffenderIdentifierService {
     private final boolean updateNomsNumberFeatureSwitch;
-    private final OffenderTransformer offenderTransformer;
     private final OffenderRepository offenderRepository;
     private final SpgNotificationService spgNotificationService;
     private final ReferenceDataService referenceDataService;
 
     public OffenderIdentifierService(
             @Value("${features.noms.update.noms.number}") Boolean updateNomsNumberFeatureSwitch,
-            OffenderTransformer offenderTransformer,
             OffenderRepository offenderRepository,
             SpgNotificationService spgNotificationService,
             ReferenceDataService referenceDataService) {
         this.updateNomsNumberFeatureSwitch = updateNomsNumberFeatureSwitch;
-        this.offenderTransformer = offenderTransformer;
         this.offenderRepository = offenderRepository;
         this.spgNotificationService = spgNotificationService;
         this.referenceDataService = referenceDataService;

--- a/src/main/java/uk/gov/justice/digital/delius/service/OffenderManagerService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/OffenderManagerService.java
@@ -24,7 +24,6 @@ import java.util.stream.Stream;
 public class OffenderManagerService {
 
     private final OffenderRepository offenderRepository;
-    private final OffenderManagerTransformer offenderManagerTransformer;
     private final ProbationAreaRepository probationAreaRepository;
     private final PrisonOffenderManagerRepository prisonOffenderManagerRepository;
     private final ResponsibleOfficerRepository responsibleOfficerRepository;
@@ -37,9 +36,8 @@ public class OffenderManagerService {
 
 
     @Autowired
-    public OffenderManagerService(OffenderRepository offenderRepository, OffenderManagerTransformer offenderManagerTransformer, ProbationAreaRepository probationAreaRepository, PrisonOffenderManagerRepository prisonOffenderManagerRepository, ResponsibleOfficerRepository responsibleOfficerRepository, StaffService staffService, TeamService teamService, ReferenceDataService referenceDataService, ContactService contactService) {
+    public OffenderManagerService(OffenderRepository offenderRepository, ProbationAreaRepository probationAreaRepository, PrisonOffenderManagerRepository prisonOffenderManagerRepository, ResponsibleOfficerRepository responsibleOfficerRepository, StaffService staffService, TeamService teamService, ReferenceDataService referenceDataService, ContactService contactService) {
         this.offenderRepository = offenderRepository;
-        this.offenderManagerTransformer = offenderManagerTransformer;
         this.probationAreaRepository = probationAreaRepository;
         this.prisonOffenderManagerRepository = prisonOffenderManagerRepository;
         this.responsibleOfficerRepository = responsibleOfficerRepository;

--- a/src/main/java/uk/gov/justice/digital/delius/service/OffenderService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/OffenderService.java
@@ -27,9 +27,7 @@ import static java.util.function.Predicate.not;
 public class OffenderService {
 
     private final OffenderRepository offenderRepository;
-    private final OffenderTransformer offenderTransformer;
     private final ConvictionService convictionService;
-    private final ReleaseTransformer releaseTransformer;
 
     @Transactional(readOnly = true)
     public Optional<OffenderDetail> getOffenderByOffenderId(Long offenderId) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/PersonalCircumstanceService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/PersonalCircumstanceService.java
@@ -15,12 +15,10 @@ import static uk.gov.justice.digital.delius.transformers.TypesTransformer.conver
 @Service
 public class PersonalCircumstanceService {
     private final PersonalCircumstanceRepository personalCircumstanceRepository;
-    private final PersonalCircumstanceTransformer personalCircumstanceTransformer;
 
     @Autowired
-    public PersonalCircumstanceService(PersonalCircumstanceRepository personalCircumstanceRepository, PersonalCircumstanceTransformer personalCircumstanceTransformer) {
+    public PersonalCircumstanceService(PersonalCircumstanceRepository personalCircumstanceRepository) {
         this.personalCircumstanceRepository = personalCircumstanceRepository;
-        this.personalCircumstanceTransformer = personalCircumstanceTransformer;
     }
 
     public List<PersonalCircumstance> personalCircumstancesFor(Long offenderId) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/ReferenceDataService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ReferenceDataService.java
@@ -41,15 +41,13 @@ public class ReferenceDataService {
     private static final String ADDITIONAL_IDENTIFIER_DATASET = "ADDITIONAL IDENTIFIER TYPE";
     private static final String DUPLICATE_NOMS_NUMBER_CODE = "DNOMS";
     private static final String FORMER_NOMS_NUMBER_CODE = "XNOMS";
-    private final ProbationAreaTransformer probationAreaTransformer;
     private final ProbationAreaRepository probationAreaRepository;
     private final StandardReferenceRepository standardReferenceRepository;
     private final ReferenceDataMasterRepository referenceDataMasterRepository;
 
 
     @Autowired
-    public ReferenceDataService(ProbationAreaTransformer probationAreaTransformer, ProbationAreaRepository probationAreaRepository, StandardReferenceRepository standardReferenceRepository, ReferenceDataMasterRepository referenceDataMasterRepository) {
-        this.probationAreaTransformer = probationAreaTransformer;
+    public ReferenceDataService(ProbationAreaRepository probationAreaRepository, StandardReferenceRepository standardReferenceRepository, ReferenceDataMasterRepository referenceDataMasterRepository) {
         this.probationAreaRepository = probationAreaRepository;
         this.standardReferenceRepository = standardReferenceRepository;
         this.referenceDataMasterRepository = referenceDataMasterRepository;

--- a/src/main/java/uk/gov/justice/digital/delius/service/RegistrationService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/RegistrationService.java
@@ -15,12 +15,10 @@ import static uk.gov.justice.digital.delius.transformers.TypesTransformer.conver
 @Service
 public class RegistrationService {
     private final RegistrationRepository registrationRepository;
-    private final RegistrationTransformer registrationTransformer;
 
     @Autowired
-    public RegistrationService(RegistrationRepository registrationRepository, RegistrationTransformer registrationTransformer) {
+    public RegistrationService(RegistrationRepository registrationRepository) {
         this.registrationRepository = registrationRepository;
-        this.registrationTransformer = registrationTransformer;
     }
 
     public List<Registration> registrationsFor(Long offenderId) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
@@ -24,8 +24,6 @@ public class RequirementService {
     private OffenderRepository offenderRepository;
     @Autowired
     private EventRepository eventRepository;
-    @Autowired
-    private RequirementTransformer requirementTransformer;
 
     public ConvictionRequirements getRequirementsByConvictionId(String crn, Long convictionId) {
         var offender = offenderRepository.findByCrn(crn)
@@ -36,7 +34,7 @@ public class RequirementService {
                 .filter(event -> convictionId.equals(event.getEventId()))
                 .map(Event::getDisposal)
                 .flatMap(this::getRequirementStreamFromDisposal)
-                .map(requirement -> requirementTransformer.requirementOf(requirement))
+                .map(RequirementTransformer::requirementOf)
                 .collect(Collectors.toList());
 
         return new ConvictionRequirements(requirements);

--- a/src/main/java/uk/gov/justice/digital/delius/service/StaffService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/StaffService.java
@@ -26,8 +26,6 @@ public class StaffService {
 
     private final StaffRepository staffRepository;
     private final LdapRepository ldapRepository;
-    private final OffenderTransformer offenderTransformer;
-    private final StaffTransformer staffTransformer;
     private final StaffHelperRepository staffHelperRepository;
 
 

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AdditionalOffenceTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AdditionalOffenceTransformer.java
@@ -10,9 +10,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
-import static uk.gov.justice.digital.delius.transformers.OffenceDetailTransformer.detailOf;
-import static uk.gov.justice.digital.delius.transformers.OffenceIdTransformer.additionalOffenceIdOf;
-import static uk.gov.justice.digital.delius.transformers.TypesTransformer.convertToBoolean;
 
 @Component
 public class AdditionalOffenceTransformer {
@@ -22,23 +19,6 @@ public class AdditionalOffenceTransformer {
         this.lookupSupplier = lookupSupplier;
     }
 
-
-    public static List<Offence> offencesOf(List<AdditionalOffence> additionalOffences) {
-        return additionalOffences.stream()
-            .filter(offence -> !convertToBoolean(offence.getSoftDeleted()))
-            .map(additionalOffence ->
-                Offence.builder()
-                    .offenceId(additionalOffenceIdOf(additionalOffence.getAdditionalOffenceId()))
-                    .detail(detailOf(additionalOffence.getOffence()))
-                    .createdDatetime(additionalOffence.getCreatedDatetime())
-                    .lastUpdatedDatetime(additionalOffence.getLastUpdatedDatetime())
-                    .mainOffence(false)
-                    .offenceCount(additionalOffence.getOffenceCount())
-                    .offenceDate(additionalOffence.getOffenceDate())
-                    .build()
-            )
-            .collect(toList());
-    }
 
     public List<AdditionalOffence> additionalOffencesOf(
             List<Offence> additionalOffences,

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentTransformer.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.Appointment;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.jpa.standard.entity.ContactOutcomeType;
@@ -11,18 +10,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static uk.gov.justice.digital.delius.data.api.Appointment.Attended.*;
+import static uk.gov.justice.digital.delius.data.api.Appointment.Attended.ATTENDED;
+import static uk.gov.justice.digital.delius.data.api.Appointment.Attended.NOT_RECORDED;
+import static uk.gov.justice.digital.delius.data.api.Appointment.Attended.UNATTENDED;
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.ynToBoolean;
 
-@Component
 public class AppointmentTransformer {
-    private final ContactTransformer contactTransformer;
-    private final RequirementTransformer requirementTransformer = new RequirementTransformer();
-
-    public AppointmentTransformer(ContactTransformer contactTransformer) {
-        this.contactTransformer = contactTransformer;
-    }
-
 
     public static List<Appointment> appointmentsOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.Contact> contacts) {
         return contacts.stream()

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/ContactTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/ContactTransformer.java
@@ -1,12 +1,23 @@
 package uk.gov.justice.digital.delius.transformers;
 
 import com.google.common.collect.ImmutableList;
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.Contact;
 import uk.gov.justice.digital.delius.data.api.Human;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.data.api.Nsi;
-import uk.gov.justice.digital.delius.jpa.standard.entity.*;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ContactOutcomeType;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ContactType;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Explanation;
+import uk.gov.justice.digital.delius.jpa.standard.entity.LicenceCondition;
+import uk.gov.justice.digital.delius.jpa.standard.entity.LicenceConditionTypeMainCat;
+import uk.gov.justice.digital.delius.jpa.standard.entity.PartitionArea;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ProviderEmployee;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ProviderLocation;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ProviderTeam;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Staff;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Team;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,12 +27,7 @@ import static java.util.Comparator.comparing;
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.ynToBoolean;
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.zeroOneToBoolean;
 
-@Component
 public class ContactTransformer {
-
-    private final RequirementTransformer requirementTransformer = new RequirementTransformer();
-
-    private final NsiTransformer nsiTransformer = new NsiTransformer();
 
     public static List<Contact> contactsOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.Contact> contacts) {
         return contacts.stream()

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformer.java
@@ -1,42 +1,37 @@
 package uk.gov.justice.digital.delius.transformers;
 
 import com.google.common.collect.ImmutableList;
-import lombok.val;
-import org.springframework.stereotype.Component;
+import uk.gov.justice.digital.delius.data.api.Appointments;
+import uk.gov.justice.digital.delius.data.api.Conviction;
 import uk.gov.justice.digital.delius.data.api.Custody;
-import uk.gov.justice.digital.delius.data.api.*;
-import uk.gov.justice.digital.delius.data.api.Offence;
+import uk.gov.justice.digital.delius.data.api.CustodyRelatedKeyDates;
 import uk.gov.justice.digital.delius.data.api.CustodyRelatedKeyDates.CustodyRelatedKeyDatesBuilder;
+import uk.gov.justice.digital.delius.data.api.KeyValue;
+import uk.gov.justice.digital.delius.data.api.Offence;
+import uk.gov.justice.digital.delius.data.api.Sentence;
+import uk.gov.justice.digital.delius.data.api.UnpaidWork;
 import uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Disposal;
+import uk.gov.justice.digital.delius.jpa.standard.entity.DisposalType;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
-import uk.gov.justice.digital.delius.jpa.standard.entity.OrderManager;
-import uk.gov.justice.digital.delius.jpa.standard.entity.*;
-import uk.gov.justice.digital.delius.service.LookupSupplier;
+import uk.gov.justice.digital.delius.jpa.standard.entity.KeyDate;
+import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
+import uk.gov.justice.digital.delius.jpa.standard.entity.UpwAppointment;
+import uk.gov.justice.digital.delius.jpa.standard.entity.UpwDetails;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.toList;
-import static uk.gov.justice.digital.delius.helpers.FluentHelper.not;
-import static uk.gov.justice.digital.delius.service.LookupSupplier.INITIAL_ORDER_ALLOCATION;
-import static uk.gov.justice.digital.delius.service.LookupSupplier.TRANSFER_CASE_INITIAL_REASON;
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.zeroOneToBoolean;
 
-@Component
 public class ConvictionTransformer {
-    private final MainOffenceTransformer mainOffenceTransformer;
-    private final AdditionalOffenceTransformer additionalOffenceTransformer;
-    private final CourtAppearanceTransformer courtAppearanceTransformer;
-    private final LookupSupplier lookupSupplier;
-    private final InstitutionTransformer institutionTransformer;
 
     enum KeyDateTypes {
         LICENCE_EXPIRY_DATE("LED", CustodyRelatedKeyDatesBuilder::licenceExpiryDate),
@@ -80,12 +75,7 @@ public class ConvictionTransformer {
         }
     }
 
-    public ConvictionTransformer(MainOffenceTransformer mainOffenceTransformer, AdditionalOffenceTransformer additionalOffenceTransformer, CourtAppearanceTransformer courtAppearanceTransformer, LookupSupplier lookupSupplier, InstitutionTransformer institutionTransformer) {
-        this.mainOffenceTransformer = mainOffenceTransformer;
-        this.additionalOffenceTransformer = additionalOffenceTransformer;
-        this.courtAppearanceTransformer = courtAppearanceTransformer;
-        this.lookupSupplier = lookupSupplier;
-        this.institutionTransformer = institutionTransformer;
+    public ConvictionTransformer() {
     }
 
     public static Conviction convictionOf(Event event) {
@@ -124,9 +114,9 @@ public class ConvictionTransformer {
 
     private static List<Offence> offencesOf(Event event) {
         return ImmutableList.<Offence>builder()
-                .addAll(Optional.ofNullable(event.getMainOffence()).map(mainOffence -> ImmutableList.of(MainOffenceTransformer
+                .addAll(Optional.ofNullable(event.getMainOffence()).map(mainOffence -> ImmutableList.of(OffenceTransformer
                         .offenceOf(mainOffence))).orElse(ImmutableList.of()) )
-                .addAll(AdditionalOffenceTransformer.offencesOf(event.getAdditionalOffences()))
+                .addAll(OffenceTransformer.offencesOf(event.getAdditionalOffences()))
                 .build();
     }
 
@@ -214,81 +204,6 @@ public class ConvictionTransformer {
                     keyDateType.set(custodyRelatedKeyDates, keyDate.getKeyDate());
                 });
         return custodyRelatedKeyDates.build();
-    }
-
-    public Event eventOf(
-            Long offenderId,
-            CourtCase courtCase,
-            String eventNumber) {
-        val event = Event
-                .builder()
-                .offenderId(offenderId)
-                .activeFlag(1L)
-                .referralDate(courtCase.getReferralDate())
-                .disposal(null) // TODO sentencing is done in a later phase
-                .partitionAreaId(0L)
-                .rowVersion(1L)
-                .softDeleted(0L)
-                .convictionDate(courtCase.getConvictionDate())
-                .inBreach(0L)
-                .eventNumber(eventNumber)
-                .createdByUserId(lookupSupplier.userSupplier().get().getUserId())
-                .createdDatetime(LocalDateTime.now())
-                .lastUpdatedUserId(lookupSupplier.userSupplier().get().getUserId())
-                .lastUpdatedDatetime(LocalDateTime.now())
-                .pendingTransfer(0L)
-                .postSentenceSupervisionRequirementFlag(0L)
-                .build();
-
-        event.setMainOffence(mainOffenceTransformer.mainOffenceOf(offenderId, mainOffence(courtCase.getOffences()), event));
-        event.setAdditionalOffences(additionalOffenceTransformer.additionalOffencesOf(additionalOffences(courtCase.getOffences()), event));
-        event.setCourtAppearances(courtAppearances(offenderId, event, courtCase.getCourtAppearance(), courtCase.getNextAppearance()));
-        event.setOrderManagers(ImmutableList.of(orderManager(courtCase.getOrderManager(), event)));
-
-        return event;
-
-    }
-
-    private OrderManager orderManager(
-            uk.gov.justice.digital.delius.data.api.OrderManager orderManager,
-            Event event) {
-        return OrderManager
-                .builder()
-                .event(event)
-                .activeFlag(1L)
-                .allocationDate(LocalDateTime.now())
-                .allocationReason(lookupSupplier.orderAllocationReasonSupplier().apply(INITIAL_ORDER_ALLOCATION))
-                .createdByUserId(lookupSupplier.userSupplier().get().getUserId())
-                .createdDatetime(LocalDateTime.now())
-                .lastUpdatedUserId(lookupSupplier.userSupplier().get().getUserId())
-                .lastUpdatedDatetime(LocalDateTime.now())
-                .probationArea(lookupSupplier.probationAreaSupplier().apply(orderManager))
-                .team(lookupSupplier.teamSupplier().apply(orderManager))
-                .providerEmployee(null)
-                .endDate(null)
-                .orderTransferId(null)
-                .partitionAreaId(0L)
-                .providerTeam(null)
-                .rowVersion(1L)
-                .softDeleted(0L)
-                .staff(lookupSupplier.staffSupplier().apply(orderManager))
-                .transferReason(lookupSupplier.transferReasonSupplier().apply(TRANSFER_CASE_INITIAL_REASON))
-                .build();
-    }
-
-    private static List<Offence> additionalOffences(List<Offence> offences) {
-        return offences.stream().filter(not(Offence::getMainOffence)).collect(Collectors.toList());
-    }
-    private static Offence mainOffence(List<Offence> offences) {
-        return offences.stream().filter(Offence::getMainOffence).findFirst().orElseThrow(() -> new RuntimeException("No main offence found"));
-    }
-    private List<CourtAppearance> courtAppearances(
-            Long offenderId,
-            Event event,
-            uk.gov.justice.digital.delius.data.api.CourtAppearance first,
-            uk.gov.justice.digital.delius.data.api.CourtAppearance next) {
-        val builder = ImmutableList.<CourtAppearance>builder().add(courtAppearanceTransformer.courtAppearanceOf(offenderId, event, first));
-        return Optional.ofNullable(next).map(courtAppearance -> builder.add(courtAppearanceTransformer.courtAppearanceOf(offenderId, event, courtAppearance))).orElse(builder).build();
     }
 
 }

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceTransformer.java
@@ -17,13 +17,9 @@ import static uk.gov.justice.digital.delius.transformers.TypesTransformer.conver
 
 @Component
 public class CourtAppearanceTransformer {
-    private final CourtReportTransformer courtReportTransformer;
-    private final CourtTransformer courtTransformer;
     private final LookupSupplier lookupSupplier;
 
-    public CourtAppearanceTransformer(CourtReportTransformer courtReportTransformer, CourtTransformer courtTransformer, LookupSupplier lookupSupplier) {
-        this.courtReportTransformer = courtReportTransformer;
-        this.courtTransformer = courtTransformer;
+    public CourtAppearanceTransformer(LookupSupplier lookupSupplier) {
         this.lookupSupplier = lookupSupplier;
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/CourtReportTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/CourtReportTransformer.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.CourtReport;
 
 import java.util.Optional;
@@ -8,14 +7,7 @@ import java.util.Optional;
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.ynToBoolean;
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.zeroOneToBoolean;
 
-@Component
 public class CourtReportTransformer {
-    final private CourtTransformer courtTransformer;
-
-    public CourtReportTransformer(CourtTransformer courtTransformer) {
-        this.courtTransformer = courtTransformer;
-    }
-
 
     public static CourtReport courtReportOf(uk.gov.justice.digital.delius.jpa.standard.entity.CourtReport report) {
         return CourtReport.builder()

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/CourtTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/CourtTransformer.java
@@ -1,11 +1,9 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.Court;
 
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.ynToBoolean;
 
-@Component
 public class CourtTransformer {
 
 

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/DocumentTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/DocumentTransformer.java
@@ -1,10 +1,26 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.stereotype.Component;
-import uk.gov.justice.digital.delius.data.api.ReportDocumentDates;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.data.api.OffenderDocumentDetail;
-import uk.gov.justice.digital.delius.jpa.standard.entity.*;
+import uk.gov.justice.digital.delius.data.api.ReportDocumentDates;
+import uk.gov.justice.digital.delius.jpa.standard.entity.AddressAssessmentDocument;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ApprovedPremisesReferralDocument;
+import uk.gov.justice.digital.delius.jpa.standard.entity.AssessmentDocument;
+import uk.gov.justice.digital.delius.jpa.standard.entity.CaseAllocationDocument;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ContactDocument;
+import uk.gov.justice.digital.delius.jpa.standard.entity.CourtReportDocument;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Document;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
+import uk.gov.justice.digital.delius.jpa.standard.entity.EventDocument;
+import uk.gov.justice.digital.delius.jpa.standard.entity.InstitutionalReportDocument;
+import uk.gov.justice.digital.delius.jpa.standard.entity.NsiDocument;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Offender;
+import uk.gov.justice.digital.delius.jpa.standard.entity.OffenderDocument;
+import uk.gov.justice.digital.delius.jpa.standard.entity.PersonalCircumstanceDocument;
+import uk.gov.justice.digital.delius.jpa.standard.entity.PersonalContactDocument;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ReferralDocument;
+import uk.gov.justice.digital.delius.jpa.standard.entity.UPWAppointmentDocument;
+import uk.gov.justice.digital.delius.jpa.standard.entity.User;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -14,7 +30,6 @@ import java.util.Optional;
 
 import static java.util.stream.Collectors.toList;
 
-@Component
 public class DocumentTransformer {
     public static List<OffenderDocumentDetail> offenderDocumentsDetailsOfOffenderDocuments(List<OffenderDocument> documents) {
         return documents

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/EventTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/EventTransformer.java
@@ -1,0 +1,112 @@
+package uk.gov.justice.digital.delius.transformers;
+
+import com.google.common.collect.ImmutableList;
+import lombok.val;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.digital.delius.data.api.CourtCase;
+import uk.gov.justice.digital.delius.data.api.Offence;
+import uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
+import uk.gov.justice.digital.delius.jpa.standard.entity.OrderManager;
+import uk.gov.justice.digital.delius.service.LookupSupplier;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static uk.gov.justice.digital.delius.helpers.FluentHelper.not;
+import static uk.gov.justice.digital.delius.service.LookupSupplier.INITIAL_ORDER_ALLOCATION;
+import static uk.gov.justice.digital.delius.service.LookupSupplier.TRANSFER_CASE_INITIAL_REASON;
+
+@Component
+public class EventTransformer {
+    private final MainOffenceTransformer mainOffenceTransformer;
+    private final AdditionalOffenceTransformer additionalOffenceTransformer;
+    private final CourtAppearanceTransformer courtAppearanceTransformer;
+    private final LookupSupplier lookupSupplier;
+
+    public EventTransformer(MainOffenceTransformer mainOffenceTransformer, AdditionalOffenceTransformer additionalOffenceTransformer, CourtAppearanceTransformer courtAppearanceTransformer, LookupSupplier lookupSupplier) {
+        this.mainOffenceTransformer = mainOffenceTransformer;
+        this.additionalOffenceTransformer = additionalOffenceTransformer;
+        this.courtAppearanceTransformer = courtAppearanceTransformer;
+        this.lookupSupplier = lookupSupplier;
+    }
+
+
+    public Event eventOf(
+            Long offenderId,
+            CourtCase courtCase,
+            String eventNumber) {
+        val event = Event
+                .builder()
+                .offenderId(offenderId)
+                .activeFlag(1L)
+                .referralDate(courtCase.getReferralDate())
+                .disposal(null) // TODO sentencing is done in a later phase
+                .partitionAreaId(0L)
+                .rowVersion(1L)
+                .softDeleted(0L)
+                .convictionDate(courtCase.getConvictionDate())
+                .inBreach(0L)
+                .eventNumber(eventNumber)
+                .createdByUserId(lookupSupplier.userSupplier().get().getUserId())
+                .createdDatetime(LocalDateTime.now())
+                .lastUpdatedUserId(lookupSupplier.userSupplier().get().getUserId())
+                .lastUpdatedDatetime(LocalDateTime.now())
+                .pendingTransfer(0L)
+                .postSentenceSupervisionRequirementFlag(0L)
+                .build();
+
+        event.setMainOffence(mainOffenceTransformer.mainOffenceOf(offenderId, mainOffence(courtCase.getOffences()), event));
+        event.setAdditionalOffences(additionalOffenceTransformer.additionalOffencesOf(additionalOffences(courtCase.getOffences()), event));
+        event.setCourtAppearances(courtAppearances(offenderId, event, courtCase.getCourtAppearance(), courtCase.getNextAppearance()));
+        event.setOrderManagers(ImmutableList.of(orderManager(courtCase.getOrderManager(), event)));
+
+        return event;
+
+    }
+
+    private OrderManager orderManager(
+            uk.gov.justice.digital.delius.data.api.OrderManager orderManager,
+            Event event) {
+        return OrderManager
+                .builder()
+                .event(event)
+                .activeFlag(1L)
+                .allocationDate(LocalDateTime.now())
+                .allocationReason(lookupSupplier.orderAllocationReasonSupplier().apply(INITIAL_ORDER_ALLOCATION))
+                .createdByUserId(lookupSupplier.userSupplier().get().getUserId())
+                .createdDatetime(LocalDateTime.now())
+                .lastUpdatedUserId(lookupSupplier.userSupplier().get().getUserId())
+                .lastUpdatedDatetime(LocalDateTime.now())
+                .probationArea(lookupSupplier.probationAreaSupplier().apply(orderManager))
+                .team(lookupSupplier.teamSupplier().apply(orderManager))
+                .providerEmployee(null)
+                .endDate(null)
+                .orderTransferId(null)
+                .partitionAreaId(0L)
+                .providerTeam(null)
+                .rowVersion(1L)
+                .softDeleted(0L)
+                .staff(lookupSupplier.staffSupplier().apply(orderManager))
+                .transferReason(lookupSupplier.transferReasonSupplier().apply(TRANSFER_CASE_INITIAL_REASON))
+                .build();
+    }
+
+    private static List<Offence> additionalOffences(List<Offence> offences) {
+        return offences.stream().filter(not(Offence::getMainOffence)).collect(Collectors.toList());
+    }
+    private static Offence mainOffence(List<Offence> offences) {
+        return offences.stream().filter(Offence::getMainOffence).findFirst().orElseThrow(() -> new RuntimeException("No main offence found"));
+    }
+    private List<CourtAppearance> courtAppearances(
+            Long offenderId,
+            Event event,
+            uk.gov.justice.digital.delius.data.api.CourtAppearance first,
+            uk.gov.justice.digital.delius.data.api.CourtAppearance next) {
+        val builder = ImmutableList.<CourtAppearance>builder().add(courtAppearanceTransformer.courtAppearanceOf(offenderId, event, first));
+        return Optional.ofNullable(next).map(courtAppearance -> builder.add(courtAppearanceTransformer.courtAppearanceOf(offenderId, event, courtAppearance))).orElse(builder).build();
+    }
+
+}

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/InstitutionTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/InstitutionTransformer.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.Institution;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.jpa.standard.entity.RInstitution;
@@ -11,7 +10,6 @@ import java.util.Optional;
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.ynToBoolean;
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.zeroOneToBoolean;
 
-@Component
 public class InstitutionTransformer {
     public static Institution institutionOf(RInstitution institution) {
         return Optional.ofNullable(institution).map(inst -> Institution.builder()

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/InstitutionalReportTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/InstitutionalReportTransformer.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.Conviction;
 import uk.gov.justice.digital.delius.data.api.InstitutionalReport;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Custody;
@@ -10,13 +9,7 @@ import java.util.Optional;
 
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.convertToBoolean;
 
-@Component
 public class InstitutionalReportTransformer {
-    private final ConvictionTransformer convictionTransformer;
-
-    public InstitutionalReportTransformer(ConvictionTransformer convictionTransformer) {
-        this.convictionTransformer = convictionTransformer;
-    }
 
     public static InstitutionalReport institutionalReportOf(uk.gov.justice.digital.delius.jpa.standard.entity.InstitutionalReport report) {
         return InstitutionalReport.builder()

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/KeyValueTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/KeyValueTransformer.java
@@ -1,12 +1,10 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 
 import java.util.Optional;
 
-@Component
 public class KeyValueTransformer {
     public static KeyValue keyValueOf(StandardReference standardReference) {
         return Optional.ofNullable(standardReference).map(reason -> KeyValue.builder()

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/MainOffenceTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/MainOffenceTransformer.java
@@ -8,29 +8,12 @@ import uk.gov.justice.digital.delius.service.LookupSupplier;
 
 import java.time.LocalDateTime;
 
-import static uk.gov.justice.digital.delius.transformers.OffenceDetailTransformer.detailOf;
-
 @Component
 public class MainOffenceTransformer {
     private final LookupSupplier lookupSupplier;
 
     public MainOffenceTransformer(LookupSupplier lookupSupplier) {
         this.lookupSupplier = lookupSupplier;
-    }
-
-    public static Offence offenceOf(MainOffence mainOffence) {
-        return Offence.builder()
-            .offenceId(OffenceIdTransformer.mainOffenceIdOf(mainOffence.getMainOffenceId()))
-            .detail(detailOf(mainOffence.getOffence()))
-            .createdDatetime(mainOffence.getCreatedDatetime())
-            .lastUpdatedDatetime(mainOffence.getLastUpdatedDatetime())
-            .mainOffence(true)
-            .offenceCount(mainOffence.getOffenceCount())
-            .offenceDate(mainOffence.getOffenceDate())
-            .offenderId(mainOffence.getOffenderId())
-            .tics(mainOffence.getTics())
-            .verdict(mainOffence.getVerdict())
-            .build();
     }
 
     public MainOffence mainOffenceOf(Long offenderId, Offence mainOffence, Event event) {

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/NsiTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/NsiTransformer.java
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.data.api.NsiManager;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Nsi;
@@ -13,32 +11,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-@Component
 public class NsiTransformer {
 
     public static final String NSI_LENGTH_UNIT = "Months";
     public static final boolean INCLUDE_PROBATION_AREA_TEAMS = false;
-    private final RequirementTransformer requirementTransformer;
-    private final ProbationAreaTransformer probationAreaTransformer;
-    private final TeamTransformer teamTransformer;
-    private final StaffTransformer staffTransformer;
-
-    public NsiTransformer(@Autowired final RequirementTransformer requirementTransformer,
-                          @Autowired ProbationAreaTransformer probationAreaTransformer,
-                          @Autowired TeamTransformer teamTransformer,
-                          @Autowired StaffTransformer staffTransformer) {
-        this.requirementTransformer = requirementTransformer;
-        this.probationAreaTransformer = probationAreaTransformer;
-        this.teamTransformer = teamTransformer;
-        this.staffTransformer = staffTransformer;
-    }
-
-    public NsiTransformer() {
-        this.requirementTransformer = new RequirementTransformer();
-        this.probationAreaTransformer = new ProbationAreaTransformer();
-        this.teamTransformer = new TeamTransformer();
-        this.staffTransformer = new StaffTransformer();
-    }
 
     public static uk.gov.justice.digital.delius.data.api.Nsi nsiOf(Nsi nsi) {
         return Optional.ofNullable(nsi).map(n ->

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/OffenceTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/OffenceTransformer.java
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.delius.transformers;
+
+import uk.gov.justice.digital.delius.data.api.Offence;
+import uk.gov.justice.digital.delius.jpa.standard.entity.AdditionalOffence;
+import uk.gov.justice.digital.delius.jpa.standard.entity.MainOffence;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+import static uk.gov.justice.digital.delius.transformers.OffenceDetailTransformer.detailOf;
+import static uk.gov.justice.digital.delius.transformers.OffenceIdTransformer.additionalOffenceIdOf;
+import static uk.gov.justice.digital.delius.transformers.TypesTransformer.convertToBoolean;
+
+public class OffenceTransformer {
+    public static List<Offence> offencesOf(List<AdditionalOffence> additionalOffences) {
+        return additionalOffences.stream()
+            .filter(offence -> !convertToBoolean(offence.getSoftDeleted()))
+            .map(additionalOffence ->
+                Offence.builder()
+                    .offenceId(additionalOffenceIdOf(additionalOffence.getAdditionalOffenceId()))
+                    .detail(detailOf(additionalOffence.getOffence()))
+                    .createdDatetime(additionalOffence.getCreatedDatetime())
+                    .lastUpdatedDatetime(additionalOffence.getLastUpdatedDatetime())
+                    .mainOffence(false)
+                    .offenceCount(additionalOffence.getOffenceCount())
+                    .offenceDate(additionalOffence.getOffenceDate())
+                    .build()
+            )
+            .collect(toList());
+    }
+
+    public static Offence offenceOf(MainOffence mainOffence) {
+        return Offence.builder()
+            .offenceId(OffenceIdTransformer.mainOffenceIdOf(mainOffence.getMainOffenceId()))
+            .detail(detailOf(mainOffence.getOffence()))
+            .createdDatetime(mainOffence.getCreatedDatetime())
+            .lastUpdatedDatetime(mainOffence.getLastUpdatedDatetime())
+            .mainOffence(true)
+            .offenceCount(mainOffence.getOffenceCount())
+            .offenceDate(mainOffence.getOffenceDate())
+            .offenderId(mainOffence.getOffenderId())
+            .tics(mainOffence.getTics())
+            .verdict(mainOffence.getVerdict())
+            .build();
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/OffenderManagerTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/OffenderManagerTransformer.java
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.CommunityOrPrisonOffenderManager;
 import uk.gov.justice.digital.delius.jpa.standard.entity.OffenderManager;
 import uk.gov.justice.digital.delius.jpa.standard.entity.PrisonOffenderManager;
@@ -10,19 +8,8 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.Staff;
 
 import java.util.Optional;
 
-@Component
 public class OffenderManagerTransformer {
-    private final StaffTransformer staffTransformer;
-    private final TeamTransformer teamTransformer;
-    private final ProbationAreaTransformer probationAreaTransformer;
     private static final String UNALLOCATED_STAFF_CODE_SUFFIX = "U";
-
-    @Autowired
-    public OffenderManagerTransformer(StaffTransformer staffTransformer, TeamTransformer teamTransformer, ProbationAreaTransformer probationAreaTransformer) {
-        this.staffTransformer = staffTransformer;
-        this.teamTransformer = teamTransformer;
-        this.probationAreaTransformer = probationAreaTransformer;
-    }
 
     public static CommunityOrPrisonOffenderManager offenderManagerOf(OffenderManager offenderManager) {
         return CommunityOrPrisonOffenderManager

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/OffenderTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/OffenderTransformer.java
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.delius.transformers;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.AdditionalIdentifier;
 import uk.gov.justice.digital.delius.data.api.Address;
 import uk.gov.justice.digital.delius.data.api.ContactDetails;
@@ -44,15 +42,7 @@ import static java.util.stream.Collectors.toList;
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.ynToBoolean;
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.zeroOneToBoolean;
 
-@Component
 public class OffenderTransformer {
-
-    private final ContactTransformer contactTransformer;
-
-    @Autowired
-    public OffenderTransformer(ContactTransformer contactTransformer) {
-        this.contactTransformer = contactTransformer;
-    }
 
     private static List<PhoneNumber> phoneNumbersOf(Offender offender) {
         return ImmutableList.of(

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformer.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.data.api.PersonalCircumstance;
 import uk.gov.justice.digital.delius.jpa.standard.entity.CircumstanceSubType;
@@ -11,7 +10,6 @@ import java.util.Optional;
 
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.ynToBoolean;
 
-@Component
 public class PersonalCircumstanceTransformer {
     public static PersonalCircumstance personalCircumstanceOf(uk.gov.justice.digital.delius.jpa.standard.entity.PersonalCircumstance personalCircumstance) {
         return PersonalCircumstance.builder()

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/ProbationAreaTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/ProbationAreaTransformer.java
@@ -1,10 +1,14 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.AllTeam;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.data.api.ProbationArea;
-import uk.gov.justice.digital.delius.jpa.standard.entity.*;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Borough;
+import uk.gov.justice.digital.delius.jpa.standard.entity.District;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ExternalProvider;
+import uk.gov.justice.digital.delius.jpa.standard.entity.LocalDeliveryUnit;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Organisation;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Team;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,17 +17,7 @@ import java.util.stream.Stream;
 
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.zeroOneToBoolean;
 
-@Component
 public class ProbationAreaTransformer {
-    private final InstitutionTransformer institutionTransformer;
-
-    public ProbationAreaTransformer(InstitutionTransformer institutionTransformer) {
-        this.institutionTransformer = institutionTransformer;
-    }
-
-    public ProbationAreaTransformer() {
-        this.institutionTransformer = new InstitutionTransformer();
-    }
 
     public static List<ProbationArea> probationAreasOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea> probationAreas) {
         return probationAreas.stream().map(ProbationAreaTransformer::probationAreaOf).collect(Collectors.toList());

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/RecallTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/RecallTransformer.java
@@ -1,11 +1,9 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.data.api.OffenderRecall;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Recall;
 
-@Component
 public class RecallTransformer {
 
     public static OffenderRecall offenderRecallOf(Recall recall) {

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/RegistrationTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/RegistrationTransformer.java
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.data.api.Registration;
-import uk.gov.justice.digital.delius.jpa.standard.entity.*;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Deregistration;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea;
+import uk.gov.justice.digital.delius.jpa.standard.entity.RegisterType;
+import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -11,13 +13,7 @@ import java.util.function.Predicate;
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.convertToBoolean;
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.ynToBoolean;
 
-@Component
 public class RegistrationTransformer {
-    private final ContactTransformer contactTransformer;
-
-    public RegistrationTransformer(ContactTransformer contactTransformer) {
-        this.contactTransformer = contactTransformer;
-    }
 
     public static Registration registrationOf(uk.gov.justice.digital.delius.jpa.standard.entity.Registration registration) {
         final Predicate<Deregistration> hasDeregistered = notUsed -> convertToBoolean(registration.getDeregistered());

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/ReleaseTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/ReleaseTransformer.java
@@ -1,18 +1,11 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import lombok.AllArgsConstructor;
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.data.api.OffenderLatestRecall;
 import uk.gov.justice.digital.delius.data.api.OffenderRelease;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Release;
 
-@Component
-@AllArgsConstructor
 public class ReleaseTransformer {
-
-    private InstitutionTransformer institutionTransformer;
-    private RecallTransformer recallTransformer;
 
     public static OffenderRelease offenderReleaseOf(Release release) {
         final var releaseType = KeyValue.builder()

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/RequirementTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/RequirementTransformer.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.jpa.standard.entity.AdRequirementTypeMainCategory;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Requirement;
@@ -11,7 +10,6 @@ import java.util.Optional;
 
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.zeroOneToBoolean;
 
-@Component
 public class RequirementTransformer {
 
     public static uk.gov.justice.digital.delius.data.api.Requirement requirementOf(Requirement requirement) {

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/StaffTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/StaffTransformer.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.Human;
 import uk.gov.justice.digital.delius.data.api.StaffDetails;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Staff;
@@ -10,17 +9,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@Component
 public class StaffTransformer {
-
-    private final TeamTransformer teamTransformer;
-
-    public StaffTransformer(TeamTransformer teamTransformer) {
-        this.teamTransformer = teamTransformer;
-    }
-    public StaffTransformer() {
-        this.teamTransformer = new TeamTransformer();
-    }
 
     public static StaffDetails staffDetailsOf(Staff staff) {
         return StaffDetails.builder()

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/TeamTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/TeamTransformer.java
@@ -1,13 +1,11 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.data.api.Team;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Borough;
 import uk.gov.justice.digital.delius.jpa.standard.entity.District;
 import uk.gov.justice.digital.delius.jpa.standard.entity.LocalDeliveryUnit;
 
-@Component
 public class TeamTransformer {
     public static Team teamOf(uk.gov.justice.digital.delius.jpa.standard.entity.Team team) {
         return Team.builder().code(team.getCode()).description(team.getDescription())

--- a/src/test/java/uk/gov/justice/digital/delius/service/AppointmentServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/AppointmentServiceTest.java
@@ -35,7 +35,7 @@ public class AppointmentServiceTest {
     @Before
     @SuppressWarnings("unchecked")
     public void before(){
-        service = new AppointmentService(contactRepository, new AppointmentTransformer(new ContactTransformer()));
+        service = new AppointmentService(contactRepository);
         when(contactRepository.findAll(any(Specification.class), any(Sort.class))).thenReturn(ImmutableList.of());
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/ContactService_addContactForBookingNumberUpdateTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ContactService_addContactForBookingNumberUpdateTest.java
@@ -10,7 +10,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Contact;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactTypeRepository;
-import uk.gov.justice.digital.delius.transformers.ContactTransformer;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,7 +19,13 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.justice.digital.delius.util.EntityHelper.*;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aContactType;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aCustodyEvent;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aProbationArea;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aStaff;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aTeam;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anOffender;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anOrderManager;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ContactService_addContactForBookingNumberUpdateTest {
@@ -36,7 +41,7 @@ public class ContactService_addContactForBookingNumberUpdateTest {
 
     @Before
     public void setup() {
-        contactService = new ContactService(contactRepository, contactTypeRepository, new ContactTransformer());
+        contactService = new ContactService(contactRepository, contactTypeRepository);
         when(contactTypeRepository.findByCode(any())).thenReturn(Optional.of(aContactType()));
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/ContactService_addContactForBulkCustodyKeyDateUpdateTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ContactService_addContactForBulkCustodyKeyDateUpdateTest.java
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.delius.service;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -10,7 +10,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Contact;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactTypeRepository;
-import uk.gov.justice.digital.delius.transformers.ContactTransformer;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -22,7 +21,13 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.justice.digital.delius.util.EntityHelper.*;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aContactType;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aCustodyEvent;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aProbationArea;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aStaff;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aTeam;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anOffender;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anOrderManager;
 
 @ExtendWith(MockitoExtension.class)
 public class ContactService_addContactForBulkCustodyKeyDateUpdateTest {
@@ -38,7 +43,7 @@ public class ContactService_addContactForBulkCustodyKeyDateUpdateTest {
 
     @BeforeEach
     public void setup() {
-        contactService = new ContactService(contactRepository, contactTypeRepository, new ContactTransformer());
+        contactService = new ContactService(contactRepository, contactTypeRepository);
         when(contactTypeRepository.findByCode(any())).thenReturn(Optional.of(aContactType()));
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/ContactService_addContactForPOMAllocationTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ContactService_addContactForPOMAllocationTest.java
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.Contact;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactTypeRepository;
-import uk.gov.justice.digital.delius.transformers.ContactTransformer;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -20,7 +19,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.justice.digital.delius.util.EntityHelper.*;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aContactType;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aPrisonOffenderManager;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aPrisonProbationArea;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aStaff;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aTeam;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anActivePrisonOffenderManager;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ContactService_addContactForPOMAllocationTest {
@@ -36,7 +40,7 @@ public class ContactService_addContactForPOMAllocationTest {
 
     @Before
     public void setup() {
-        contactService = new ContactService(contactRepository, contactTypeRepository, new ContactTransformer());
+        contactService = new ContactService(contactRepository, contactTypeRepository);
         when(contactTypeRepository.findByCode(any())).thenReturn(Optional.of(aContactType()));
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/ContactService_addContactForPrisonLocationChangeTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ContactService_addContactForPrisonLocationChangeTest.java
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.Contact;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactTypeRepository;
-import uk.gov.justice.digital.delius.transformers.ContactTransformer;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -22,7 +21,13 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.justice.digital.delius.util.EntityHelper.*;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aContactType;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aCustodyEvent;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aProbationArea;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aStaff;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aTeam;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anOffender;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anOrderManager;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ContactService_addContactForPrisonLocationChangeTest {
@@ -38,7 +43,7 @@ public class ContactService_addContactForPrisonLocationChangeTest {
 
     @Before
     public void setup() {
-        contactService = new ContactService(contactRepository, contactTypeRepository, new ContactTransformer());
+        contactService = new ContactService(contactRepository, contactTypeRepository);
         when(contactTypeRepository.findByCode(any())).thenReturn(Optional.of(aContactType()));
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/ContactService_addContactForResponsibleOfficerChangeTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ContactService_addContactForResponsibleOfficerChangeTest.java
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.Contact;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactTypeRepository;
-import uk.gov.justice.digital.delius.transformers.ContactTransformer;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -21,7 +20,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.justice.digital.delius.util.EntityHelper.*;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aContactType;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aPrisonProbationArea;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aResponsibleOfficer;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aStaff;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aTeam;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anActivePrisonOffenderManager;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ContactService_addContactForResponsibleOfficerChangeTest {
@@ -37,7 +41,7 @@ public class ContactService_addContactForResponsibleOfficerChangeTest {
 
     @Before
     public void setup() {
-        contactService = new ContactService(contactRepository, contactTypeRepository, new ContactTransformer());
+        contactService = new ContactService(contactRepository, contactTypeRepository);
         when(contactTypeRepository.findByCode(any())).thenReturn(Optional.of(aContactType()));
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/ConvictionServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ConvictionServiceTest.java
@@ -14,11 +14,25 @@ import uk.gov.justice.digital.delius.data.api.Conviction;
 import uk.gov.justice.digital.delius.data.api.CourtCase;
 import uk.gov.justice.digital.delius.data.api.OffenceDetail;
 import uk.gov.justice.digital.delius.jpa.national.entity.User;
-import uk.gov.justice.digital.delius.jpa.standard.entity.*;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Court;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Custody;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Disposal;
+import uk.gov.justice.digital.delius.jpa.standard.entity.DisposalType;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Offence;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Staff;
+import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Team;
+import uk.gov.justice.digital.delius.jpa.standard.entity.TransferReason;
 import uk.gov.justice.digital.delius.jpa.standard.repository.EventRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
 import uk.gov.justice.digital.delius.service.ConvictionService.DuplicateConvictionsForBookingNumberException;
-import uk.gov.justice.digital.delius.transformers.*;
+import uk.gov.justice.digital.delius.transformers.AdditionalOffenceTransformer;
+import uk.gov.justice.digital.delius.transformers.CourtAppearanceTransformer;
+import uk.gov.justice.digital.delius.transformers.CustodyKeyDateTransformer;
+import uk.gov.justice.digital.delius.transformers.EventTransformer;
+import uk.gov.justice.digital.delius.transformers.MainOffenceTransformer;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -33,7 +47,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
-@Import({ConvictionService.class, ConvictionTransformer.class, MainOffenceTransformer.class, AdditionalOffenceTransformer.class, CourtAppearanceTransformer.class, CourtReportTransformer.class, CourtTransformer.class, InstitutionTransformer.class, CustodyKeyDateTransformer.class})
+@Import({ConvictionService.class, EventTransformer.class, MainOffenceTransformer.class, AdditionalOffenceTransformer.class, CourtAppearanceTransformer.class, CustodyKeyDateTransformer.class})
 @TestPropertySource(properties = "features.noms.update.keydates=true")
 public class ConvictionServiceTest {
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_AddOrReplaceOrDeleteCustodyKeyDatesTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_AddOrReplaceOrDeleteCustodyKeyDatesTest.java
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.delius.jpa.national.entity.User;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 import uk.gov.justice.digital.delius.jpa.standard.repository.EventRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
-import uk.gov.justice.digital.delius.transformers.ConvictionTransformer;
+import uk.gov.justice.digital.delius.transformers.EventTransformer;
 import uk.gov.justice.digital.delius.transformers.CustodyKeyDateTransformer;
 
 import java.time.LocalDate;
@@ -46,7 +46,7 @@ public class ConvictionService_AddOrReplaceOrDeleteCustodyKeyDatesTest {
     private OffenderRepository offenderRepository;
 
     @Mock
-    private ConvictionTransformer convictionTransformer;
+    private EventTransformer eventTransformer;
 
     @Mock
     private SpgNotificationService spgNotificationService;
@@ -67,7 +67,7 @@ public class ConvictionService_AddOrReplaceOrDeleteCustodyKeyDatesTest {
 
     @BeforeEach
     public void setUp() {
-        convictionService = new ConvictionService(true, eventRepository, offenderRepository, convictionTransformer, spgNotificationService, lookupSupplier, new CustodyKeyDateTransformer(lookupSupplier), iapsNotificationService, contactService);
+        convictionService = new ConvictionService(true, eventRepository, offenderRepository, eventTransformer, spgNotificationService, lookupSupplier, new CustodyKeyDateTransformer(lookupSupplier), iapsNotificationService, contactService);
         when(lookupSupplier.userSupplier()).thenReturn(() -> User.builder().userId(88L).build());
         when(lookupSupplier.custodyKeyDateTypeSupplier()).thenReturn(code -> Optional.of(StandardReference
                 .builder()

--- a/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_AddReplaceCustodyKeyDateTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_AddReplaceCustodyKeyDateTest.java
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.delius.service.ConvictionService.CustodyTypeCodeIs
 import uk.gov.justice.digital.delius.service.ConvictionService.SingleActiveCustodyConvictionNotFoundException;
 import uk.gov.justice.digital.delius.transformers.ConvictionTransformer;
 import uk.gov.justice.digital.delius.transformers.CustodyKeyDateTransformer;
+import uk.gov.justice.digital.delius.transformers.EventTransformer;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -43,7 +44,7 @@ public class ConvictionService_AddReplaceCustodyKeyDateTest {
     private OffenderRepository offenderRepository;
 
     @Mock
-    private ConvictionTransformer convictionTransformer;
+    private EventTransformer eventTransformer;
 
     @Mock
     private SpgNotificationService spgNotificationService;
@@ -62,7 +63,7 @@ public class ConvictionService_AddReplaceCustodyKeyDateTest {
 
     @Before
     public void setUp() {
-        convictionService = new ConvictionService(true, eventRepository, offenderRepository, convictionTransformer, spgNotificationService, lookupSupplier, new CustodyKeyDateTransformer(lookupSupplier), iapsNotificationService, contactService);
+        convictionService = new ConvictionService(true, eventRepository, offenderRepository, eventTransformer, spgNotificationService, lookupSupplier, new CustodyKeyDateTransformer(lookupSupplier), iapsNotificationService, contactService);
         when(lookupSupplier.userSupplier()).thenReturn(() -> User.builder().userId(88L).build());
         when(eventRepository.findByOffenderId(anyLong())).thenReturn(ImmutableList.of(aCustodyEvent()));
         when(lookupSupplier.custodyKeyDateTypeSupplier()).thenReturn(code -> Optional.of(StandardReference

--- a/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_DeleteCustodyKeyDateTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_DeleteCustodyKeyDateTest.java
@@ -13,7 +13,7 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
 import uk.gov.justice.digital.delius.jpa.standard.repository.EventRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
 import uk.gov.justice.digital.delius.service.ConvictionService.SingleActiveCustodyConvictionNotFoundException;
-import uk.gov.justice.digital.delius.transformers.ConvictionTransformer;
+import uk.gov.justice.digital.delius.transformers.EventTransformer;
 import uk.gov.justice.digital.delius.transformers.CustodyKeyDateTransformer;
 
 import java.time.LocalDate;
@@ -38,7 +38,7 @@ public class ConvictionService_DeleteCustodyKeyDateTest {
     private OffenderRepository offenderRepository;
 
     @Mock
-    private ConvictionTransformer convictionTransformer;
+    private EventTransformer eventTransformer;
 
     @Mock
     private SpgNotificationService spgNotificationService;
@@ -58,7 +58,7 @@ public class ConvictionService_DeleteCustodyKeyDateTest {
 
     @Before
     public void setUp() {
-        convictionService = new ConvictionService(true, eventRepository, offenderRepository, convictionTransformer, spgNotificationService, lookupSupplier, new CustodyKeyDateTransformer(lookupSupplier), iapsNotificationService, contactService);
+        convictionService = new ConvictionService(true, eventRepository, offenderRepository, eventTransformer, spgNotificationService, lookupSupplier, new CustodyKeyDateTransformer(lookupSupplier), iapsNotificationService, contactService);
     }
 
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_GetCustodyKeyDateTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_GetCustodyKeyDateTest.java
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
 import uk.gov.justice.digital.delius.service.ConvictionService.SingleActiveCustodyConvictionNotFoundException;
 import uk.gov.justice.digital.delius.transformers.ConvictionTransformer;
 import uk.gov.justice.digital.delius.transformers.CustodyKeyDateTransformer;
+import uk.gov.justice.digital.delius.transformers.EventTransformer;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -36,7 +37,7 @@ public class ConvictionService_GetCustodyKeyDateTest {
     private OffenderRepository offenderRepository;
 
     @Mock
-    private ConvictionTransformer convictionTransformer;
+    private EventTransformer eventTransformer;
 
     @Mock
     private SpgNotificationService spgNotificationService;
@@ -52,7 +53,7 @@ public class ConvictionService_GetCustodyKeyDateTest {
 
     @Before
     public void setUp() {
-        convictionService = new ConvictionService(true, eventRepository, offenderRepository, convictionTransformer, spgNotificationService, lookupSupplier, new CustodyKeyDateTransformer(lookupSupplier), iapsNotificationService, contactService);
+        convictionService = new ConvictionService(true, eventRepository, offenderRepository, eventTransformer, spgNotificationService, lookupSupplier, new CustodyKeyDateTransformer(lookupSupplier), iapsNotificationService, contactService);
         when(eventRepository.findByOffenderId(anyLong())).thenReturn(ImmutableList.of(aCustodyEvent()));
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/DocumentServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/DocumentServiceTest.java
@@ -26,7 +26,7 @@ import static uk.gov.justice.digital.delius.util.EntityHelper.*;
 import static uk.gov.justice.digital.delius.util.OffenderHelper.anOffender;
 
 @RunWith(SpringRunner.class)
-@Import({DocumentService.class, DocumentTransformer.class})
+@Import({DocumentService.class})
 public class DocumentServiceTest {
     @Autowired
     private DocumentService documentService;

--- a/src/test/java/uk/gov/justice/digital/delius/service/OffenderIdentifierServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/OffenderIdentifierServiceTest.java
@@ -11,8 +11,6 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.AdditionalIdentifier;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Offender;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
-import uk.gov.justice.digital.delius.transformers.ContactTransformer;
-import uk.gov.justice.digital.delius.transformers.OffenderTransformer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +37,7 @@ class OffenderIdentifierServiceTest {
     class FeatureSwitchedOff {
         @BeforeEach
         void setUp() {
-            service = new OffenderIdentifierService(false, new OffenderTransformer(new ContactTransformer()), offenderRepository, spgNotificationService, referenceDataService);
+            service = new OffenderIdentifierService(false, offenderRepository, spgNotificationService, referenceDataService);
         }
 
         @Test
@@ -64,7 +62,7 @@ class OffenderIdentifierServiceTest {
     class FeatureSwitchedOn {
         @BeforeEach
         void setUp() {
-            service = new OffenderIdentifierService(true, new OffenderTransformer(new ContactTransformer()), offenderRepository, spgNotificationService, referenceDataService);
+            service = new OffenderIdentifierService(true, offenderRepository, spgNotificationService, referenceDataService);
             when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.empty());
         }
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/OffenderManagerService_allocatePrisonOffenderManagerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/OffenderManagerService_allocatePrisonOffenderManagerTest.java
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.PrisonOffenderManagerRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ProbationAreaRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ResponsibleOfficerRepository;
-import uk.gov.justice.digital.delius.transformers.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -59,12 +58,6 @@ public class OffenderManagerService_allocatePrisonOffenderManagerTest {
     public void setup() {
         offenderManagerService = new OffenderManagerService(
                 offenderRepository,
-                new OffenderManagerTransformer(
-                        new StaffTransformer(
-                                new TeamTransformer()),
-                        new TeamTransformer(),
-                        new ProbationAreaTransformer(
-                                new InstitutionTransformer())),
                 probationAreaRepository,
                 prisonOffenderManagerRepository,
                 responsibleOfficerRepository,

--- a/src/test/java/uk/gov/justice/digital/delius/service/OffenderManagerService_autoAllocatePrisonOffenderManagerAtInstitutionTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/OffenderManagerService_autoAllocatePrisonOffenderManagerAtInstitutionTest.java
@@ -14,7 +14,6 @@ import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.PrisonOffenderManagerRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ProbationAreaRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ResponsibleOfficerRepository;
-import uk.gov.justice.digital.delius.transformers.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -54,12 +53,6 @@ public class OffenderManagerService_autoAllocatePrisonOffenderManagerAtInstituti
     public void setup() {
         offenderManagerService = new OffenderManagerService(
                 offenderRepository,
-                new OffenderManagerTransformer(
-                        new StaffTransformer(
-                                new TeamTransformer()),
-                        new TeamTransformer(),
-                        new ProbationAreaTransformer(
-                                new InstitutionTransformer())),
                 probationAreaRepository,
                 prisonOffenderManagerRepository,
                 responsibleOfficerRepository,

--- a/src/test/java/uk/gov/justice/digital/delius/service/OffenderManagerService_getAllOffenderManagersTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/OffenderManagerService_getAllOffenderManagersTest.java
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.PrisonOffenderManagerRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ProbationAreaRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ResponsibleOfficerRepository;
-import uk.gov.justice.digital.delius.transformers.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -44,12 +43,6 @@ public class OffenderManagerService_getAllOffenderManagersTest {
     public void setup() {
         offenderManagerService = new OffenderManagerService(
                 offenderRepository,
-                new OffenderManagerTransformer(
-                        new StaffTransformer(
-                                new TeamTransformer()),
-                        new TeamTransformer(),
-                        new ProbationAreaTransformer(
-                                new InstitutionTransformer())),
                 probationAreaRepository,
                 prisonOffenderManagerRepository,
                 responsibleOfficerRepository,

--- a/src/test/java/uk/gov/justice/digital/delius/service/OffenderManagerService_isPrisonOffenderManagerAtInstitutionTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/OffenderManagerService_isPrisonOffenderManagerAtInstitutionTest.java
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.PrisonOffenderManagerRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ProbationAreaRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ResponsibleOfficerRepository;
-import uk.gov.justice.digital.delius.transformers.*;
 
 import java.util.List;
 
@@ -41,12 +40,6 @@ public class OffenderManagerService_isPrisonOffenderManagerAtInstitutionTest {
     public void setup() {
         offenderManagerService = new OffenderManagerService(
                 offenderRepository,
-                new OffenderManagerTransformer(
-                        new StaffTransformer(
-                                new TeamTransformer()),
-                        new TeamTransformer(),
-                        new ProbationAreaTransformer(
-                                new InstitutionTransformer())),
                 probationAreaRepository,
                 prisonOffenderManagerRepository,
                 responsibleOfficerRepository,

--- a/src/test/java/uk/gov/justice/digital/delius/service/OffenderServiceTest_getOffenderLatestRecall.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/OffenderServiceTest_getOffenderLatestRecall.java
@@ -14,9 +14,6 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Release;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
-import uk.gov.justice.digital.delius.transformers.ContactTransformer;
-import uk.gov.justice.digital.delius.transformers.OffenderTransformer;
-import uk.gov.justice.digital.delius.transformers.ReleaseTransformer;
 import uk.gov.justice.digital.delius.util.EntityHelper;
 
 import java.time.LocalDateTime;
@@ -41,8 +38,6 @@ public class OffenderServiceTest_getOffenderLatestRecall {
     private OffenderRepository mockOffenderRepository;
     @Mock
     private ConvictionService mockConvictionService;
-    @Mock
-    private ReleaseTransformer mockReleaseTransformer;
 
     private OffenderService offenderService;
 
@@ -50,10 +45,7 @@ public class OffenderServiceTest_getOffenderLatestRecall {
     public void setup() {
         offenderService = new OffenderService(
                 mockOffenderRepository,
-                new OffenderTransformer(
-                        new ContactTransformer()),
-                mockConvictionService,
-                mockReleaseTransformer
+                mockConvictionService
         );
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/ReferenceDataServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ReferenceDataServiceTest.java
@@ -14,8 +14,6 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ProbationAreaRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ReferenceDataMasterRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.StandardReferenceRepository;
-import uk.gov.justice.digital.delius.transformers.InstitutionTransformer;
-import uk.gov.justice.digital.delius.transformers.ProbationAreaTransformer;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,7 +24,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.justice.digital.delius.util.EntityHelper.*;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aBorough;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aDistrict;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aProbationArea;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aTeam;
 
 @ExtendWith(MockitoExtension.class)
 public class ReferenceDataServiceTest {
@@ -45,7 +46,6 @@ public class ReferenceDataServiceTest {
     @BeforeEach
     public void setup() {
         referenceDataService = new ReferenceDataService(
-                new ProbationAreaTransformer(new InstitutionTransformer()),
                 probationAreaRepository,
                 standardReferenceRepository,
                 referenceDataMasterRepository);

--- a/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.Offender;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Requirement;
 import uk.gov.justice.digital.delius.jpa.standard.repository.EventRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
-import uk.gov.justice.digital.delius.transformers.RequirementTransformer;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,8 +28,6 @@ public class RequirementServiceTest {
     private static final String CRN = "CRN";
     public static final Long OFFENDER_ID = 123456789L;
 
-    @Mock
-    private RequirementTransformer transformer;
     @Mock
     private OffenderRepository offenderRepository;
     @Mock
@@ -48,7 +45,7 @@ public class RequirementServiceTest {
 
     @Before
     public void setUp() {
-        requirementService = new RequirementService(offenderRepository, eventRepository, transformer);
+        requirementService = new RequirementService(offenderRepository, eventRepository);
 
         when(offenderRepository.findByCrn(CRN)).thenReturn(Optional.of(offender));
         when(offender.getOffenderId()).thenReturn(OFFENDER_ID);

--- a/src/test/java/uk/gov/justice/digital/delius/service/StaffServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/StaffServiceTest.java
@@ -1,12 +1,5 @@
 package uk.gov.justice.digital.delius.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-import static uk.gov.justice.digital.delius.util.EntityHelper.*;
-
-import java.util.*;
-
 import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,10 +15,21 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.Staff;
 import uk.gov.justice.digital.delius.jpa.standard.repository.StaffHelperRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.StaffRepository;
 import uk.gov.justice.digital.delius.ldap.repository.LdapRepository;
-import uk.gov.justice.digital.delius.transformers.ContactTransformer;
-import uk.gov.justice.digital.delius.transformers.OffenderTransformer;
-import uk.gov.justice.digital.delius.transformers.StaffTransformer;
-import uk.gov.justice.digital.delius.transformers.TeamTransformer;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aProbationArea;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aStaff;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aUser;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StaffServiceTest {
@@ -49,8 +53,6 @@ public class StaffServiceTest {
         staffService = new StaffService(
                 staffRepository,
                 ldapRepository,
-                new OffenderTransformer(new ContactTransformer()),
-                new StaffTransformer(new TeamTransformer()),
                 staffHelperRepository);
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AdditionalOffenceTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AdditionalOffenceTransformerTest.java
@@ -8,10 +8,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.justice.digital.delius.data.api.OffenceDetail;
 import uk.gov.justice.digital.delius.jpa.national.entity.User;
-import uk.gov.justice.digital.delius.jpa.standard.entity.AdditionalOffence;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Offence;
-import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 import uk.gov.justice.digital.delius.service.LookupSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,64 +28,6 @@ public class AdditionalOffenceTransformerTest {
         when(lookupSupplier.userSupplier()).thenReturn(() -> User.builder().userId(99L).build());
         when(lookupSupplier.offenceSupplier()).thenReturn((code) -> Offence.builder().offenceId(88L).build());
     }
-    @Test
-    public void itFiltersOutSoftDeletedEntries() {
-
-        ImmutableList<AdditionalOffence> additionalOffences = ImmutableList.of(
-            AdditionalOffence.builder()
-                .additionalOffenceId(1L)
-                .offence(Offence.builder()
-                    .ogrsOffenceCategory(StandardReference.builder().build())
-                    .build())
-                .build(),
-            AdditionalOffence.builder()
-                .additionalOffenceId(2L)
-                .offence(Offence.builder()
-                    .ogrsOffenceCategory(StandardReference.builder().build())
-                    .build())
-                .softDeleted(1L)
-                .build(),
-            AdditionalOffence.builder()
-                .additionalOffenceId(3L)
-                .offence(Offence.builder()
-                    .ogrsOffenceCategory(StandardReference.builder().build())
-                    .build())
-                .build()
-        );
-
-        assertThat(AdditionalOffenceTransformer.offencesOf(additionalOffences))
-            .extracting("offenceId").containsOnly("A1", "A3");
-    }
-
-
-    @Test
-    public void itConvertsTheIdCorrectly() {
-        ImmutableList<AdditionalOffence> additionalOffences = ImmutableList.of(
-            AdditionalOffence.builder()
-                .additionalOffenceId(92L)
-                .offence(Offence.builder()
-                    .ogrsOffenceCategory(StandardReference.builder().build())
-                    .build())
-                .build()
-        );
-
-        assertThat(AdditionalOffenceTransformer.offencesOf(additionalOffences).get(0).getOffenceId())
-            .isEqualTo("A92");
-    }
-
-    @Test
-    public void itSetsTheMainOffenceFlagToFalse() {
-        ImmutableList<AdditionalOffence> additionalOffences = ImmutableList.of(
-            AdditionalOffence.builder()
-                .offence(Offence.builder()
-                    .ogrsOffenceCategory(StandardReference.builder().build())
-                    .build())
-                .build()
-        );
-
-        assertThat(AdditionalOffenceTransformer.offencesOf(additionalOffences).get(0).getMainOffence()).isFalse();
-    }
-
 
     @Test
     public void eachOffenceIsCopied() {

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentTransformerTest.java
@@ -1,21 +1,22 @@
 package uk.gov.justice.digital.delius.transformers;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
 import org.junit.Test;
 import uk.gov.justice.digital.delius.data.api.Appointment;
-import uk.gov.justice.digital.delius.jpa.standard.entity.*;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Contact;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ContactOutcomeType;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ContactType;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Explanation;
+import uk.gov.justice.digital.delius.jpa.standard.entity.LicenceCondition;
+import uk.gov.justice.digital.delius.jpa.standard.entity.OfficeLocation;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Requirement;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Staff;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Team;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AppointmentTransformerTest {
-    private AppointmentTransformer transformer;
-
-    @Before
-    public void before() {
-        transformer = new AppointmentTransformer(new ContactTransformer());
-    }
-
     @Test
     public void appointmentOutcomeMappedFromContactOutcomeType() {
         assertThat(AppointmentTransformer.appointmentsOf(ImmutableList.of(

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceTransformerTest.java
@@ -31,7 +31,7 @@ public class CourtAppearanceTransformerTest {
 
     @Before
     public void setup() {
-        courtAppearanceTransformer = new CourtAppearanceTransformer(new CourtReportTransformer(new CourtTransformer()), new CourtTransformer(), lookupSupplier);
+        courtAppearanceTransformer = new CourtAppearanceTransformer(lookupSupplier);
         when(lookupSupplier.userSupplier()).thenReturn(() -> User.builder().userId(99L).build());
         when(lookupSupplier.courtAppearanceOutcomeSupplier()).thenReturn(code -> StandardReference.builder().codeValue(code).build());
         when(lookupSupplier.courtSupplier()).thenReturn(courtId -> Court.builder().courtId(courtId).build());

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/InstitutionTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/InstitutionTransformerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.junit.Before;
 import org.junit.Test;
 import uk.gov.justice.digital.delius.jpa.standard.entity.RInstitution;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
@@ -8,38 +7,31 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class InstitutionTransformerTest {
-    private InstitutionTransformer institutionTransformer;
-
-    @Before
-    public void before() {
-        institutionTransformer = new InstitutionTransformer();
-    }
-
     @Test
     public void isEstablishmentIsConvertedToBoolean() {
-        assertThat(institutionTransformer.institutionOf(
+        assertThat(InstitutionTransformer.institutionOf(
                 anInstitution().toBuilder().establishment("Y").build()
         ).getIsEstablishment()).isTrue();
 
-        assertThat(institutionTransformer.institutionOf(
+        assertThat(InstitutionTransformer.institutionOf(
                 anInstitution().toBuilder().establishment("N").build()
         ).getIsEstablishment()).isFalse();
     }
 
     @Test
     public void isPrivateIsConvertedToBoolean() {
-        assertThat(institutionTransformer.institutionOf(
+        assertThat(InstitutionTransformer.institutionOf(
                 anInstitution().toBuilder().privateFlag(1L).build()
         ).getIsPrivate()).isTrue();
 
-        assertThat(institutionTransformer.institutionOf(
+        assertThat(InstitutionTransformer.institutionOf(
                 anInstitution().toBuilder().privateFlag(0L).build()
         ).getIsPrivate()).isFalse();
     }
 
     @Test
     public void establishmentTypeConvertedToKeyValuePair() {
-        assertThat(institutionTransformer.institutionOf(
+        assertThat(InstitutionTransformer.institutionOf(
                 anInstitution().toBuilder().establishmentType(StandardReference
                         .builder()
                         .codeValue("XX")

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/InstitutionalReportTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/InstitutionalReportTransformerTest.java
@@ -1,42 +1,17 @@
 package uk.gov.justice.digital.delius.transformers;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Custody;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Disposal;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
 import uk.gov.justice.digital.delius.jpa.standard.entity.InstitutionalReport;
-import uk.gov.justice.digital.delius.service.LookupSupplier;
 
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(MockitoJUnitRunner.class)
 public class InstitutionalReportTransformerTest {
-    @Mock
-    private LookupSupplier lookupSupplier;
-    private InstitutionalReportTransformer institutionalReportTransformer;
-
-    @Before
-    public void setup() {
-        institutionalReportTransformer = new InstitutionalReportTransformer(
-                new ConvictionTransformer(
-                        new MainOffenceTransformer(lookupSupplier),
-                        new AdditionalOffenceTransformer(lookupSupplier),
-                        new CourtAppearanceTransformer(
-                                new CourtReportTransformer(
-                                        new CourtTransformer()),
-                                new CourtTransformer(),
-                                lookupSupplier),
-                        lookupSupplier,
-                        new InstitutionTransformer()));
-    }
-
     @Test
     public void itTransformsOKWhenNothingIsSoftDeleted() {
         InstitutionalReport institutionalReport =
@@ -47,7 +22,7 @@ public class InstitutionalReportTransformerTest {
                 .softDeleted(1L)
                 .build();
 
-        assertThat(institutionalReportTransformer.institutionalReportOf(institutionalReport)).isNotNull();
+        assertThat(InstitutionalReportTransformer.institutionalReportOf(institutionalReport)).isNotNull();
     }
 
     @Test
@@ -60,7 +35,7 @@ public class InstitutionalReportTransformerTest {
                 .softDeleted(1L)
                 .build();
 
-        assertThat(institutionalReportTransformer.institutionalReportOf(institutionalReport).getConviction()).isNull();
+        assertThat(InstitutionalReportTransformer.institutionalReportOf(institutionalReport).getConviction()).isNull();
     }
 
     @Test
@@ -73,7 +48,7 @@ public class InstitutionalReportTransformerTest {
                 .softDeleted(1L)
                 .build();
 
-        assertThat(institutionalReportTransformer.institutionalReportOf(institutionalReport).getConviction()).isNull();
+        assertThat(InstitutionalReportTransformer.institutionalReportOf(institutionalReport).getConviction()).isNull();
     }
 
     @Test
@@ -86,7 +61,7 @@ public class InstitutionalReportTransformerTest {
                 .softDeleted(1L)
                 .build();
 
-        assertThat(institutionalReportTransformer.institutionalReportOf(institutionalReport).getConviction()).isNull();
+        assertThat(InstitutionalReportTransformer.institutionalReportOf(institutionalReport).getConviction()).isNull();
     }
 
 

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/MainOffenceTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/MainOffenceTransformerTest.java
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.delius.jpa.national.entity.User;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
 import uk.gov.justice.digital.delius.jpa.standard.entity.MainOffence;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Offence;
-import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 import uk.gov.justice.digital.delius.service.LookupSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,29 +28,6 @@ public class MainOffenceTransformerTest {
         when(lookupSupplier.userSupplier()).thenReturn(() -> User.builder().userId(99L).build());
         when(lookupSupplier.offenceSupplier()).thenReturn(code -> Offence.builder().code(code).build());
 
-    }
-
-    @Test
-    public void itConvertsTheIdCorrectly() {
-        MainOffence mainOffence = MainOffence.builder()
-            .mainOffenceId(92L)
-            .offence(Offence.builder()
-                .ogrsOffenceCategory(StandardReference.builder().build())
-                .build())
-            .build();
-
-        assertThat(MainOffenceTransformer.offenceOf(mainOffence).getOffenceId()).isEqualTo("M92");
-    }
-
-    @Test
-    public void itSetsTheMainOffenceFlagToTrue() {
-        MainOffence mainOffence = MainOffence.builder()
-            .offence(Offence.builder()
-                .ogrsOffenceCategory(StandardReference.builder().build())
-                .build())
-            .build();
-
-        assertThat(MainOffenceTransformer.offenceOf(mainOffence).getMainOffence()).isTrue();
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/OffenceTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/OffenceTransformerTest.java
@@ -1,0 +1,95 @@
+package uk.gov.justice.digital.delius.transformers;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import uk.gov.justice.digital.delius.jpa.standard.entity.AdditionalOffence;
+import uk.gov.justice.digital.delius.jpa.standard.entity.MainOffence;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Offence;
+import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OffenceTransformerTest {
+    @Test
+    public void itFiltersOutSoftDeletedEntries() {
+
+        ImmutableList<AdditionalOffence> additionalOffences = ImmutableList.of(
+            AdditionalOffence.builder()
+                .additionalOffenceId(1L)
+                .offence(Offence.builder()
+                    .ogrsOffenceCategory(StandardReference.builder().build())
+                    .build())
+                .build(),
+            AdditionalOffence.builder()
+                .additionalOffenceId(2L)
+                .offence(Offence.builder()
+                    .ogrsOffenceCategory(StandardReference.builder().build())
+                    .build())
+                .softDeleted(1L)
+                .build(),
+            AdditionalOffence.builder()
+                .additionalOffenceId(3L)
+                .offence(Offence.builder()
+                    .ogrsOffenceCategory(StandardReference.builder().build())
+                    .build())
+                .build()
+        );
+
+        assertThat(OffenceTransformer.offencesOf(additionalOffences))
+            .extracting("offenceId").containsOnly("A1", "A3");
+    }
+
+
+    @Test
+    public void itConvertsTheIdCorrectly() {
+        ImmutableList<AdditionalOffence> additionalOffences = ImmutableList.of(
+            AdditionalOffence.builder()
+                .additionalOffenceId(92L)
+                .offence(Offence.builder()
+                    .ogrsOffenceCategory(StandardReference.builder().build())
+                    .build())
+                .build()
+        );
+
+        assertThat(OffenceTransformer.offencesOf(additionalOffences).get(0).getOffenceId())
+            .isEqualTo("A92");
+    }
+
+    @Test
+    public void itSetsTheMainOffenceFlagToFalse() {
+        ImmutableList<AdditionalOffence> additionalOffences = ImmutableList.of(
+            AdditionalOffence.builder()
+                .offence(Offence.builder()
+                    .ogrsOffenceCategory(StandardReference.builder().build())
+                    .build())
+                .build()
+        );
+
+        assertThat(OffenceTransformer.offencesOf(additionalOffences).get(0).getMainOffence()).isFalse();
+    }
+
+    @Test
+    public void itConvertsMainOffenceIdCorrectly() {
+        MainOffence mainOffence = MainOffence.builder()
+                .mainOffenceId(92L)
+                .offence(Offence.builder()
+                        .ogrsOffenceCategory(StandardReference.builder().build())
+                        .build())
+                .build();
+
+        assertThat(OffenceTransformer.offenceOf(mainOffence).getOffenceId()).isEqualTo("M92");
+    }
+
+    @Test
+    public void itSetsTheMainOffenceFlagToTrue() {
+        MainOffence mainOffence = MainOffence.builder()
+                .offence(Offence.builder()
+                        .ogrsOffenceCategory(StandardReference.builder().build())
+                        .build())
+                .build();
+
+        assertThat(OffenceTransformer.offenceOf(mainOffence).getMainOffence()).isTrue();
+    }
+
+
+}

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/OffenderManagerTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/OffenderManagerTransformerTest.java
@@ -10,13 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.justice.digital.delius.util.EntityHelper.*;
 
 public class OffenderManagerTransformerTest {
-    private final OffenderManagerTransformer offenderManagerTransformer =
-            new OffenderManagerTransformer(
-                    new StaffTransformer(
-                            new TeamTransformer()),
-                    new TeamTransformer(),
-                    new ProbationAreaTransformer(
-                            new InstitutionTransformer()));
 
     @Test
     public void staffNameDetailsTakenFromStaffInOffenderManager() {

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/OffenderTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/OffenderTransformerTest.java
@@ -28,7 +28,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.justice.digital.delius.util.OffenderHelper.anOffender;
 
 public class OffenderTransformerTest {
-    private OffenderTransformer offenderTransformer = new OffenderTransformer(new ContactTransformer());
 
     @Test
     public void offenderManagerAllocationReasonMappedFromAllocationReasonInOffenderTransfer() {

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.junit.Before;
 import org.junit.Test;
 import uk.gov.justice.digital.delius.jpa.standard.entity.CircumstanceSubType;
 import uk.gov.justice.digital.delius.jpa.standard.entity.CircumstanceType;
@@ -10,12 +9,6 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class PersonalCircumstanceTransformerTest {
-    private PersonalCircumstanceTransformer transformer;
-
-    @Before
-    public void before() {
-        transformer = new PersonalCircumstanceTransformer();
-    }
 
     @Test
     public void probationAreasMappedOnlyWhenNotNull() {

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/ProbationAreaTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/ProbationAreaTransformerTest.java
@@ -23,7 +23,6 @@ class ProbationAreaTransformerTest {
     private ProviderTeam providerTeam;
 
     private ProbationArea probationArea;
-    private final ProbationAreaTransformer probationAreaTransformer = new ProbationAreaTransformer();
 
     @BeforeEach
     public void setUp() {
@@ -38,7 +37,7 @@ class ProbationAreaTransformerTest {
         when(team.getCode()).thenReturn("team");
         when(providerTeam.getCode()).thenReturn("providerteam");
 
-        var result = probationAreaTransformer.probationAreaOf(probationArea);
+        var result = ProbationAreaTransformer.probationAreaOf(probationArea);
         assertThat(result.getTeams()).hasSize(2);
         assertThat(result.getTeams().get(0).getCode()).isEqualTo("team");
         assertThat(result.getTeams().get(1).getCode()).isEqualTo("providerteam");

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/RecallTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/RecallTransformerTest.java
@@ -18,8 +18,6 @@ public class RecallTransformerTest {
     private static final String SOME_REASON = "This is a reason";
     private static final String SOME_NOTES = "Here are some notes";
 
-    private RecallTransformer recallTransformer = new RecallTransformer();
-
     @Test
     public void offenderRecallOf_valuesMappedCorrectly() {
         Recall recall = Recall.builder()

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/RegistrationTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/RegistrationTransformerTest.java
@@ -1,20 +1,19 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.junit.Before;
 import org.junit.Test;
-import uk.gov.justice.digital.delius.jpa.standard.entity.*;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Deregistration;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea;
+import uk.gov.justice.digital.delius.jpa.standard.entity.RegisterType;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Registration;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Staff;
+import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Team;
 
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RegistrationTransformerTest {
-    private RegistrationTransformer transformer;
-
-    @Before
-    public void before() {
-        transformer = new RegistrationTransformer(new ContactTransformer());
-    }
 
     @Test
     public void registerMappedFromRegisterTypeFlagReferenceData() {

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/ReleaseTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/ReleaseTransformerTest.java
@@ -2,12 +2,8 @@ package uk.gov.justice.digital.delius.transformers;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.justice.digital.delius.data.api.Institution;
 import uk.gov.justice.digital.delius.data.api.OffenderLatestRecall;
-import uk.gov.justice.digital.delius.data.api.OffenderRecall;
 import uk.gov.justice.digital.delius.data.api.OffenderRelease;
 import uk.gov.justice.digital.delius.jpa.standard.entity.RInstitution;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Recall;
@@ -19,9 +15,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ReleaseTransformerTest {
@@ -32,12 +25,8 @@ public class ReleaseTransformerTest {
     private final RInstitution SOME_R_INSTITUTION = RInstitution.builder().code("MDI").description("HMP Moorland").build();
     private final String SOME_NOTES = "These are notes";
     private final StandardReference SOME_REASON = StandardReference.builder().codeValue("CODE_VALUE").codeDescription("Code description").build();
-    private final OffenderRecall SOME_OFFENDER_RECALL = OffenderRecall.builder().date(SOME_DATE).build();
     private final String SOME_RELEASE_TYPE_CODE = "The release type code";
     private final String SOME_RELEASE_TYPE = "The release type";
-
-    @InjectMocks
-    private ReleaseTransformer releaseTransformer;
 
     @Test
     public void offenderReleaseOf_valuesMappedCorrectly() {

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/StaffTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/StaffTransformerTest.java
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.delius.data.api.Human;
 import uk.gov.justice.digital.delius.jpa.standard.entity.User;
 
 public class StaffTransformerTest {
-    private StaffTransformer staffTransformer = new StaffTransformer(new TeamTransformer());
 
     @Test
     public void staffNameDetailsTakenFromStaff() {

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/TeamTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/TeamTransformerTest.java
@@ -10,11 +10,10 @@ import static uk.gov.justice.digital.delius.util.EntityHelper.aDistrict;
 import static uk.gov.justice.digital.delius.util.EntityHelper.aTeam;
 
 public class TeamTransformerTest {
-    private TeamTransformer teamTransformer = new TeamTransformer();
 
     @Test
     public void willCopyCode() {
-        assertThat(teamTransformer.teamOf(
+        assertThat(TeamTransformer.teamOf(
             aTeam().toBuilder().code("ABC").build()).getCode())
                 .isEqualTo("ABC");
 
@@ -22,7 +21,7 @@ public class TeamTransformerTest {
 
     @Test
     public void willCopyDescription() {
-        assertThat(teamTransformer.teamOf(
+        assertThat(TeamTransformer.teamOf(
             aTeam().toBuilder().description("My Description").build()).getDescription())
                 .isEqualTo("My Description");
 
@@ -30,7 +29,7 @@ public class TeamTransformerTest {
 
     @Test
     public void willCopyTelephone() {
-        assertThat(teamTransformer.teamOf(aTeam().toBuilder().telephone("0114 222 4444").build()).getTelephone())
+        assertThat(TeamTransformer.teamOf(aTeam().toBuilder().telephone("0114 222 4444").build()).getTelephone())
                 .isEqualTo("0114 222 4444");
 
     }
@@ -38,7 +37,7 @@ public class TeamTransformerTest {
     @Test
     public void willCopyDistrict() {
         assertThat(
-                teamTransformer
+                TeamTransformer
                         .teamOf(aTeam().toBuilder()
                                 .district(aDistrict().toBuilder().code("AA")
                                         .description("My Description").build())
@@ -50,7 +49,7 @@ public class TeamTransformerTest {
 
     @Test
     public void willCopyDistrictAcrossAsLocalDeliveryUnit() {
-        assertThat(teamTransformer
+        assertThat(TeamTransformer
                 .teamOf(aTeam().toBuilder()
                         .district(aDistrict().toBuilder()
                                 .code("LL")
@@ -62,7 +61,7 @@ public class TeamTransformerTest {
 
     @Test
     public void willCopyLduAcrossAsTeamType() {
-        assertThat(teamTransformer
+        assertThat(TeamTransformer
                 .teamOf(aTeam().toBuilder()
                         .localDeliveryUnit(LocalDeliveryUnit.builder().code("LL")
                                 .description("My Description").build())
@@ -73,7 +72,7 @@ public class TeamTransformerTest {
 
     @Test
     public void willCopyBorough() {
-        assertThat(teamTransformer.teamOf(aTeam()
+        assertThat(TeamTransformer.teamOf(aTeam()
                 .toBuilder()
                 .district(District
                     .builder()


### PR DESCRIPTION
Part 2 of clearing up the mess that has become Transformer tree nightmare.

This PR splits a couple of the transformers into two

1. One creates model objects from entities
2. The other created entities from models

All transformers that are no longer beans have been removed from constructors