### PR TITLE
DT-1099 Update keydates and POM now require update role

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("uk.gov.justice.hmpps.gradle-spring-boot") version "1.0.0"
+    id("uk.gov.justice.hmpps.gradle-spring-boot") version "1.0.2"
     id 'groovy'
     id 'org.unbroken-dome.test-sets' version '3.0.1'
 }

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/CustodyKeyDatesController.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/CustodyKeyDatesController.java
@@ -41,7 +41,8 @@ public class CustodyKeyDatesController {
             @ApiResponse(code = 400, message = "The keyDate is not valid or a key date can not be added to an offender which does not have a single custody event"),
             @ApiResponse(code = 404, message = "The requested offender was not found.")
     })
-    @ApiOperation(value = "Adds or replaces a custody key date for the active custodial conviction")
+    @ApiOperation(value = "Adds or replaces a custody key date for the active custodial conviction", notes = "Requires role ROLE_COMMUNITY_CUSTODY_UPDATE")
+    @PreAuthorize("hasRole('ROLE_COMMUNITY_CUSTODY_UPDATE')")
     public CustodyKeyDate putCustodyKeyDateByCrn(final @PathVariable String crn,
                                                  final @PathVariable String typeCode,
                                                  final @RequestBody CreateCustodyKeyDate custodyKeyDate) {
@@ -56,7 +57,8 @@ public class CustodyKeyDatesController {
             @ApiResponse(code = 400, message = "The keyDate is not valid or a key date can not be added to an offender which does not have a single custody event"),
             @ApiResponse(code = 404, message = "The requested offender was not found.")
     })
-    @ApiOperation(value = "Adds or replaces a custody key date for the active custodial conviction")
+    @ApiOperation(value = "Adds or replaces a custody key date for the active custodial conviction", notes = "Requires role ROLE_COMMUNITY_CUSTODY_UPDATE")
+    @PreAuthorize("hasRole('ROLE_COMMUNITY_CUSTODY_UPDATE')")
     public CustodyKeyDate putCustodyKeyDateByNomsNumber(final @PathVariable String nomsNumber,
                                                         final @PathVariable String typeCode,
                                                         final @RequestBody CreateCustodyKeyDate custodyKeyDate) {
@@ -70,7 +72,7 @@ public class CustodyKeyDatesController {
             @ApiResponse(code = 401, message = "Request is missing Authorization header (no JWT)"),
             @ApiResponse(code = 404, message = "The requested offender or conviction was not found.")
     })
-    @ApiOperation(value = "Replaces all key dates specified in body. Key dates are either added or replaced or deleted if absent (see ReplaceCustodyKeyDates for the list). The the custodial conviction must be active")
+    @ApiOperation(value = "Replaces all key dates specified in body. Key dates are either added or replaced or deleted if absent (see ReplaceCustodyKeyDates for the list). The the custodial conviction must be active", notes = "Requires role ROLE_COMMUNITY_CUSTODY_UPDATE")
     @PreAuthorize("hasRole('ROLE_COMMUNITY_CUSTODY_UPDATE')")
     public Custody replaceAllCustodyKeyDateByNomsNumberAndBookingNumber(final @PathVariable String nomsNumber,
                                                                         final @PathVariable String bookingNumber,
@@ -94,7 +96,8 @@ public class CustodyKeyDatesController {
             @ApiResponse(code = 400, message = "The keyDate is not valid or a key date can not be added to an offender which does not have a single custody event"),
             @ApiResponse(code = 404, message = "The requested offender was not found.")
     })
-    @ApiOperation(value = "Adds or replaces a custody key date for the active custodial conviction")
+    @ApiOperation(value = "Adds or replaces a custody key date for the active custodial conviction", notes = "Requires role ROLE_COMMUNITY_CUSTODY_UPDATE")
+    @PreAuthorize("hasRole('ROLE_COMMUNITY_CUSTODY_UPDATE')")
     public CustodyKeyDate putCustodyKeyDateByOffenderId(final @PathVariable Long offenderId,
                                                         final @PathVariable String typeCode,
                                                         final @RequestBody CreateCustodyKeyDate custodyKeyDate) {
@@ -109,7 +112,8 @@ public class CustodyKeyDatesController {
             @ApiResponse(code = 400, message = "The keyDate is not valid or a key date can not be added to an offender which does not have a single custody event"),
             @ApiResponse(code = 404, message = "The requested conviction with associated prison booking was not found.")
     })
