### PR TITLE
DCS-607 New end-points for retrieving staff details and managed offenders by staffIdentifier

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/StaffResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/StaffResource.java
@@ -26,7 +26,8 @@ public class StaffResource {
 
     private final StaffService staffService;
 
-    @ApiOperation(value = "Return list of of currently managed offenders for one responsible officer (RO)", notes = "Accepts a Delius staff officer code")
+    @Deprecated(forRemoval = true)
+    @ApiOperation(value = "Deprecated. Return list of of currently managed offenders for one responsible officer (RO)", notes = "Accepts a Delius staff officer code")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK", response = ManagedOffender.class, responseContainer = "List"),
             @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
@@ -42,7 +43,24 @@ public class StaffResource {
                 .orElseThrow(() -> new NotFoundException(String.format("Staff member with code %s", staffCode)));
     }
 
-    @ApiOperation(value = "Return details of a staff member including option user details", notes = "Accepts a Delius staff officer code")
+    @ApiOperation(value = "Return list of of currently managed offenders for one responsible officer (RO)", notes = "Accepts a Delius staff officer identifier")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "OK", response = ManagedOffender.class, responseContainer = "List"),
+            @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
+            @ApiResponse(code = 401, message = "Unauthorised", response = ErrorResponse.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = ErrorResponse.class),
+            @ApiResponse(code = 404, message = "Not found", response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)})
+    @GetMapping(path = "/staff/staffIdentifier/{staffIdentifier}/managedOffenders")
+    public List<ManagedOffender> getOffendersForResponsibleOfficerIdentifier(
+            @ApiParam(name = "staffIdentifier", value = "Delius officer identifier of the responsible officer", example = "123456", required = true) @NotNull @PathVariable(value = "staffIdentifier") final Long staffIdentifier,
+            @ApiParam(name = "current", value = "Current only", example = "false") @RequestParam(name = "current", required = false, defaultValue = "false") final boolean current) {
+        return staffService.getManagedOffendersByStaffIdentifier(staffIdentifier, current)
+                .orElseThrow(() -> new NotFoundException(String.format("Staff member with identifier %d", staffIdentifier)));
+    }
+
+    @Deprecated(forRemoval = true)
+    @ApiOperation(value = "Deprecated. Return details of a staff member including option user details", notes = "Accepts a Delius staff officer code")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK", response = StaffDetails.class),
             @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
