### PR TITLE
🐛 attendances "attended" and "complied" are represented by "Y" and "N…

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/service/AttendanceService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/AttendanceService.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +13,7 @@ import uk.gov.justice.digital.delius.data.api.Attendance;
 import uk.gov.justice.digital.delius.data.api.Attendance.ContactTypeDetail;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Contact;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactRepository;
+import uk.gov.justice.digital.delius.transformers.TypesTransformer;
 
 @Slf4j
 @Service
@@ -32,12 +34,6 @@ public class AttendanceService {
         return contactRepository.findByOffenderAndEventId(offenderId, eventId, contactDate);
     }
 
-    static boolean forEntityBoolean(final String booleanStr) {
-        if (booleanStr == null)
-            return false;
-        return booleanStr.trim().equals("Y");
-    }
-
     public static List<Attendance> attendancesFor(final List<Contact> contacts) {
 
         if (contacts == null) {
@@ -48,8 +44,8 @@ public class AttendanceService {
             .stream()
             .filter(Objects::nonNull)
             .map(contactEntity -> Attendance.builder()
-                .attended(forEntityBoolean(contactEntity.getAttended()))
-                .complied(forEntityBoolean(contactEntity.getComplied()))
+                .attended(Optional.ofNullable(TypesTransformer.ynToBoolean(contactEntity.getAttended())).orElse(false))
+                .complied(Optional.ofNullable(TypesTransformer.ynToBoolean(contactEntity.getComplied())).orElse(false))
                 .attendanceDate(contactEntity.getContactDate())
                 .contactId(contactEntity.getContactId())
                 .outcome(contactEntity.getContactOutcomeType() != null ? contactEntity.getContactOutcomeType().getDescription() : null)

--- a/src/main/java/uk/gov/justice/digital/delius/service/AttendanceService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/AttendanceService.java
@@ -35,7 +35,7 @@ public class AttendanceService {
     static boolean forEntityBoolean(final String booleanStr) {
         if (booleanStr == null)
             return false;
-        return booleanStr.trim().equals("1");
+        return booleanStr.trim().equals("Y");
     }
 
     public static List<Attendance> attendancesFor(final List<Contact> contacts) {

--- a/src/main/resources/db/data/V1_12__offender_add_contact_with_outcome_type_data.sql
+++ b/src/main/resources/db/data/V1_12__offender_add_contact_with_outcome_type_data.sql
@@ -40,7 +40,7 @@ values (2502719240,
         null, -- OFFICE_LOCATION_ID
         3, -- ROW_VERSION
         null, -- ALERT_ACTIVE
-        null, -- ATTENDED
+        'Y', -- ATTENDED
         to_date('13-SEP-19','DD-MON-RR'),
         null,
         to_date('13-SEP-19','DD-MON-RR'), -- LAST_UPDATED_DATETIME

--- a/src/test/java/uk/gov/justice/digital/delius/controller/secure/AttendanceResourceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/controller/secure/AttendanceResourceTest.java
@@ -110,7 +110,7 @@ public class AttendanceResourceTest {
         final LocalDate attendanceDate1 = LocalDate.of(2019, Month.AUGUST, 24);
         final LocalDate attendanceDate2 = LocalDate.of(2020, Month.FEBRUARY, 29);
         final Contact contact1 = AttendanceServiceTest.getContactEntity(SOME_CONTACT_ID_1, attendanceDate1, null, null);
-        final Contact contact2 = AttendanceServiceTest.getContactEntity(SOME_CONTACT_ID_2, attendanceDate2, "1", "1");
+        final Contact contact2 = AttendanceServiceTest.getContactEntity(SOME_CONTACT_ID_2, attendanceDate2, "Y", "Y");
         final List<Contact> contacts = Arrays.asList(contact1, contact2);
 
         when(offenderService.offenderIdOfCrn(SOME_CRN)).thenReturn(Optional.of(SOME_OFFENDER_ID));

--- a/src/test/java/uk/gov/justice/digital/delius/service/AttendanceServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/AttendanceServiceTest.java
@@ -89,8 +89,8 @@ public class AttendanceServiceTest {
     }
 
     @Test
-    public void forEntityBooleanIs1() {
-        assertThat(forEntityBoolean("1")).isTrue();
+    public void forEntityBooleanIsTrue() {
+        assertThat(forEntityBoolean("Y")).isTrue();
     }
 
     @Test
@@ -101,7 +101,7 @@ public class AttendanceServiceTest {
     @Test
     public void attendancesFor() {
         final LocalDate attendanceDate = LocalDate.of(2000, Month.APRIL, 20);
-        final Contact contact = getContactEntity(SOME_CONTACT_ID, attendanceDate, "1", null);
+        final Contact contact = getContactEntity(SOME_CONTACT_ID, attendanceDate, "Y", null);
 
         // Act
         final List<Attendance> attendances = AttendanceService.attendancesFor(singletonList(contact));

--- a/src/test/java/uk/gov/justice/digital/delius/service/AttendanceServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/AttendanceServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static uk.gov.justice.digital.delius.service.AttendanceService.forEntityBoolean;
 
 import java.time.LocalDate;
 import java.time.Month;
@@ -81,21 +80,6 @@ public class AttendanceServiceTest {
 
         verify(contactRepository).findByOffenderAndEventId(SOME_OFFENDER_ID, SOME_EVENT_ID, today);
         verifyNoMoreInteractions(contactRepository);
-    }
-
-    @Test
-    public void forEntityBooleanNull() {
-        assertThat(forEntityBoolean(null)).isFalse();
-    }
-
-    @Test
-    public void forEntityBooleanIsTrue() {
-        assertThat(forEntityBoolean("Y")).isTrue();
-    }
-
-    @Test
-    public void forEntityBooleanIs0() {
-        assertThat(forEntityBoolean("0")).isFalse();
     }
 
     @Test

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AttendanceResourceAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AttendanceResourceAPITest.java
@@ -1,7 +1,11 @@
 package uk.gov.justice.digital.delius.controller.secure;
 
+import java.time.LocalDate;
+import java.time.Month;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import uk.gov.justice.digital.delius.data.api.Attendance;
+import uk.gov.justice.digital.delius.data.api.Attendance.ContactTypeDetail;
 import uk.gov.justice.digital.delius.data.api.Attendances;
 
 import static io.restassured.RestAssured.given;
@@ -80,6 +84,14 @@ public class AttendanceResourceAPITest extends IntegrationTestBase {
             .as(Attendances.class);
 
         assertThat(attendances.getAttendances().stream()).hasSize(1);
+        assertThat(attendances.getAttendances()).containsExactlyInAnyOrder(Attendance.builder()
+            .attended(true)
+            .attendanceDate(LocalDate.of(2020, Month.SEPTEMBER, 4))
+            .complied(false)
+            .contactType(ContactTypeDetail.builder().code("C084").description("3 Way Meeting (NS)").build())
+            .outcome("Appointment Kept")
+            .contactId(2502719240L)
+            .build());
     }
 
     @Test


### PR DESCRIPTION
Doing QA in dev / test environment, noticed that complied / attended were always returned as false. Turns out that the database stores these as Y / N. Seems like the database has various approaches to storage of what are boolean values. 