-    @ApiOperation(value = "Adds or replaces a custody key date for the active custodial conviction")
+    @ApiOperation(value = "Adds or replaces a custody key date for the active custodial conviction", notes = "Requires role ROLE_COMMUNITY_CUSTODY_UPDATE")
+    @PreAuthorize("hasRole('ROLE_COMMUNITY_CUSTODY_UPDATE')")
     public CustodyKeyDate putCustodyKeyDateByPrisonBookingNumber(final @PathVariable String prisonBookingNumber,
                                                                  final @PathVariable String typeCode,
                                                                  final @RequestBody CreateCustodyKeyDate custodyKeyDate) {
@@ -250,7 +254,8 @@ public class CustodyKeyDatesController {
             @ApiResponse(code = 400, message = "The keyDate is not valid or a key date can not be deleted from an offender which does not have a single custody event"),
             @ApiResponse(code = 404, message = "The requested offender was not found.")
     })
-    @ApiOperation(value = "Deletes the custody key date for the active custodial conviction")
+    @ApiOperation(value = "Deletes the custody key date for the active custodial conviction", notes = "Requires role ROLE_COMMUNITY_CUSTODY_UPDATE")
+    @PreAuthorize("hasRole('ROLE_COMMUNITY_CUSTODY_UPDATE')")
     public void deleteCustodyKeyDateByCrn(final @PathVariable String crn,
                                           final @PathVariable String typeCode) {
         log.info("Call to deleteCustodyKeyDateByCrn for {} code {}", crn, typeCode);
@@ -264,8 +269,8 @@ public class CustodyKeyDatesController {
             @ApiResponse(code = 400, message = "The keyDate is not valid or a key date can not be deleted from an offender which does not have a single custody event"),
             @ApiResponse(code = 404, message = "The requested offender was not found.")
     })
-    @ApiOperation(value = "Deletes the custody key date for the active custodial conviction")
-
+    @ApiOperation(value = "Deletes the custody key date for the active custodial conviction", notes = "Requires role ROLE_COMMUNITY_CUSTODY_UPDATE")
+    @PreAuthorize("hasRole('ROLE_COMMUNITY_CUSTODY_UPDATE')")
     public void deleteCustodyKeyDateByNomsNumber(final @PathVariable String nomsNumber,
                                                  final @PathVariable String typeCode) {
         log.info("Call to deleteCustodyKeyDateByNomsNumber for {} code {}", nomsNumber, typeCode);
@@ -279,7 +284,8 @@ public class CustodyKeyDatesController {
             @ApiResponse(code = 400, message = "The keyDate is not valid or a key date can not be deleted from an offender which does not have a single custody event"),
             @ApiResponse(code = 404, message = "The requested offender was not found.")
     })
-    @ApiOperation(value = "Deletes the custody key date for the active custodial conviction")
+    @ApiOperation(value = "Deletes the custody key date for the active custodial conviction", notes = "Requires role ROLE_COMMUNITY_CUSTODY_UPDATE")
+    @PreAuthorize("hasRole('ROLE_COMMUNITY_CUSTODY_UPDATE')")
     public void deleteCustodyKeyDateByOffenderId(final @PathVariable Long offenderId,
                                                  final @PathVariable String typeCode) {
         log.info("Call to deleteCustodyKeyDateByOffenderId for {} code {}", offenderId, typeCode);
@@ -293,7 +299,8 @@ public class CustodyKeyDatesController {
             @ApiResponse(code = 400, message = "The keyDate is not valid"),
             @ApiResponse(code = 404, message = "The requested prison booking was not found.")
     })
-    @ApiOperation(value = "Deletes the custody key date for the associated custodial conviction")
+    @ApiOperation(value = "Deletes the custody key date for the associated custodial conviction", notes = "Requires role ROLE_COMMUNITY_CUSTODY_UPDATE")
+    @PreAuthorize("hasRole('ROLE_COMMUNITY_CUSTODY_UPDATE')")
     public void deleteCustodyKeyDateByPrisonBookingNumber(final @PathVariable String prisonBookingNumber,
                                                           final @PathVariable String typeCode) {
         log.info("Call to deleteCustodyKeyDateByPrisonBookingNumber for {} code {}", prisonBookingNumber, typeCode);

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
@@ -293,7 +293,8 @@ public class OffendersResource {
             @ApiResponse(code = 401, message = "Request is missing Authorization header (no JWT)"),
             @ApiResponse(code = 404, message = "The offender or prison institution is not found")
     })