@@ -58,6 +76,24 @@ public class StaffResource {
         log.info("getStaffDetails called with {}", staffCode);
         return staffService.getStaffDetails(staffCode)
                 .orElseThrow(() -> new NotFoundException(String.format("Staff member with code %s", staffCode)));
+    }
+
+    @ApiOperation(value = "Return details of a staff member including option user details", notes = "Accepts a Delius staff officer identifier")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "OK", response = StaffDetails.class),
+            @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
+            @ApiResponse(code = 401, message = "Unauthorised", response = ErrorResponse.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = ErrorResponse.class),
+            @ApiResponse(code = 404, message = "Not found", response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)})
+    @GetMapping(path = "/staff/staffIdentifier/{staffIdentifier}")
+    public StaffDetails getStaffDetailsForStaffIdentifier(
+            @ApiParam(name = "staffIdentifier", value = "Delius officer identifier", example = "123456", required = true)
+            @NotNull
+            @PathVariable(value = "staffIdentifier") final long staffIdentifier) {
+        log.info("getStaffDetailsForStaffIdentifier called with {}", staffIdentifier);
+        return staffService.getStaffDetailsByStaffIdentifier(staffIdentifier)
+                .orElseThrow(() -> new NotFoundException(String.format("Staff member with identifier %s", staffIdentifier)));
     }
 
     @ApiOperation(value = "Return details of a staff member including user details", notes = "Accepts a Delius staff username")

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ManagedOffender.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ManagedOffender.java
@@ -17,6 +17,8 @@ public class ManagedOffender {
     @ApiModelProperty(required = true)
     private String staffCode;
     @ApiModelProperty(required = true)
+    private Long staffIdentifier;
+    @ApiModelProperty(required = true)
     private Long offenderId;
     @ApiModelProperty(required = true)
     private String nomsNumber;

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/StaffDetails.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/StaffDetails.java
@@ -14,12 +14,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class StaffDetails {
-    @ApiModelProperty(value = "the optional username of this staff member, will be absent if the staff member is not a user of Delius", required = false, example = "SheilaHancockNPS")
+    @ApiModelProperty(value = "the optional username of this staff member, will be absent if the staff member is not a user of Delius", example = "SheilaHancockNPS")
     private String username;
-    @ApiModelProperty(value = "the optional email address of this staff member, will be absent if the staff member is not a user of Delius", required = false, example = "sheila.hancock@test.justice.gov.uk")
+    @ApiModelProperty(value = "the optional email address of this staff member, will be absent if the staff member is not a user of Delius", example = "sheila.hancock@test.justice.gov.uk")
     private String email;
     @ApiModelProperty(value = "staff code AKA officer code", example = "SH0001")
     private String staffCode;
+    @ApiModelProperty(value = "staff identifier", example = "123456")
+    private Long staffIdentifier;
     @ApiModelProperty(value = "staff name details")
     private Human staff;
     @ApiModelProperty(value = "all teams related to this staff member")

--- a/src/main/java/uk/gov/justice/digital/delius/service/StaffService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/StaffService.java
@@ -40,9 +40,31 @@ public class StaffService {
     }
 
     @Transactional(readOnly = true)
+    public Optional<List<ManagedOffender>> getManagedOffendersByStaffIdentifier(final long staffIdentifier, final boolean current) {
+
+        return staffRepository.findByStaffId(staffIdentifier).map(
+                staff -> OffenderTransformer.managedOffenderOf(staff, current)
+        );
+    }
+
+    @Transactional(readOnly = true)
     public Optional<StaffDetails> getStaffDetails(final String staffCode) {
         return staffRepository
                 .findByOfficerCode(staffCode)
+                .map(StaffTransformer::staffDetailsOf)
+                .map(staffDetails ->
+                        Optional.ofNullable(staffDetails.getUsername())
+                                .map(username -> staffDetails
+                                        .toBuilder()
+                                        .email(ldapRepository.getEmail(username))
+                                        .build())
+                                .orElse(staffDetails));
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<StaffDetails> getStaffDetailsByStaffIdentifier(final long staffIdentifier) {
+        return staffRepository
+                .findByStaffId(staffIdentifier)
                 .map(StaffTransformer::staffDetailsOf)
                 .map(staffDetails ->
                         Optional.ofNullable(staffDetails.getUsername())

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/OffenderTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/OffenderTransformer.java
@@ -407,6 +407,7 @@ public class OffenderTransformer {
 
         return ManagedOffender.builder()
                 .staffCode(staff.getOfficerCode())
+                .staffIdentifier(staff.getStaffId())
                 .offenderId(om.getOffenderId())
                 .nomsNumber(Optional.ofNullable(om.getManagedOffender()).map(Offender::getNomsNumber).orElse(null))
                 .crnNumber(Optional.ofNullable(om.getManagedOffender()).map(Offender::getCrn).orElse(null))
@@ -423,6 +424,7 @@ public class OffenderTransformer {
 
         return ManagedOffender.builder()
                 .staffCode(staff.getOfficerCode())
+                .staffIdentifier(staff.getStaffId())
                 .offenderId(pom.getOffenderId())
                 .nomsNumber(Optional.ofNullable(pom.getManagedOffender()).map(Offender::getNomsNumber).orElse(null))
                 .crnNumber(Optional.ofNullable(pom.getManagedOffender()).map(Offender::getCrn).orElse(null))

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/StaffTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/StaffTransformer.java
@@ -15,6 +15,7 @@ public class StaffTransformer {
         return StaffDetails.builder()
                 .staff(humanOf(staff))
                 .staffCode(staff.getOfficerCode())
+                .staffIdentifier(staff.getStaffId())
                 .username(
                     Optional.ofNullable(staff.getUser()).map(User::getDistinguishedName).orElse(null))
                 .teams(staff.getTeams().stream()
@@ -28,7 +29,7 @@ public class StaffTransformer {
         Optional<String> maybeThirdName = Optional.ofNullable(thirdName);
 
         return Stream.of(maybeSecondName, maybeThirdName)
-                .flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty))
+                .flatMap(Optional::stream)
                 .collect(Collectors.joining(" "));
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/OffenderTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/OffenderTransformerTest.java
@@ -144,16 +144,15 @@ public class OffenderTransformerTest {
                 .get(0))
                 .hasFieldOrPropertyWithValue("nomsNumber", "A1111")
                 .hasFieldOrPropertyWithValue("offenderSurname", "SMITH")
-                .hasFieldOrPropertyWithValue("staffCode", "AAAA");
+                .hasFieldOrPropertyWithValue("staffCode", "AAAA")
+                .hasFieldOrPropertyWithValue("staffIdentifier", 3L);
     }
 
     @Test
     public void allManagedOffenders() {
 
         // Get current and past managed offenders for this officer
-        assertThat(OffenderTransformer.managedOffenderOf(anOfficerWithOffenderManagers(), false)
-                .stream()
-                .collect(Collectors.toList()))
+        assertThat(new ArrayList<>(OffenderTransformer.managedOffenderOf(anOfficerWithOffenderManagers(), false)))
                 .hasSize(2);
     }
 
@@ -205,8 +204,7 @@ public class OffenderTransformerTest {
     private List<OffenderManager> aListOfOffenderManagers() {
 
         // List of offender managers managing the same offender with one current and one historical
-        List<OffenderManager> offenderManagers = ImmutableList.of(
-
+        return ImmutableList.of(
                 aOffenderManager()
                         .toBuilder()
                         .offenderManagerId(1L)
@@ -235,38 +233,30 @@ public class OffenderTransformerTest {
                         .managedOffender(anOffenderWithoutManagers())
                         .build()
         );
-
-        return offenderManagers;
     }
 
     private List<PrisonOffenderManager> aListOfPrisonOffenderManagers() {
-
-        List<PrisonOffenderManager> prisonOffenderManagers = new ArrayList<PrisonOffenderManager>();
-        return prisonOffenderManagers;
+        return new ArrayList<>();
     }
 
     private Offender anOffenderWithoutManagers() {
 
-        Offender offender = Offender.builder()
+        return Offender.builder()
                 .offenderId(1L)
                 .surname("SMITH")
                 .nomsNumber("A1111")
                 .build();
-
-        return offender;
     }
 
     private Offender anOffenderWithManagers() {
 
-        Offender offender = Offender.builder()
+        return Offender.builder()
                 .offenderId(1L)
                 .surname("SMITH")
                 .nomsNumber("A1111")
                 .offenderManagers(aListOfOffenderManagers())
                 .prisonOffenderManagers(aListOfPrisonOffenderManagers())
                 .build();
-
-        return offender;
     }
 
 

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/StaffTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/StaffTransformerTest.java
@@ -36,6 +36,20 @@ public class StaffTransformerTest {
     }
 
     @Test
+    public void staffIdentifierTakenFromStaff() {
+        assertThat(StaffTransformer.staffDetailsOf(
+                aStaff()
+                        .toBuilder()
+                        .forename("John")
+                        .surname("Smith")
+                        .officerCode("XXXXX")
+                        .staffId(1L)
+                        .build()).getStaffIdentifier())
+                .isEqualTo(1L);
+    }
+
+
+    @Test
     public void teamsTakenFromStaff() {
         assertThat(StaffTransformer.staffDetailsOf(
                                         aStaff()

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/StaffResource_ManagedOffendersAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/StaffResource_ManagedOffendersAPITest.java
@@ -1,0 +1,109 @@
+package uk.gov.justice.digital.delius.controller.secure;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.justice.digital.delius.data.api.ManagedOffender;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+public class StaffResource_ManagedOffendersAPITest extends IntegrationTestBase {
+    @Test
+    public void getCurrentManagedOffendersForOfficer() {
+        ManagedOffender[] managedOffenders = given()
+                .auth()
+                .oauth2(tokenWithRoleCommunity())
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .get("staff/staffIdentifier/11/managedOffenders?current=true")
+                .then()
+                .extract()
+                .body()
+                .as(ManagedOffender[].class);
+
+        List<ManagedOffender> mos = Arrays.asList(managedOffenders);
+        assertThat(mos).hasSize(3);
+        assertThat(mos).extracting("staffIdentifier").contains(11L, 11L, 11L);
+    }
+
+    @Test
+    public void getAllManagedOffendersForOfficer() {
+        ManagedOffender[] managedOffenders = given()
+                .auth()
+                .oauth2(tokenWithRoleCommunity())
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .get("staff/staffIdentifier/11/managedOffenders")
+                .then()
+                .extract()
+                .body()
+                .as(ManagedOffender[].class);
+
+        List<ManagedOffender> mos = Arrays.asList(managedOffenders);
+        assertThat(mos).hasSize(3);
+    }
+
+    @Test
+    public void getInvalidOfficerNotFound() {
+
+        given()
+                .auth()
+                .oauth2(tokenWithRoleCommunity())
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .get("staff/staffIdentifier/9999/managedOffenders")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void getManagedOffendersSoftDeletedCheck() {
+
+        /*
+         This officer has two offenders assigned but one is SOFT_DELETED in seed data.
+         The response should be only one managed offender - G3232VA.
+        */
+
+        ManagedOffender[] managedOffenders =
+                given()
+                        .auth()
+                        .oauth2(tokenWithRoleCommunity())
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .when()
+                        .get("/staff/staffIdentifier/18/managedOffenders")
+                        .then()
+                        .statusCode(200)
+                        .extract()
+                        .body()
+                        .as(ManagedOffender[].class);
+
+        List<ManagedOffender> mos = Arrays.asList(managedOffenders);
+        assertThat(mos).hasSize(1);
+        assertThat(mos.get(0).getNomsNumber()).isEqualToIgnoringCase("G3232VA");
+    }
+
+    @Test
+    public void getUnassignedOfficerEmptyList() {
+
+        ManagedOffender[] managedOffenders =
+                given()
+                        .auth()
+                        .oauth2(tokenWithRoleCommunity())
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .when()
+                        .get("/staff/staffIdentifier/16/managedOffenders")
+                        .then()
+                        .statusCode(200)
+                        .extract()
+                        .body()
+                        .as(ManagedOffender[].class);
+
+        List<ManagedOffender> mos = Arrays.asList(managedOffenders);
+        assertThat(mos).isEmpty();
+    }
+
+
+}

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/StaffResource_StaffDetailsAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/StaffResource_StaffDetailsAPITest.java
@@ -31,6 +31,24 @@ public class StaffResource_StaffDetailsAPITest extends IntegrationTestBase {
     }
 
     @Test
+    public void canRetrieveStaffDetailsByStaffIdentifier() {
+
+        val staffDetails = given()
+                .auth()
+                .oauth2(tokenWithRoleCommunity())
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .get("staff/staffIdentifier/11")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(StaffDetails.class);
+
+        assertThat(staffDetails).isNotNull();
+    }
+
+    @Test
     public void retrievingStaffDetailsReturn404WhenStaffDoesNotExist() {
 
         given()
@@ -39,6 +57,19 @@ public class StaffResource_StaffDetailsAPITest extends IntegrationTestBase {
                 .contentType(APPLICATION_JSON_VALUE)
                 .when()
                 .get("staff/staffCode/XXXXX")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void retrievingStaffDetailsByStaffIdentifierReturn404WhenStaffDoesNotExist() {
+
+        given()
+                .auth()
+                .oauth2(tokenWithRoleCommunity())
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .get("staff/staffIdentifier/99999")
                 .then()
                 .statusCode(404);
     }
@@ -157,7 +188,7 @@ public class StaffResource_StaffDetailsAPITest extends IntegrationTestBase {
     @Test
     public void retrieveMultipleUserDetailsWithNoBodyContentReturn400() {
 
-            given()
+        given()
                 .auth()
                 .oauth2(tokenWithRoleCommunity())
                 .contentType(APPLICATION_JSON_VALUE)


### PR DESCRIPTION
New secure endpoints for retrieving staff details and managed offenders by staff identifier (staff id)
```
GET /secure/staff/staffIdentifier/{staffIdentifier}
GET /secure/staff/staffIdentifier/{staffIdentifier}/managedOffenders
```
Also added staffIdentifier property to `...api.StaffDetails` and `...api.ManagedOffender`

Happy to change `staffIdentifier` to `staffId` if the abbreviation is preferred...