### PR TITLE
DT-864 Convert Spring tests to pure unit tests and split out entity builders

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/entitybuilders/AdditionalOffenceEntityBuilder.java
+++ b/src/main/java/uk/gov/justice/digital/delius/entitybuilders/AdditionalOffenceEntityBuilder.java
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.delius.transformers;
+package uk.gov.justice.digital.delius.entitybuilders;
 
 import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.Offence;
@@ -12,10 +12,10 @@ import java.util.List;
 import static java.util.stream.Collectors.toList;
 
 @Component
-public class AdditionalOffenceTransformer {
+public class AdditionalOffenceEntityBuilder {
     private final LookupSupplier lookupSupplier;
 
-    public AdditionalOffenceTransformer(LookupSupplier lookupSupplier) {
+    public AdditionalOffenceEntityBuilder(LookupSupplier lookupSupplier) {
         this.lookupSupplier = lookupSupplier;
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/entitybuilders/CourtAppearanceEntityBuilder.java
+++ b/src/main/java/uk/gov/justice/digital/delius/entitybuilders/CourtAppearanceEntityBuilder.java
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.delius.entitybuilders;
+
+import org.springframework.stereotype.Component;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
+import uk.gov.justice.digital.delius.service.LookupSupplier;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Component
+public class CourtAppearanceEntityBuilder {
+    private final LookupSupplier lookupSupplier;
+
+    public CourtAppearanceEntityBuilder(LookupSupplier lookupSupplier) {
+        this.lookupSupplier = lookupSupplier;
+    }
+
+    public uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance courtAppearanceOf(
+            Long offenderId,
+            Event event,
+            uk.gov.justice.digital.delius.data.api.CourtAppearance courtAppearance) {
+        return uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance
+                .builder()
+                .appearanceDate(courtAppearance.getAppearanceDate())
+                .courtReports(null) // TODO adding court reports is a future task
+                .teamId(null) // TODO associating with a team is a future task depending on research
+                .staffId(null) // TODO associating with a team is a future task depending on research
+                .event(event)
+                .offenderId(offenderId)
+                .softDeleted(0L)
+                .outcome(Optional.ofNullable(courtAppearance.getOutcome())
+                        .map(outcome -> lookupSupplier.courtAppearanceOutcomeSupplier().apply(outcome.getCode()))
+                        .orElse(null))
+                .courtNotes(courtAppearance.getCourtNotes())
+                .bailConditions(courtAppearance.getBailConditions())
+                .createdByUserId(lookupSupplier.userSupplier().get().getUserId())
+                .createdDatetime(LocalDateTime.now())
+                .lastUpdatedUserId(lookupSupplier.userSupplier().get().getUserId())
+                .lastUpdatedDatetime(LocalDateTime.now())
+                .court(lookupSupplier.courtSupplier().apply(courtAppearance.getCourt().getCourtId()))
+                .appearanceTypeId(courtAppearance.getAppearanceTypeId())
+                .crownCourtCalendarNumber(courtAppearance.getCrownCourtCalendarNumber())
+                .partitionAreaId(0L)
+                .remandStatusId(courtAppearance.getRemandStatusId())
+                .pleaId(courtAppearance.getPleaId())
+                .rowVersion(1L)
+                .build();
+    }
+
+
+}

--- a/src/main/java/uk/gov/justice/digital/delius/entitybuilders/EventEntityBuilder.java
+++ b/src/main/java/uk/gov/justice/digital/delius/entitybuilders/EventEntityBuilder.java
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.delius.transformers;
+package uk.gov.justice.digital.delius.entitybuilders;
 
 import com.google.common.collect.ImmutableList;
 import lombok.val;
@@ -20,16 +20,16 @@ import static uk.gov.justice.digital.delius.service.LookupSupplier.INITIAL_ORDER
 import static uk.gov.justice.digital.delius.service.LookupSupplier.TRANSFER_CASE_INITIAL_REASON;
 
 @Component
-public class EventTransformer {
-    private final MainOffenceTransformer mainOffenceTransformer;
-    private final AdditionalOffenceTransformer additionalOffenceTransformer;
-    private final CourtAppearanceTransformer courtAppearanceTransformer;
+public class EventEntityBuilder {
+    private final MainOffenceEntityBuilder mainOffenceEntityBuilder;
+    private final AdditionalOffenceEntityBuilder additionalOffenceEntityBuilder;
+    private final CourtAppearanceEntityBuilder courtAppearanceEntityBuilder;
     private final LookupSupplier lookupSupplier;
 
-    public EventTransformer(MainOffenceTransformer mainOffenceTransformer, AdditionalOffenceTransformer additionalOffenceTransformer, CourtAppearanceTransformer courtAppearanceTransformer, LookupSupplier lookupSupplier) {
-        this.mainOffenceTransformer = mainOffenceTransformer;
-        this.additionalOffenceTransformer = additionalOffenceTransformer;
-        this.courtAppearanceTransformer = courtAppearanceTransformer;
+    public EventEntityBuilder(MainOffenceEntityBuilder mainOffenceEntityBuilder, AdditionalOffenceEntityBuilder additionalOffenceEntityBuilder, CourtAppearanceEntityBuilder courtAppearanceEntityBuilder, LookupSupplier lookupSupplier) {
+        this.mainOffenceEntityBuilder = mainOffenceEntityBuilder;
+        this.additionalOffenceEntityBuilder = additionalOffenceEntityBuilder;
+        this.courtAppearanceEntityBuilder = courtAppearanceEntityBuilder;
         this.lookupSupplier = lookupSupplier;
     }
 
@@ -58,8 +58,8 @@ public class EventTransformer {
                 .postSentenceSupervisionRequirementFlag(0L)
                 .build();
 
-        event.setMainOffence(mainOffenceTransformer.mainOffenceOf(offenderId, mainOffence(courtCase.getOffences()), event));
-        event.setAdditionalOffences(additionalOffenceTransformer.additionalOffencesOf(additionalOffences(courtCase.getOffences()), event));
+        event.setMainOffence(mainOffenceEntityBuilder.mainOffenceOf(offenderId, mainOffence(courtCase.getOffences()), event));
+        event.setAdditionalOffences(additionalOffenceEntityBuilder.additionalOffencesOf(additionalOffences(courtCase.getOffences()), event));
         event.setCourtAppearances(courtAppearances(offenderId, event, courtCase.getCourtAppearance(), courtCase.getNextAppearance()));
         event.setOrderManagers(ImmutableList.of(orderManager(courtCase.getOrderManager(), event)));
 
@@ -105,8 +105,8 @@ public class EventTransformer {
             Event event,
             uk.gov.justice.digital.delius.data.api.CourtAppearance first,
             uk.gov.justice.digital.delius.data.api.CourtAppearance next) {
-        val builder = ImmutableList.<CourtAppearance>builder().add(courtAppearanceTransformer.courtAppearanceOf(offenderId, event, first));
-        return Optional.ofNullable(next).map(courtAppearance -> builder.add(courtAppearanceTransformer.courtAppearanceOf(offenderId, event, courtAppearance))).orElse(builder).build();
+        val builder = ImmutableList.<CourtAppearance>builder().add(courtAppearanceEntityBuilder.courtAppearanceOf(offenderId, event, first));
+        return Optional.ofNullable(next).map(courtAppearance -> builder.add(courtAppearanceEntityBuilder.courtAppearanceOf(offenderId, event, courtAppearance))).orElse(builder).build();
     }
 
 }

--- a/src/main/java/uk/gov/justice/digital/delius/entitybuilders/KeyDateEntityBuilder.java
+++ b/src/main/java/uk/gov/justice/digital/delius/entitybuilders/KeyDateEntityBuilder.java
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.delius.entitybuilders;
+
+import org.springframework.stereotype.Component;
+import uk.gov.justice.digital.delius.jpa.standard.entity.KeyDate;
+import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
+import uk.gov.justice.digital.delius.service.LookupSupplier;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Component
+public class KeyDateEntityBuilder {
+    private LookupSupplier lookupSupplier;
+
+    public KeyDateEntityBuilder(LookupSupplier lookupSupplier) {
+        this.lookupSupplier = lookupSupplier;
+    }
+
+    public KeyDate keyDateOf(uk.gov.justice.digital.delius.jpa.standard.entity.Custody custody, StandardReference keyDateType, LocalDate date) {
+        return KeyDate
+                .builder()
+                .createdByUserId(lookupSupplier.userSupplier().get().getUserId())
+                .createdDatetime(LocalDateTime.now())
+                .lastUpdatedUserId(lookupSupplier.userSupplier().get().getUserId())
+                .lastUpdatedDatetime(LocalDateTime.now())
+                .custody(custody)
+                .keyDate(date)
+                .keyDateType(keyDateType)
+                .partitionAreaId(0L)
+                .softDeleted(0L)
+                .rowVersion(1L)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/delius/entitybuilders/MainOffenceEntityBuilder.java
+++ b/src/main/java/uk/gov/justice/digital/delius/entitybuilders/MainOffenceEntityBuilder.java
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.delius.transformers;
+package uk.gov.justice.digital.delius.entitybuilders;
 
 import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.Offence;
@@ -9,10 +9,10 @@ import uk.gov.justice.digital.delius.service.LookupSupplier;
 import java.time.LocalDateTime;
 
 @Component
-public class MainOffenceTransformer {
+public class MainOffenceEntityBuilder {
     private final LookupSupplier lookupSupplier;
 
-    public MainOffenceTransformer(LookupSupplier lookupSupplier) {
+    public MainOffenceEntityBuilder(LookupSupplier lookupSupplier) {
         this.lookupSupplier = lookupSupplier;
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/service/ConvictionService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ConvictionService.java
@@ -15,7 +15,8 @@ import uk.gov.justice.digital.delius.jpa.standard.repository.EventRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
 import uk.gov.justice.digital.delius.transformers.ConvictionTransformer;
 import uk.gov.justice.digital.delius.transformers.CustodyKeyDateTransformer;
-import uk.gov.justice.digital.delius.transformers.EventTransformer;
+import uk.gov.justice.digital.delius.entitybuilders.EventEntityBuilder;
+import uk.gov.justice.digital.delius.entitybuilders.KeyDateEntityBuilder;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -38,8 +39,8 @@ public class ConvictionService {
     private final Boolean updateCustodyKeyDatesFeatureSwitch;
     private final EventRepository eventRepository;
     private final OffenderRepository offenderRepository;
-    private final EventTransformer eventTransformer;
-    private final CustodyKeyDateTransformer custodyKeyDateTransformer;
+    private final EventEntityBuilder eventEntityBuilder;
+    private final KeyDateEntityBuilder keyDateEntityBuilder;
     private final IAPSNotificationService iapsNotificationService;
     private final SpgNotificationService spgNotificationService;
     private final LookupSupplier lookupSupplier;
@@ -87,19 +88,19 @@ public class ConvictionService {
                     Boolean updateCustodyKeyDatesFeatureSwitch,
             EventRepository eventRepository,
             OffenderRepository offenderRepository,
-            EventTransformer eventTransformer,
+            EventEntityBuilder eventEntityBuilder,
             SpgNotificationService spgNotificationService,
             LookupSupplier lookupSupplier,
-            CustodyKeyDateTransformer custodyKeyDateTransformer,
+            KeyDateEntityBuilder keyDateEntityBuilder,
             IAPSNotificationService iapsNotificationService,
             ContactService contactService) {
         this.updateCustodyKeyDatesFeatureSwitch = updateCustodyKeyDatesFeatureSwitch;
         this.eventRepository = eventRepository;
         this.offenderRepository = offenderRepository;
-        this.eventTransformer = eventTransformer;
+        this.eventEntityBuilder = eventEntityBuilder;
+        this.keyDateEntityBuilder = keyDateEntityBuilder;
         this.spgNotificationService = spgNotificationService;
         this.lookupSupplier = lookupSupplier;
-        this.custodyKeyDateTransformer = custodyKeyDateTransformer;
         this.iapsNotificationService = iapsNotificationService;
         this.contactService = contactService;
         log.info("NOMIS update custody key dates feature is {}", updateCustodyKeyDatesFeatureSwitch ? "ON" : "OFF");
@@ -127,7 +128,7 @@ public class ConvictionService {
 
     @Transactional
     public Conviction addCourtCaseFor(Long offenderId, CourtCase courtCase) {
-        val event = eventTransformer.eventOf(
+        val event = eventEntityBuilder.eventOf(
                 offenderId,
                 courtCase,
                 calculateNextEventNumber(offenderId));
@@ -394,7 +395,7 @@ public class ConvictionService {
         });
 
         if (maybeExistingKeyDate.isEmpty()) {
-            val keyDate = custodyKeyDateTransformer.keyDateOf(event.getDisposal().getCustody(), custodyKeyDateType, custodyKeyDate.getDate());
+            val keyDate = keyDateEntityBuilder.keyDateOf(event.getDisposal().getCustody(), custodyKeyDateType, custodyKeyDate.getDate());
             event.getDisposal()
                     .getCustody()
                     .getKeyDates()

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceTransformer.java
@@ -1,27 +1,17 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.CourtAppearance;
 import uk.gov.justice.digital.delius.data.api.CourtReport;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
-import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
-import uk.gov.justice.digital.delius.service.LookupSupplier;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import static java.util.stream.Collectors.toList;
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.convertToBoolean;
 
-@Component
 public class CourtAppearanceTransformer {
-    private final LookupSupplier lookupSupplier;
-
-    public CourtAppearanceTransformer(LookupSupplier lookupSupplier) {
-        this.lookupSupplier = lookupSupplier;
-    }
 
     public static CourtAppearance courtAppearanceOf(uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance courtAppearance) {
         return CourtAppearance.builder()
@@ -43,36 +33,6 @@ public class CourtAppearanceTransformer {
             .offenderId(courtAppearance.getOffenderId())
             .courtReports(CourtAppearanceTransformer.courtReportsOf(courtAppearance.getCourtReports()))
             .build();
-    }
-
-    public uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance courtAppearanceOf(
-            Long offenderId,
-            Event event,
-            uk.gov.justice.digital.delius.data.api.CourtAppearance courtAppearance) {
-        return uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance
-                .builder()
-                .appearanceDate(courtAppearance.getAppearanceDate())
-                .courtReports(null) // TODO adding court reports is a future task
-                .teamId(null) // TODO associating with a team is a future task depending on research
-                .staffId(null) // TODO associating with a team is a future task depending on research
-                .event(event)
-                .offenderId(offenderId)
-                .softDeleted(0L)
-                .outcome(Optional.ofNullable(courtAppearance.getOutcome()).map(outcome -> lookupSupplier.courtAppearanceOutcomeSupplier().apply(outcome.getCode())).orElse(null) )
-                .courtNotes(courtAppearance.getCourtNotes())
-                .bailConditions(courtAppearance.getBailConditions())
-                .createdByUserId(lookupSupplier.userSupplier().get().getUserId())
-                .createdDatetime(LocalDateTime.now())
-                .lastUpdatedUserId(lookupSupplier.userSupplier().get().getUserId())
-                .lastUpdatedDatetime(LocalDateTime.now())
-                .court(lookupSupplier.courtSupplier().apply(courtAppearance.getCourt().getCourtId()))
-                .appearanceTypeId(courtAppearance.getAppearanceTypeId())
-                .crownCourtCalendarNumber(courtAppearance.getCrownCourtCalendarNumber())
-                .partitionAreaId(0L)
-                .remandStatusId(courtAppearance.getRemandStatusId())
-                .pleaId(courtAppearance.getPleaId())
-                .rowVersion(1L)
-                .build();
     }
 
 

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/CustodyKeyDateTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/CustodyKeyDateTransformer.java
@@ -1,44 +1,16 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.data.api.CustodyKeyDate;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.jpa.standard.entity.KeyDate;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
-import uk.gov.justice.digital.delius.service.LookupSupplier;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-
-@Component
 public class CustodyKeyDateTransformer {
-    private LookupSupplier lookupSupplier;
-
-    public CustodyKeyDateTransformer(LookupSupplier lookupSupplier) {
-        this.lookupSupplier = lookupSupplier;
-    }
-
     private static KeyValue keyValueOf(StandardReference outcome) {
         return KeyValue
                 .builder()
                 .description(outcome.getCodeDescription())
                 .code(outcome.getCodeValue())
-                .build();
-    }
-
-    public KeyDate keyDateOf(uk.gov.justice.digital.delius.jpa.standard.entity.Custody custody, StandardReference keyDateType, LocalDate date) {
-        return KeyDate
-                .builder()
-                .createdByUserId(lookupSupplier.userSupplier().get().getUserId())
-                .createdDatetime(LocalDateTime.now())
-                .lastUpdatedUserId(lookupSupplier.userSupplier().get().getUserId())
-                .lastUpdatedDatetime(LocalDateTime.now())
-                .custody(custody)
-                .keyDate(date)
-                .keyDateType(keyDateType)
-                .partitionAreaId(0L)
-                .softDeleted(0L)
-                .rowVersion(1L)
                 .build();
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/entitybuilders/AdditionalOffenceEntityBuilderTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/entitybuilders/AdditionalOffenceEntityBuilderTest.java
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.delius.transformers;
+package uk.gov.justice.digital.delius.entitybuilders;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.Before;
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.justice.digital.delius.data.api.OffenceDetail;
+import uk.gov.justice.digital.delius.entitybuilders.AdditionalOffenceEntityBuilder;
 import uk.gov.justice.digital.delius.jpa.national.entity.User;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Offence;
@@ -16,15 +17,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class AdditionalOffenceTransformerTest {
+public class AdditionalOffenceEntityBuilderTest {
     @Mock
     private LookupSupplier lookupSupplier;
 
-    private AdditionalOffenceTransformer  additionalOffenceTransformer;
+    private AdditionalOffenceEntityBuilder additionalOffenceEntityBuilder;
 
     @Before
     public void setup() {
-        additionalOffenceTransformer = new AdditionalOffenceTransformer(lookupSupplier);
+        additionalOffenceEntityBuilder = new AdditionalOffenceEntityBuilder(lookupSupplier);
         when(lookupSupplier.userSupplier()).thenReturn(() -> User.builder().userId(99L).build());
         when(lookupSupplier.offenceSupplier()).thenReturn((code) -> Offence.builder().offenceId(88L).build());
     }
@@ -36,7 +37,7 @@ public class AdditionalOffenceTransformerTest {
                 anOffence()
         );
 
-        assertThat(additionalOffenceTransformer.additionalOffencesOf(offences, anEvent())).hasSize(2);
+        assertThat(additionalOffenceEntityBuilder.additionalOffencesOf(offences, anEvent())).hasSize(2);
     }
 
     @Test
@@ -47,10 +48,10 @@ public class AdditionalOffenceTransformerTest {
                 anOffence()
         );
 
-        assertThat(additionalOffenceTransformer.additionalOffencesOf(offences, anEvent()).get(0).getCreatedByUserId()).isEqualTo(99L);
-        assertThat(additionalOffenceTransformer.additionalOffencesOf(offences, anEvent()).get(0).getLastUpdatedUserId()).isEqualTo(99L);
-        assertThat(additionalOffenceTransformer.additionalOffencesOf(offences, anEvent()).get(0).getCreatedDatetime()).isNotNull();
-        assertThat(additionalOffenceTransformer.additionalOffencesOf(offences, anEvent()).get(0).getLastUpdatedDatetime()).isNotNull();
+        assertThat(additionalOffenceEntityBuilder.additionalOffencesOf(offences, anEvent()).get(0).getCreatedByUserId()).isEqualTo(99L);
+        assertThat(additionalOffenceEntityBuilder.additionalOffencesOf(offences, anEvent()).get(0).getLastUpdatedUserId()).isEqualTo(99L);
+        assertThat(additionalOffenceEntityBuilder.additionalOffencesOf(offences, anEvent()).get(0).getCreatedDatetime()).isNotNull();
+        assertThat(additionalOffenceEntityBuilder.additionalOffencesOf(offences, anEvent()).get(0).getLastUpdatedDatetime()).isNotNull();
     }
 
     @Test
@@ -59,9 +60,9 @@ public class AdditionalOffenceTransformerTest {
                 anOffence()
         );
 
-        assertThat(additionalOffenceTransformer.additionalOffencesOf(offences, anEvent()).get(0).getSoftDeleted()).isEqualTo(0L);
-        assertThat(additionalOffenceTransformer.additionalOffencesOf(offences, anEvent()).get(0).getPartitionAreaId()).isEqualTo(0L);
-        assertThat(additionalOffenceTransformer.additionalOffencesOf(offences, anEvent()).get(0).getRowVersion()).isEqualTo(1L);
+        assertThat(additionalOffenceEntityBuilder.additionalOffencesOf(offences, anEvent()).get(0).getSoftDeleted()).isEqualTo(0L);
+        assertThat(additionalOffenceEntityBuilder.additionalOffencesOf(offences, anEvent()).get(0).getPartitionAreaId()).isEqualTo(0L);
+        assertThat(additionalOffenceEntityBuilder.additionalOffencesOf(offences, anEvent()).get(0).getRowVersion()).isEqualTo(1L);
 
     }
 
@@ -79,7 +80,7 @@ public class AdditionalOffenceTransformerTest {
                         .build()
         );
 
-        assertThat(additionalOffenceTransformer.additionalOffencesOf(offences, anEvent()).get(0).getOffence().getOffenceId()).isEqualTo(88L);
+        assertThat(additionalOffenceEntityBuilder.additionalOffencesOf(offences, anEvent()).get(0).getOffence().getOffenceId()).isEqualTo(88L);
 
     }
     private Event anEvent() {

--- a/src/test/java/uk/gov/justice/digital/delius/entitybuilders/CourtAppearanceEntityBuilderTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/entitybuilders/CourtAppearanceEntityBuilderTest.java
@@ -1,0 +1,92 @@
+package uk.gov.justice.digital.delius.entitybuilders;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.justice.digital.delius.data.api.KeyValue;
+import uk.gov.justice.digital.delius.entitybuilders.CourtAppearanceEntityBuilder;
+import uk.gov.justice.digital.delius.jpa.national.entity.User;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Court;
+import uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
+import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
+import uk.gov.justice.digital.delius.service.LookupSupplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class CourtAppearanceEntityBuilderTest {
+    @Mock
+    private LookupSupplier lookupSupplier;
+
+    private CourtAppearanceEntityBuilder courtAppearanceEntityBuilder;
+
+    @Before
+    public void setup() {
+        courtAppearanceEntityBuilder = new CourtAppearanceEntityBuilder(lookupSupplier);
+        when(lookupSupplier.userSupplier()).thenReturn(() -> User.builder().userId(99L).build());
+        when(lookupSupplier.courtAppearanceOutcomeSupplier()).thenReturn(code -> StandardReference.builder().codeValue(code).build());
+        when(lookupSupplier.courtSupplier()).thenReturn(courtId -> Court.builder().courtId(courtId).build());
+
+    }
+    @Test
+    public void setsSensibleDefaults() {
+        final CourtAppearance courtAppearance = courtAppearanceEntityBuilder.courtAppearanceOf(1L, aEvent(), aApiCourtAppearance());
+
+        assertThat(courtAppearance.getRowVersion()).isEqualTo(1L);
+        assertThat(courtAppearance.getPartitionAreaId()).isEqualTo(0L);
+        assertThat(courtAppearance.getSoftDeleted()).isEqualTo(0L);
+    }
+
+    @Test
+    public void outcomeNotMappedIfNotPresent() {
+        final CourtAppearance courtAppearance = courtAppearanceEntityBuilder.courtAppearanceOf(1L, aEvent(), aApiCourtAppearance().toBuilder().outcome(null).build());
+
+        assertThat(courtAppearance.getOutcome()).isNull();
+    }
+
+    @Test
+    public void outcomeIsMappedWhenPresent() {
+        final CourtAppearance courtAppearance = courtAppearanceEntityBuilder.courtAppearanceOf(1L, aEvent(), aApiCourtAppearance().toBuilder().outcome(KeyValue.builder().code("AA").build()).build());
+
+        assertThat(courtAppearance.getOutcome()).isNotNull();
+        assertThat(courtAppearance.getOutcome().getCodeValue()).isEqualTo("AA");
+    }
+
+    @Test
+    public void setsAuditFields() {
+        when(lookupSupplier.userSupplier()).thenReturn(() -> User.builder().userId(99L).build());
+
+        final CourtAppearance courtAppearance = courtAppearanceEntityBuilder.courtAppearanceOf(1L, aEvent(), aApiCourtAppearance().toBuilder().outcome(KeyValue.builder().code("AA").build()).build());
+
+        assertThat(courtAppearance.getCreatedByUserId()).isEqualTo(99L);
+        assertThat(courtAppearance.getLastUpdatedUserId()).isEqualTo(99L);
+        assertThat(courtAppearance.getCreatedDatetime()).isNotNull();
+        assertThat(courtAppearance.getLastUpdatedDatetime()).isNotNull();
+    }
+
+
+    private uk.gov.justice.digital.delius.data.api.CourtAppearance aApiCourtAppearance() {
+        return uk.gov.justice.digital.delius.data.api.CourtAppearance
+                .builder()
+                .court(aApiCourt())
+                .build();
+    }
+
+    private uk.gov.justice.digital.delius.data.api.Court aApiCourt() {
+        return uk.gov.justice.digital.delius.data.api.Court.builder().build();
+    }
+
+    private Event aEvent() {
+        return Event
+                .builder()
+                .additionalOffences(ImmutableList.of())
+                .build();
+    }
+
+}

--- a/src/test/java/uk/gov/justice/digital/delius/entitybuilders/MainOffenceEntityBuilderTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/entitybuilders/MainOffenceEntityBuilderTest.java
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.delius.transformers;
+package uk.gov.justice.digital.delius.entitybuilders;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -16,15 +16,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class MainOffenceTransformerTest {
+public class MainOffenceEntityBuilderTest {
     @Mock
     private LookupSupplier lookupSupplier;
 
-    private MainOffenceTransformer mainOffenceTransformer;
+    private MainOffenceEntityBuilder mainOffenceEntityBuilder;
 
     @Before
     public void setup() {
-        mainOffenceTransformer = new MainOffenceTransformer(lookupSupplier);
+        mainOffenceEntityBuilder = new MainOffenceEntityBuilder(lookupSupplier);
         when(lookupSupplier.userSupplier()).thenReturn(() -> User.builder().userId(99L).build());
         when(lookupSupplier.offenceSupplier()).thenReturn(code -> Offence.builder().code(code).build());
 
@@ -32,7 +32,7 @@ public class MainOffenceTransformerTest {
 
     @Test
     public void setsSensibleDefaults() {
-        final MainOffence mainOffence = mainOffenceTransformer.mainOffenceOf(1L, anOffence(), anEvent());
+        final MainOffence mainOffence = mainOffenceEntityBuilder.mainOffenceOf(1L, anOffence(), anEvent());
 
         assertThat(mainOffence.getPartitionAreaId()).isEqualTo(0L);
         assertThat(mainOffence.getRowVersion()).isEqualTo(1L);
@@ -43,7 +43,7 @@ public class MainOffenceTransformerTest {
     public void setsAuditFields() {
         when(lookupSupplier.userSupplier()).thenReturn(() -> User.builder().userId(99L).build());
 
-        final MainOffence mainOffence = mainOffenceTransformer.mainOffenceOf(1L, anOffence(), anEvent());
+        final MainOffence mainOffence = mainOffenceEntityBuilder.mainOffenceOf(1L, anOffence(), anEvent());
 
         assertThat(mainOffence.getCreatedByUserId()).isEqualTo(99L);
         assertThat(mainOffence.getLastUpdatedUserId()).isEqualTo(99L);
@@ -53,7 +53,8 @@ public class MainOffenceTransformerTest {
 
     @Test
     public void offenceIsSetFromDetailCode() {
-        final MainOffence mainOffence = mainOffenceTransformer.mainOffenceOf(1L, anOffence().toBuilder().detail(anOffence().getDetail().toBuilder().code("AA").build()).build(), anEvent());
+        final MainOffence mainOffence = mainOffenceEntityBuilder
+                .mainOffenceOf(1L, anOffence().toBuilder().detail(anOffence().getDetail().toBuilder().code("AA").build()).build(), anEvent());
 
         assertThat(mainOffence.getOffence().getCode()).isEqualTo("AA");
     }

--- a/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_AddOrReplaceOrDeleteCustodyKeyDatesTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_AddOrReplaceOrDeleteCustodyKeyDatesTest.java
@@ -14,8 +14,8 @@ import uk.gov.justice.digital.delius.jpa.national.entity.User;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 import uk.gov.justice.digital.delius.jpa.standard.repository.EventRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
-import uk.gov.justice.digital.delius.transformers.EventTransformer;
-import uk.gov.justice.digital.delius.transformers.CustodyKeyDateTransformer;
+import uk.gov.justice.digital.delius.entitybuilders.EventEntityBuilder;
+import uk.gov.justice.digital.delius.entitybuilders.KeyDateEntityBuilder;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -46,7 +46,7 @@ public class ConvictionService_AddOrReplaceOrDeleteCustodyKeyDatesTest {
     private OffenderRepository offenderRepository;
 
     @Mock
-    private EventTransformer eventTransformer;
+    private EventEntityBuilder eventEntityBuilder;
 
     @Mock
     private SpgNotificationService spgNotificationService;
@@ -67,7 +67,7 @@ public class ConvictionService_AddOrReplaceOrDeleteCustodyKeyDatesTest {
 
     @BeforeEach
     public void setUp() {
-        convictionService = new ConvictionService(true, eventRepository, offenderRepository, eventTransformer, spgNotificationService, lookupSupplier, new CustodyKeyDateTransformer(lookupSupplier), iapsNotificationService, contactService);
+        convictionService = new ConvictionService(true, eventRepository, offenderRepository, eventEntityBuilder, spgNotificationService, lookupSupplier, new KeyDateEntityBuilder(lookupSupplier), iapsNotificationService, contactService);
         when(lookupSupplier.userSupplier()).thenReturn(() -> User.builder().userId(88L).build());
         when(lookupSupplier.custodyKeyDateTypeSupplier()).thenReturn(code -> Optional.of(StandardReference
                 .builder()

--- a/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_AddReplaceCustodyKeyDateTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_AddReplaceCustodyKeyDateTest.java
@@ -17,9 +17,8 @@ import uk.gov.justice.digital.delius.jpa.standard.repository.EventRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
 import uk.gov.justice.digital.delius.service.ConvictionService.CustodyTypeCodeIsNotValidException;
 import uk.gov.justice.digital.delius.service.ConvictionService.SingleActiveCustodyConvictionNotFoundException;
-import uk.gov.justice.digital.delius.transformers.ConvictionTransformer;
-import uk.gov.justice.digital.delius.transformers.CustodyKeyDateTransformer;
-import uk.gov.justice.digital.delius.transformers.EventTransformer;
+import uk.gov.justice.digital.delius.entitybuilders.EventEntityBuilder;
+import uk.gov.justice.digital.delius.entitybuilders.KeyDateEntityBuilder;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -44,7 +43,7 @@ public class ConvictionService_AddReplaceCustodyKeyDateTest {
     private OffenderRepository offenderRepository;
 
     @Mock
-    private EventTransformer eventTransformer;
+    private EventEntityBuilder eventEntityBuilder;
 
     @Mock
     private SpgNotificationService spgNotificationService;
@@ -63,7 +62,7 @@ public class ConvictionService_AddReplaceCustodyKeyDateTest {
 
     @Before
     public void setUp() {
-        convictionService = new ConvictionService(true, eventRepository, offenderRepository, eventTransformer, spgNotificationService, lookupSupplier, new CustodyKeyDateTransformer(lookupSupplier), iapsNotificationService, contactService);
+        convictionService = new ConvictionService(true, eventRepository, offenderRepository, eventEntityBuilder, spgNotificationService, lookupSupplier, new KeyDateEntityBuilder(lookupSupplier), iapsNotificationService, contactService);
         when(lookupSupplier.userSupplier()).thenReturn(() -> User.builder().userId(88L).build());
         when(eventRepository.findByOffenderId(anyLong())).thenReturn(ImmutableList.of(aCustodyEvent()));
         when(lookupSupplier.custodyKeyDateTypeSupplier()).thenReturn(code -> Optional.of(StandardReference

--- a/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_DeleteCustodyKeyDateTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_DeleteCustodyKeyDateTest.java
@@ -13,8 +13,8 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
 import uk.gov.justice.digital.delius.jpa.standard.repository.EventRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
 import uk.gov.justice.digital.delius.service.ConvictionService.SingleActiveCustodyConvictionNotFoundException;
-import uk.gov.justice.digital.delius.transformers.EventTransformer;
-import uk.gov.justice.digital.delius.transformers.CustodyKeyDateTransformer;
+import uk.gov.justice.digital.delius.entitybuilders.EventEntityBuilder;
+import uk.gov.justice.digital.delius.entitybuilders.KeyDateEntityBuilder;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -23,8 +23,14 @@ import java.util.List;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
-import static uk.gov.justice.digital.delius.util.EntityHelper.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aCommunityDisposal;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aCustodyEvent;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aKeyDate;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anEvent;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ConvictionService_DeleteCustodyKeyDateTest {
@@ -38,7 +44,7 @@ public class ConvictionService_DeleteCustodyKeyDateTest {
     private OffenderRepository offenderRepository;
 
     @Mock
-    private EventTransformer eventTransformer;
+    private EventEntityBuilder eventEntityBuilder;
 
     @Mock
     private SpgNotificationService spgNotificationService;
@@ -58,7 +64,7 @@ public class ConvictionService_DeleteCustodyKeyDateTest {
 
     @Before
     public void setUp() {
-        convictionService = new ConvictionService(true, eventRepository, offenderRepository, eventTransformer, spgNotificationService, lookupSupplier, new CustodyKeyDateTransformer(lookupSupplier), iapsNotificationService, contactService);
+        convictionService = new ConvictionService(true, eventRepository, offenderRepository, eventEntityBuilder, spgNotificationService, lookupSupplier, new KeyDateEntityBuilder(lookupSupplier), iapsNotificationService, contactService);
     }
 
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_GetCustodyKeyDateTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ConvictionService_GetCustodyKeyDateTest.java
@@ -12,9 +12,8 @@ import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.jpa.standard.repository.EventRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
 import uk.gov.justice.digital.delius.service.ConvictionService.SingleActiveCustodyConvictionNotFoundException;
-import uk.gov.justice.digital.delius.transformers.ConvictionTransformer;
-import uk.gov.justice.digital.delius.transformers.CustodyKeyDateTransformer;
-import uk.gov.justice.digital.delius.transformers.EventTransformer;
+import uk.gov.justice.digital.delius.entitybuilders.EventEntityBuilder;
+import uk.gov.justice.digital.delius.entitybuilders.KeyDateEntityBuilder;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -23,7 +22,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
-import static uk.gov.justice.digital.delius.util.EntityHelper.*;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aCommunityDisposal;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aCustodyEvent;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aKeyDate;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anEvent;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ConvictionService_GetCustodyKeyDateTest {
@@ -37,7 +39,7 @@ public class ConvictionService_GetCustodyKeyDateTest {
     private OffenderRepository offenderRepository;
 
     @Mock
-    private EventTransformer eventTransformer;
+    private EventEntityBuilder eventEntityBuilder;
 
     @Mock
     private SpgNotificationService spgNotificationService;
@@ -53,7 +55,7 @@ public class ConvictionService_GetCustodyKeyDateTest {
 
     @Before
     public void setUp() {
-        convictionService = new ConvictionService(true, eventRepository, offenderRepository, eventTransformer, spgNotificationService, lookupSupplier, new CustodyKeyDateTransformer(lookupSupplier), iapsNotificationService, contactService);
+        convictionService = new ConvictionService(true, eventRepository, offenderRepository, eventEntityBuilder, spgNotificationService, lookupSupplier, new KeyDateEntityBuilder(lookupSupplier), iapsNotificationService, contactService);
         when(eventRepository.findByOffenderId(anyLong())).thenReturn(ImmutableList.of(aCustodyEvent()));
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/CourtAppearanceServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/CourtAppearanceServiceTest.java
@@ -1,22 +1,17 @@
 package uk.gov.justice.digital.delius.service;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.delius.data.api.CourtAppearance;
 import uk.gov.justice.digital.delius.jpa.standard.entity.AdditionalOffence;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Court;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
 import uk.gov.justice.digital.delius.jpa.standard.entity.MainOffence;
 import uk.gov.justice.digital.delius.jpa.standard.repository.CourtAppearanceRepository;
-import uk.gov.justice.digital.delius.transformers.CourtAppearanceTransformer;
-import uk.gov.justice.digital.delius.transformers.CourtReportTransformer;
-import uk.gov.justice.digital.delius.transformers.CourtTransformer;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -24,21 +19,17 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-@RunWith(SpringRunner.class)
-@Import({CourtAppearanceService.class, CourtAppearanceTransformer.class, CourtReportTransformer.class, CourtTransformer.class})
+@ExtendWith(MockitoExtension.class)
 public class CourtAppearanceServiceTest {
 
-    @Autowired
     private CourtAppearanceService courtAppearanceService;
 
-    @MockBean
+    @Mock
     private CourtAppearanceRepository courtAppearanceRepository;
 
-    @MockBean
-    private LookupSupplier lookupSupplier;
-
-    @Before
+    @BeforeEach
     public void setUp() {
+        courtAppearanceService = new CourtAppearanceService(courtAppearanceRepository);
         when(courtAppearanceRepository.findByOffenderId(1L))
             .thenReturn(
                 ImmutableList.of(

--- a/src/test/java/uk/gov/justice/digital/delius/service/CourtReportServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/CourtReportServiceTest.java
@@ -1,17 +1,14 @@
 package uk.gov.justice.digital.delius.service;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import uk.gov.justice.digital.delius.jpa.standard.repository.CourtReportRepository;
-import uk.gov.justice.digital.delius.transformers.CourtAppearanceTransformer;
-import uk.gov.justice.digital.delius.transformers.CourtReportTransformer;
-import uk.gov.justice.digital.delius.transformers.CourtTransformer;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -21,22 +18,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(SpringRunner.class)
-@Import({CourtReportService.class, CourtReportTransformer.class, CourtAppearanceTransformer.class, CourtTransformer.class})
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class CourtReportServiceTest {
-    @Autowired
     private CourtReportService courtReportService;
 
-    @MockBean
+    @Mock
     private CourtReportRepository courtReportRepository;
 
-    @MockBean
-    private LookupSupplier lookupSupplier;
 
-
-
-    @Before
+    @BeforeEach
     public void before() {
+        courtReportService = new CourtReportService(courtReportRepository);
         when(courtReportRepository.findByOffenderId(any())).thenReturn(ImmutableList.of(
                 uk.gov.justice.digital.delius.jpa.standard.entity.CourtReport.builder().courtReportId(1L).offenderId(1L).dateRequested(LocalDateTime.now().minusDays(98)).build(),
                 uk.gov.justice.digital.delius.jpa.standard.entity.CourtReport.builder().courtReportId(2L).offenderId(1L).dateRequested(LocalDateTime.now().minusDays(1)).build(),

--- a/src/test/java/uk/gov/justice/digital/delius/service/DocumentServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/DocumentServiceTest.java
@@ -1,74 +1,116 @@
 package uk.gov.justice.digital.delius.service;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.delius.data.api.OffenderDocuments;
 import uk.gov.justice.digital.delius.jpa.national.repository.DocumentRepository;
 import uk.gov.justice.digital.delius.jpa.standard.entity.CourtReportDocument;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
 import uk.gov.justice.digital.delius.jpa.standard.entity.InstitutionalReportDocument;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Offender;
-import uk.gov.justice.digital.delius.jpa.standard.repository.*;
-import uk.gov.justice.digital.delius.transformers.DocumentTransformer;
+import uk.gov.justice.digital.delius.jpa.standard.repository.AddressAssessmentDocumentRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.ApprovedPremisesReferralDocumentRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.AssessmentDocumentRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.CaseAllocationDocumentRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.ContactDocumentRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.CourtReportDocumentRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.EventDocumentRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.EventRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.InstitutionReportDocumentRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.NsiDocumentRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderDocumentRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.PersonalCircumstanceDocumentRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.PersonalContactDocumentRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.ReferralDocumentRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.UPWAppointmentDocumentRepository;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static uk.gov.justice.digital.delius.util.EntityHelper.*;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aCaseAllocationDocument;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aContactDocument;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aCourtReportDocument;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aNsiDocument;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aPersonalCircumstanceDocument;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aPersonalContactDocument;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aReferralDocument;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aUPWAppointmentDocument;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anAddressAssessmentDocument;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anApprovedPremisesReferralDocument;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anAssessmentDocument;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anEvent;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anEventDocument;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anInstitutionalReportDocument;
 import static uk.gov.justice.digital.delius.util.OffenderHelper.anOffender;
 
-@RunWith(SpringRunner.class)
-@Import({DocumentService.class})
+@ExtendWith(MockitoExtension.class)
 public class DocumentServiceTest {
-    @Autowired
     private DocumentService documentService;
 
-    @MockBean
+    @Mock
     private DocumentRepository documentRepository;
-    @MockBean
+    @Mock
     private OffenderRepository offenderRepository;
-    @MockBean
+    @Mock
     private OffenderDocumentRepository offenderDocumentRepository;
-    @MockBean
+    @Mock
     private EventDocumentRepository eventDocumentRepository;
-    @MockBean
+    @Mock
     private CourtReportDocumentRepository courtReportDocumentRepository;
-    @MockBean
+    @Mock
     private InstitutionReportDocumentRepository institutionReportDocumentRepository;
-    @MockBean
+    @Mock
     private EventRepository eventRepository;
-    @MockBean
+    @Mock
     private AddressAssessmentDocumentRepository addressAssessmentRepository;
-    @MockBean
+    @Mock
     private ApprovedPremisesReferralDocumentRepository approvedPremisesReferralDocumentRepository;
-    @MockBean
+    @Mock
     private AssessmentDocumentRepository assessmentDocumentRepository;
-    @MockBean
+    @Mock
     private CaseAllocationDocumentRepository caseAllocationDocumentRepository;
-    @MockBean
+    @Mock
     private PersonalContactDocumentRepository personalContactDocumentRepository;
-    @MockBean
+    @Mock
     private ReferralDocumentRepository referralDocumentRepository;
-    @MockBean
+    @Mock
     private NsiDocumentRepository nsiDocumentRepository;
-    @MockBean
+    @Mock
     private PersonalCircumstanceDocumentRepository personalCircumstanceDocumentRepository;
-    @MockBean
+    @Mock
     private UPWAppointmentDocumentRepository upwAppointmentDocumentRepository;
-    @MockBean
+    @Mock
     private ContactDocumentRepository contactDocumentRepository;
 
 
-    @Before
+    @BeforeEach
     public void before() {
+        documentService = new DocumentService(
+                documentRepository,
+                offenderRepository,
+                offenderDocumentRepository,
+                eventDocumentRepository,
+                courtReportDocumentRepository,
+                institutionReportDocumentRepository,
+                eventRepository,
+                addressAssessmentRepository,
+                approvedPremisesReferralDocumentRepository,
+                assessmentDocumentRepository,
+                caseAllocationDocumentRepository,
+                personalContactDocumentRepository,
+                referralDocumentRepository,
+                nsiDocumentRepository,
+                personalCircumstanceDocumentRepository,
+                upwAppointmentDocumentRepository,
+                contactDocumentRepository
+        );
         when(offenderRepository.findByOffenderId(any())).thenReturn(Optional.of(anOffender()));
         when(offenderDocumentRepository.findByOffenderId(any())).thenReturn(ImmutableList.of());
         when(eventDocumentRepository.findByOffenderId(any())).thenReturn(ImmutableList.of());

--- a/src/test/java/uk/gov/justice/digital/delius/service/InstitutionalReportServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/InstitutionalReportServiceTest.java
@@ -1,15 +1,21 @@
 package uk.gov.justice.digital.delius.service;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.justice.digital.delius.jpa.standard.entity.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.delius.jpa.standard.entity.AdditionalOffence;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Custody;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Disposal;
+import uk.gov.justice.digital.delius.jpa.standard.entity.DisposalType;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
+import uk.gov.justice.digital.delius.jpa.standard.entity.InstitutionalReport;
+import uk.gov.justice.digital.delius.jpa.standard.entity.MainOffence;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Offence;
+import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 import uk.gov.justice.digital.delius.jpa.standard.repository.InstitutionalReportRepository;
-import uk.gov.justice.digital.delius.transformers.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,22 +23,19 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
-@RunWith(SpringRunner.class)
-@Import({InstitutionalReportService.class, InstitutionalReportTransformer.class,
-    MainOffenceTransformer.class, AdditionalOffenceTransformer.class, ConvictionTransformer.class, InstitutionTransformer.class})
+@ExtendWith(MockitoExtension.class)
 public class InstitutionalReportServiceTest {
 
     public static final long EVENT_ID = 42L;
-    @Autowired
     private InstitutionalReportService institutionalReportService;
 
-    @MockBean
+    @Mock
     private InstitutionalReportRepository institutionalReportRepository;
 
-    @MockBean
-    private LookupSupplier lookupSupplier;
-    @MockBean
-    private CourtAppearanceTransformer courtAppearanceTransformer;
+    @BeforeEach
+    void setUp() {
+        institutionalReportService = new InstitutionalReportService(institutionalReportRepository);
+    }
 
     @Test
     public void singleReportFilteredOutWhenSoftDeleted() {

--- a/src/test/java/uk/gov/justice/digital/delius/service/OffenceServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/OffenceServiceTest.java
@@ -1,38 +1,33 @@
 package uk.gov.justice.digital.delius.service;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.justice.digital.delius.jpa.standard.entity.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.delius.jpa.standard.entity.AdditionalOffence;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
+import uk.gov.justice.digital.delius.jpa.standard.entity.MainOffence;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Offence;
+import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 import uk.gov.justice.digital.delius.jpa.standard.repository.MainOffenceRepository;
-import uk.gov.justice.digital.delius.transformers.AdditionalOffenceTransformer;
-import uk.gov.justice.digital.delius.transformers.MainOffenceTransformer;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
-@Import({OffenceService.class, MainOffenceTransformer.class, AdditionalOffenceTransformer.class})
+@ExtendWith(MockitoExtension.class)
 public class OffenceServiceTest {
 
-    @Autowired
     private OffenceService offenceService;
 
-    @MockBean
+    @Mock
     private MainOffenceRepository mainOffenceRepository;
-
-    @MockBean
-    private LookupSupplier lookupSupplier;
-
-    @Before
+    @BeforeEach
     public void setUp() {
+        offenceService = new OffenceService(mainOffenceRepository);
 
         Mockito.when(mainOffenceRepository.findByOffenderId(1L))
             .thenReturn(ImmutableList.of(

--- a/src/test/java/uk/gov/justice/digital/delius/service/PersonalCircumstanceServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/PersonalCircumstanceServiceTest.java
@@ -1,33 +1,33 @@
 package uk.gov.justice.digital.delius.service;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.delius.jpa.standard.entity.CircumstanceSubType;
 import uk.gov.justice.digital.delius.jpa.standard.entity.CircumstanceType;
 import uk.gov.justice.digital.delius.jpa.standard.entity.PersonalCircumstance;
 import uk.gov.justice.digital.delius.jpa.standard.repository.PersonalCircumstanceRepository;
-import uk.gov.justice.digital.delius.transformers.PersonalCircumstanceTransformer;
 
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
-@Import({PersonalCircumstanceService.class, PersonalCircumstanceTransformer.class})
+@ExtendWith(MockitoExtension.class)
 public class PersonalCircumstanceServiceTest {
 
-    @Autowired
     private PersonalCircumstanceService personalCircumstanceService;
 
-    @MockBean
+    @Mock
     private PersonalCircumstanceRepository personalCircumstanceRepository;
 
+    @BeforeEach
+    void setUp() {
+        personalCircumstanceService = new PersonalCircumstanceService(personalCircumstanceRepository);
+    }
 
     @Test
     public void personalCircumstancesOrderedNaturallyByPrimaryKeyReversed() {

--- a/src/test/java/uk/gov/justice/digital/delius/service/RegistrationServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/RegistrationServiceTest.java
@@ -1,33 +1,36 @@
 package uk.gov.justice.digital.delius.service;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.justice.digital.delius.jpa.standard.entity.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea;
+import uk.gov.justice.digital.delius.jpa.standard.entity.RegisterType;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Registration;
+import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Team;
 import uk.gov.justice.digital.delius.jpa.standard.repository.RegistrationRepository;
-import uk.gov.justice.digital.delius.transformers.ContactTransformer;
-import uk.gov.justice.digital.delius.transformers.RegistrationTransformer;
 
 import java.time.LocalDate;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
-@Import({RegistrationService.class, RegistrationTransformer.class, ContactTransformer.class})
+@ExtendWith(MockitoExtension.class)
 public class RegistrationServiceTest {
 
-    @Autowired
     private RegistrationService registrationService;
 
-    @MockBean
+    @Mock
     private RegistrationRepository registrationRepository;
 
+    @BeforeEach
+    void before() {
+        registrationService = new RegistrationService(registrationRepository);
+    }
 
     @Test
     public void registrationsOrderedByRegistrationDateReversed() {

--- a/src/test/java/uk/gov/justice/digital/delius/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/UserServiceTest.java
@@ -2,13 +2,12 @@ package uk.gov.justice.digital.delius.service;
 
 import com.google.common.collect.ImmutableList;
 import com.microsoft.applicationinsights.TelemetryClient;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.delius.controller.BadRequestException;
 import uk.gov.justice.digital.delius.data.api.OffenderDetail;
 import uk.gov.justice.digital.delius.data.api.UserDetails;
@@ -30,22 +29,29 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
-@RunWith(SpringRunner.class)
-@Import({UserService.class})
+@ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
-    @MockBean
+    @Mock
     private UserRepositoryWrapper userRepositoryWrapper;
 
-    @MockBean
+    @Mock
     private LdapRepository ldapRepository;
 
-    @MockBean
+    @Mock
     private TelemetryClient telemetryClient;
 
-    @Autowired
     private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        userService = new UserService(userRepositoryWrapper, ldapRepository, telemetryClient);
+    }
 
     @Test
     public void exclusionListNotCheckedWhenNotExcludedForAnyone() {

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceTransformerTest.java
@@ -1,42 +1,23 @@
 package uk.gov.justice.digital.delius.transformers;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.justice.digital.delius.data.api.CourtReport;
-import uk.gov.justice.digital.delius.data.api.KeyValue;
-import uk.gov.justice.digital.delius.jpa.national.entity.User;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Court;
 import uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
-import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
-import uk.gov.justice.digital.delius.service.LookupSupplier;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 
 @RunWith(MockitoJUnitRunner.class)
 public class CourtAppearanceTransformerTest {
-    @Mock
-    private LookupSupplier lookupSupplier;
 
-    private CourtAppearanceTransformer courtAppearanceTransformer;
-
-    @Before
-    public void setup() {
-        courtAppearanceTransformer = new CourtAppearanceTransformer(lookupSupplier);
-        when(lookupSupplier.userSupplier()).thenReturn(() -> User.builder().userId(99L).build());
-        when(lookupSupplier.courtAppearanceOutcomeSupplier()).thenReturn(code -> StandardReference.builder().codeValue(code).build());
-        when(lookupSupplier.courtSupplier()).thenReturn(courtId -> Court.builder().courtId(courtId).build());
-
-    }
     @Test
     public void itFiltersOutSoftDeletedEntries() {
 
@@ -63,54 +44,6 @@ public class CourtAppearanceTransformerTest {
                 .courtAppearanceOf(courtAppearance).getCourtReports();
         assertThat(courtReports)
             .extracting("courtReportId").containsOnly(1L, 3L);
-    }
-
-    @Test
-    public void setsSensibleDefaults() {
-        final uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance courtAppearance = courtAppearanceTransformer.courtAppearanceOf(1L, aEvent(), aApiCourtAppearance());
-
-        assertThat(courtAppearance.getRowVersion()).isEqualTo(1L);
-        assertThat(courtAppearance.getPartitionAreaId()).isEqualTo(0L);
-        assertThat(courtAppearance.getSoftDeleted()).isEqualTo(0L);
-    }
-
-    @Test
-    public void outcomeNotMappedIfNotPresent() {
-        final uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance courtAppearance = courtAppearanceTransformer.courtAppearanceOf(1L, aEvent(), aApiCourtAppearance().toBuilder().outcome(null).build());
-
-        assertThat(courtAppearance.getOutcome()).isNull();
-    }
-
-    @Test
-    public void outcomeIsMappedWhenPresent() {
-        final uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance courtAppearance = courtAppearanceTransformer.courtAppearanceOf(1L, aEvent(), aApiCourtAppearance().toBuilder().outcome(KeyValue.builder().code("AA").build()).build());
-
-        assertThat(courtAppearance.getOutcome()).isNotNull();
-        assertThat(courtAppearance.getOutcome().getCodeValue()).isEqualTo("AA");
-    }
-
-    @Test
-    public void setsAuditFields() {
-        when(lookupSupplier.userSupplier()).thenReturn(() -> User.builder().userId(99L).build());
-
-        final uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance courtAppearance = courtAppearanceTransformer.courtAppearanceOf(1L, aEvent(), aApiCourtAppearance().toBuilder().outcome(KeyValue.builder().code("AA").build()).build());
-
-        assertThat(courtAppearance.getCreatedByUserId()).isEqualTo(99L);
-        assertThat(courtAppearance.getLastUpdatedUserId()).isEqualTo(99L);
-        assertThat(courtAppearance.getCreatedDatetime()).isNotNull();
-        assertThat(courtAppearance.getLastUpdatedDatetime()).isNotNull();
-    }
-
-
-    private uk.gov.justice.digital.delius.data.api.CourtAppearance aApiCourtAppearance() {
-        return uk.gov.justice.digital.delius.data.api.CourtAppearance
-                .builder()
-                .court(aApiCourt())
-                .build();
-    }
-
-    private uk.gov.justice.digital.delius.data.api.Court aApiCourt() {
-        return uk.gov.justice.digital.delius.data.api.Court.builder().build();
     }
 
     private Event aEvent() {

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/CustodyKeyDateTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/CustodyKeyDateTransformerTest.java
@@ -1,16 +1,13 @@
 package uk.gov.justice.digital.delius.transformers;
 
 import lombok.val;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.justice.digital.delius.data.api.CustodyKeyDate;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.jpa.standard.entity.KeyDate;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
-import uk.gov.justice.digital.delius.service.LookupSupplier;
 
 import java.time.LocalDate;
 
@@ -18,20 +15,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CustodyKeyDateTransformerTest {
-    private CustodyKeyDateTransformer custodyKeyDateTransformer;
-
-    @Mock
-    private LookupSupplier lookupSupplier;
-
-    @Before
-    public void before() {
-        custodyKeyDateTransformer = new CustodyKeyDateTransformer(lookupSupplier);
-    }
-
     @Test
     public void custodyKeyDateOfCopiesReferenceData() {
         val keyDate = LocalDate.now();
-        assertThat(custodyKeyDateTransformer.custodyKeyDateOf(
+        assertThat(CustodyKeyDateTransformer.custodyKeyDateOf(
                 KeyDate
                         .builder()
                         .keyDateType(


### PR DESCRIPTION
Final part of transformer refactoring

1. Split a few more transformers between transforming a model object from an entity to the opposite, building a entity
2. Renamed (and moved) the class that build entities to <Name>EntityBuilder after realising these don't transform, they build
3 Any service test that previously needed the Spring Runner to inject the mess of transformers are now pure mocked tests
4 With two tests left that might benefit from using SpringRunner decided to make them consistent, and just use the `MockitoExtension`