-    @ApiOperation(value = "Allocates the prison offender manager for an offender in custody. This operation may also have a side affect of creating a Staff member if one matching the name does not already exist. An existing staff member can be used if the staff code is supplied.")
+    @ApiOperation(value = "Allocates the prison offender manager for an offender in custody. This operation may also have a side affect of creating a Staff member if one matching the name does not already exist. An existing staff member can be used if the staff code is supplied.", notes = "Requires role ROLE_COMMUNITY_CUSTODY_UPDATE")
+    @PreAuthorize("hasRole('ROLE_COMMUNITY_CUSTODY_UPDATE')")
     public CommunityOrPrisonOffenderManager allocatePrisonOffenderManagerByNomsNumber(final @PathVariable String nomsNumber,
                                                                                       final @RequestBody CreatePrisonOffenderManager prisonOffenderManager) {
         log.info("Request to allocate a prison offender manager to {} at prison with code {}", nomsNumber, prisonOffenderManager.getNomsPrisonInstitutionCode());

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyKeyDatesAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyKeyDatesAPITest.java
@@ -44,11 +44,89 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
 
 
     @Test
+    void withoutUpdateRoleAccessWillBeDenied() {
+        final var token = createJwt("ROLE_COMMUNITY");
+
+        given()
+                .auth().oauth2(token)
+                .contentType("application/json")
+                .body(createCustodyKeyDate())
+                .when()
+                .put(String.format("offenders/crn/%s/custody/keyDates/POM1",  CRN))
+                .then()
+                .statusCode(403);
+
+        given()
+                .auth().oauth2(token)
+                .contentType("application/json")
+                .body(createCustodyKeyDate())
+                .when()
+                .put(String.format("offenders/nomsNumber/%s/custody/keyDates/POM1",  NOMS_NUMBER))
+                .then()
+                .statusCode(403);
+
+        given()
+                .auth().oauth2(token)
+                .contentType("application/json")
+                .body(createCustodyKeyDate())
+                .when()
+                .put(String.format("offenders/offenderId/%s/custody/keyDates/POM1",  OFFENDER_ID))
+                .then()
+                .statusCode(403);
+
+        given()
+                .auth().oauth2(token)
+                .contentType("application/json")
+                .body(createCustodyKeyDate())
+                .when()
+                .put(String.format("offenders/prisonBookingNumber/%s/custody/keyDates/POM1", PRISON_BOOKING_NUMBER))
+                .then()
+                .statusCode(403);
+
+
+        given()
+                .auth().oauth2(token)
+                .contentType("application/json")
+                .body(createCustodyKeyDate())
+                .when()
+                .delete(String.format("offenders/crn/%s/custody/keyDates/POM1",  CRN))
+                .then()
+                .statusCode(403);
+
+        given()
+                .auth().oauth2(token)
+                .contentType("application/json")
+                .body(createCustodyKeyDate())
+                .when()
+                .delete(String.format("offenders/nomsNumber/%s/custody/keyDates/POM1",  NOMS_NUMBER))
+                .then()
+                .statusCode(403);
+
+        given()
+                .auth().oauth2(token)
+                .contentType("application/json")
+                .body(createCustodyKeyDate())
+                .when()
+                .delete(String.format("offenders/offenderId/%s/custody/keyDates/POM1",  OFFENDER_ID))
+                .then()
+                .statusCode(403);
+
+        given()
+                .auth().oauth2(token)
+                .contentType("application/json")
+                .body(createCustodyKeyDate())
+                .when()
+                .delete(String.format("offenders/prisonBookingNumber/%s/custody/keyDates/POM1", PRISON_BOOKING_NUMBER))
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
     public void anAddedKeyDateCanBeRetrievedByCRN()  {
         LocalDate tomorrow = LocalDate.now().plusDays(1);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(tomorrow))
                 .when()
@@ -78,12 +156,19 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
                 .build());
     }
 
+    private String createCustodyKeyDate() {
+        return writeValueAsString(CreateCustodyKeyDate
+                .builder()
+                .date(LocalDate.now().plusDays(1))
+                .build());
+    }
+
     @Test
     public void anAddedKeyDateCanBeRetrievedByNOMSNumber() {
         LocalDate tomorrow = LocalDate.now().plusDays(1);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(tomorrow))
                 .when()
@@ -110,7 +195,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
         LocalDate tomorrow = LocalDate.now().plusDays(1);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(tomorrow))
                 .when()
@@ -137,7 +222,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
         LocalDate tomorrow = LocalDate.now().plusDays(1);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(tomorrow))
                 .when()
