### PR TITLE
add username field to /users/search and /users/{username}/detail responses

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/service/UserService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/UserService.java
@@ -116,6 +116,7 @@ public class UserService {
                         .email(user.getMail())
                         .enabled(user.isEnabled())
                         .userId(oracleUser.getUserId())
+                        .username(username)
                         .build());
     }
 
@@ -145,6 +146,7 @@ public class UserService {
                     .email(user.getMail())
                     .enabled(user.isEnabled())
                     .userId(oracleUser.getUserId())
+                    .username(userCn)
                     .build();
             })
             .filter(user -> user != null)

--- a/src/test/java/uk/gov/justice/digital/delius/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/UserServiceTest.java
@@ -365,6 +365,7 @@ public class UserServiceTest {
                 .roles(List.of(UserRole.builder().name("ROLE1").build()))
                 .enabled(true)
                 .userId(12345L)
+                .username("john.bean")
                 .build());
     }
 
@@ -402,6 +403,7 @@ public class UserServiceTest {
                     .roles(List.of(UserRole.builder().name("ROLE1").build()))
                     .enabled(true)
                     .userId(12345L)
+                    .username("john.bean")
                     .build());
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/UserServiceTest.java
@@ -329,6 +329,7 @@ public class UserServiceTest {
                         .roles(List.of(UserRole.builder().name("ROLE1").build()))
                         .enabled(true)
                         .userId(12345L)
+                        .username("john.bean")
                         .build());
     }
 


### PR DESCRIPTION
hmpps auth will require the username in the email search response in order to inform clients of the user's delius username