### PR TITLE
DT-1195 Get rid of confusing exceptions in log

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/config/ClientTrackingTelemetryModule.java
+++ b/src/main/java/uk/gov/justice/digital/delius/config/ClientTrackingTelemetryModule.java
@@ -41,7 +41,8 @@ public class ClientTrackingTelemetryModule implements WebTelemetryModule, Teleme
                 properties.put("clientId", String.valueOf(jwtBody.getClaim("client_id")));
 
             } catch (ParseException e) {
-                log.warn("problem decoding jwt public key for application insights", e);
+                // we have a bearer token we don't understand.
+                // this can happen from AWS health checks for instance - so just silently ignore
             }
         }
     }

--- a/src/main/java/uk/gov/justice/digital/delius/controller/advice/GeneralControllerAdvice.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/advice/GeneralControllerAdvice.java
@@ -40,5 +40,12 @@ public class GeneralControllerAdvice {
                 .status(e.getRawStatusCode())
                 .body(e.getResponseBodyAsByteArray());
     }
+
+    @ExceptionHandler(WebClientResponseException.NotFound.class)
+    public ResponseEntity<byte[]> handleException(final WebClientResponseException.NotFound e) {
+        return ResponseEntity
+                .status(e.getRawStatusCode())
+                .body(e.getResponseBodyAsByteArray());
+    }
 }
 


### PR DESCRIPTION
Suppress exception under these categories that is polluting logs:

1. AWS `health/ping` is sending a bearer token that we don't care about
2. case notes correctly return 404 - but we don't need an exception in the logs for that