@@ -165,7 +250,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
         LocalDate tomorrow = LocalDate.now().plusDays(1);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(tomorrow))
                 .when()
@@ -174,7 +259,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
                 .statusCode(200);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(tomorrow))
                 .when()
@@ -253,7 +338,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
         LocalDate dayAfterNext = LocalDate.now().plusDays(2);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(tomorrow))
                 .when()
@@ -262,7 +347,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
                 .statusCode(200);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(dayAfterNext))
                 .when()
@@ -291,7 +376,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
         LocalDate dayAfterNext = LocalDate.now().plusDays(2);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(tomorrow))
                 .when()
@@ -307,7 +392,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
                 .statusCode(200);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(dayAfterNext))
                 .when()
@@ -328,7 +413,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
         LocalDate dayAfterNext = LocalDate.now().plusDays(2);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(tomorrow))
                 .when()
@@ -344,7 +429,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
                 .statusCode(200);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(dayAfterNext))
                 .when()
@@ -366,7 +451,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
         LocalDate dayAfterNext = LocalDate.now().plusDays(2);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(tomorrow))
                 .when()
@@ -382,7 +467,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
                 .statusCode(200);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(dayAfterNext))
                 .when()
@@ -403,7 +488,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
         LocalDate dayAfterNext = LocalDate.now().plusDays(2);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(tomorrow))
                 .when()
@@ -419,7 +504,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
                 .statusCode(200);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(dayAfterNext))
                 .when()
@@ -438,7 +523,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
     @Test
     public void shouldRespond404WhenOffenderNotFound()  {
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(LocalDate.now()))
                 .when()
@@ -447,7 +532,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
                 .statusCode(404);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .when()
                 .delete("offenders/nomsNumber/DOESNOTEXIST/custody/keyDates/POM1")
                 .then()
@@ -461,7 +546,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
                 .statusCode(404);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(LocalDate.now()))
                 .when()
@@ -470,7 +555,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
                 .statusCode(404);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .when()
                 .delete("offenders/crn/DOESNOTEXIST/custody/keyDates/POM1")
                 .then()
@@ -484,7 +569,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
                 .statusCode(404);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(LocalDate.now()))
                 .when()
@@ -507,7 +592,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
                 .statusCode(404);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(LocalDate.now()))
                 .when()
@@ -516,7 +601,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
                 .statusCode(404);
 
         given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .when()
                 .delete("offenders/prisonBookingNumber/DOESNOTEXIST/custody/keyDates/POM1")
                 .then()
@@ -535,7 +620,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
     @Test
     public void shouldRespond400WhenAddingKeyDateThatIsNotValid()  {
         JsonPath  errorMessage = given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(LocalDate.now()))
                 .when()
@@ -552,7 +637,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
     @Test
     public void shouldRespond400WhenOffenderHasInvalidActiveCustodyEvents()  {
         JsonPath errorMessage = given()
-                .auth().oauth2(tokenWithRoleCommunity())
+                .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType("application/json")
                 .body(createCustodyKeyDateOf(LocalDate.now()))
                 .when()
@@ -667,7 +752,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
 
             // GIVEN I hae added some POM key dates from OMiC
             given()
-                    .auth().oauth2(tokenWithRoleCommunity())
+                    .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                     .contentType("application/json")
                     .body(createCustodyKeyDateOf(LocalDate.of(2030, 1, 8)))
                     .when()
@@ -676,7 +761,7 @@ public class CustodyKeyDatesAPITest extends IntegrationTestBase {
                     .statusCode(200);
 
             given()
-                    .auth().oauth2(tokenWithRoleCommunity())
+                    .auth().oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                     .contentType("application/json")
                     .body(createCustodyKeyDateOf(LocalDate.of(2030, 1, 9)))
                     .when()

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/IntegrationTestBase.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/IntegrationTestBase.java
@@ -60,6 +60,10 @@ public class IntegrationTestBase {
         return createJwt("ROLE_COMMUNITY");
     }
 
+    protected String tokenWithRoleCommunityAndCustodyUpdate() {
+        return createJwt("ROLE_COMMUNITY", "ROLE_COMMUNITY_CUSTODY_UPDATE");
+    }
+
     protected String writeValueAsString(Object data) {
         try {
             return objectMapper.writeValueAsString(data);

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_AllocatePrisonOffenderManagerTest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_AllocatePrisonOffenderManagerTest.java
@@ -21,10 +21,23 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @ExtendWith( FlywayRestoreExtension.class)
 public class OffendersResource_AllocatePrisonOffenderManagerTest  extends IntegrationTestBase  {
     @Test
+    public void mustHaveUpdateRoleToAllocatedPOM() {
+        given()
+                .auth()
+                .oauth2(tokenWithRoleCommunity())
+                .contentType(APPLICATION_JSON_VALUE)
+                .contentType("application/json")
+                .body(createPrisonOffenderManagerOf("BWIA010", "BWI"))
+                .when()
+                .put("/offenders/nomsNumber/G0560UO/prisonOffenderManager")
+                .then()
+                .statusCode(403);
+    }
+    @Test
     public void canAllocatePrisonOffenderManagersByNOMSNumberAndStaffCode() {
         final var offenderManagersBeforeAllocation = given()
                 .auth()
-                .oauth2(tokenWithRoleCommunity())
+                .oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType(APPLICATION_JSON_VALUE)
                 .when()
                 .get("/offenders/nomsNumber/G0560UO/allOffenderManagers")
@@ -40,7 +53,7 @@ public class OffendersResource_AllocatePrisonOffenderManagerTest  extends Integr
 
         final var newPrisonOffenderManager = given()
                 .auth()
-                .oauth2(tokenWithRoleCommunity())
+                .oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType(APPLICATION_JSON_VALUE)
                 .contentType("application/json")
                 .body(createPrisonOffenderManagerOf("BWIA010", "BWI"))
@@ -126,7 +139,7 @@ public class OffendersResource_AllocatePrisonOffenderManagerTest  extends Integr
 
         final var newPrisonOffenderManager = given()
                 .auth()
-                .oauth2(tokenWithRoleCommunity())
+                .oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType(APPLICATION_JSON_VALUE)
                 .contentType("application/json")
                 .body(createPrisonOffenderManagerOf(Human
@@ -205,7 +218,7 @@ public class OffendersResource_AllocatePrisonOffenderManagerTest  extends Integr
 
         final var newPrisonOffenderManager = given()
                 .auth()
-                .oauth2(tokenWithRoleCommunity())
+                .oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType(APPLICATION_JSON_VALUE)
                 .contentType("application/json")
                 .body(createPrisonOffenderManagerOf("BWIA010", "BWI"))
@@ -247,7 +260,7 @@ public class OffendersResource_AllocatePrisonOffenderManagerTest  extends Integr
     public void shouldRespondWith404WhenAllocatingPrisonOffenderManagersAndExistingStaffNotFound() {
         given()
                 .auth()
-                .oauth2(tokenWithRoleCommunity())
+                .oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType(APPLICATION_JSON_VALUE)
                 .contentType("application/json")
                 .body(createPrisonOffenderManagerOf("DOESNOTEXIST"))
@@ -261,7 +274,7 @@ public class OffendersResource_AllocatePrisonOffenderManagerTest  extends Integr
     public void shouldRespondWith404WhenAllocatingPrisonOffenderManagersAndOffenderNotFound() {
         given()
                 .auth()
-                .oauth2(tokenWithRoleCommunity())
+                .oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType(APPLICATION_JSON_VALUE)
                 .contentType("application/json")
                 .body(createPrisonOffenderManagerOf("BWIA010"))
@@ -275,7 +288,7 @@ public class OffendersResource_AllocatePrisonOffenderManagerTest  extends Integr
     public void shouldRespondWith400WhenAllocatingPrisonOffenderManagersAndPrisonInstitutionNotFound() {
         given()
                 .auth()
-                .oauth2(tokenWithRoleCommunity())
+                .oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType(APPLICATION_JSON_VALUE)
                 .contentType("application/json")
                 .body(createPrisonOffenderManagerOf("BWIA010", "DOESNOTEXIST"))
@@ -289,7 +302,7 @@ public class OffendersResource_AllocatePrisonOffenderManagerTest  extends Integr
     public void shouldRespondWith400WhenStaffMemberNotInThePrisonInstitutionProbationArea() {
         given()
                 .auth()
-                .oauth2(tokenWithRoleCommunity())
+                .oauth2(tokenWithRoleCommunityAndCustodyUpdate())
                 .contentType(APPLICATION_JSON_VALUE)
                 .contentType("application/json")
                 .body(createPrisonOffenderManagerOf("BWIA010", "WWI"))


### PR DESCRIPTION
1. Endpoints that update POMs and Key Dates new require the ROLE_COMMUNITY_CUSTODY_UPDATE role
2. OWASP fix