### PR TITLE
DT-1249 Improve Swagger documentation. Split out private APIs and add…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CircleCI](https://circleci.com/gh/ministryofjustice/community-api/tree/main.svg?style=svg)](https://circleci.com/gh/ministryofjustice/community-api)
 [![Docker Repository on Quay](https://quay.io/repository/hmpps/community-api/status "Docker Repository on Quay")](https://quay.io/repository/hmpps/community-api)
 [![Runbook](https://img.shields.io/badge/runbook-view-172B4D.svg?logo=confluence)](https://dsdmoj.atlassian.net/wiki/spaces/NOM/pages/1739325587/DPS+Runbook#Deploying-Community-API)
-[![API docs](https://img.shields.io/badge/API_docs_-view-85EA2D.svg?logo=swagger)](https://community-api-public.test.delius.probation.hmpps.dsd.io/swagger-ui.html)
+[![API docs](https://img.shields.io/badge/API_docs_-view-85EA2D.svg?logo=swagger)](https://community-api-public.test.delius.probation.hmpps.dsd.io/swagger-ui/index.html)
 
 # Community API
 Spring Boot 2, Java 11 API for accessing Probation offenders information

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ check.dependsOn(testIntegration)
 dependencies {
     implementation files('lib/ojdbc8-12.2.0.1.jar')
 
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.2'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-ldap'
@@ -24,9 +24,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
 
     implementation 'com.unboundid:unboundid-ldapsdk:4.0.14'
-    implementation 'io.springfox:springfox-swagger2:2.9.2'
-    implementation 'io.springfox:springfox-swagger-ui:2.9.2'
-    implementation 'io.springfox:springfox-bean-validators:2.9.2'
+    implementation("io.springfox:springfox-boot-starter:3.0.0")
     implementation 'org.flywaydb:flyway-core:6.5.6'
     implementation 'com.zaxxer:HikariCP:3.4.5'
     implementation 'commons-io:commons-io:2.8.0'
@@ -34,13 +32,13 @@ dependencies {
     implementation 'org.apache.commons:commons-text:1.9'
     implementation 'io.swagger:swagger-core:1.6.2'
 
-    annotationProcessor 'org.projectlombok:lombok:1.18.12'
-    compileOnly 'org.projectlombok:lombok:1.18.12'
+    annotationProcessor 'org.projectlombok:lombok:1.18.16'
+    compileOnly 'org.projectlombok:lombok:1.18.16'
 
     testRuntime 'com.h2database:h2:1.4.200'
     runtime 'com.h2database:h2:1.4.200'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.12'
-    testCompileOnly 'org.projectlombok:lombok:1.18.12'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.16'
+    testCompileOnly 'org.projectlombok:lombok:1.18.16'
 
     testImplementation 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
     testImplementation 'junit:junit:4.13'
@@ -49,7 +47,7 @@ dependencies {
     }
     testImplementation 'io.rest-assured:spring-mock-mvc:3.3.0'
     testIntegrationImplementation "com.github.tomakehurst:wiremock:2.27.2"
-    testImplementation 'io.swagger.parser.v3:swagger-parser-v2-converter:2.0.21'
+    testImplementation 'io.swagger.parser.v3:swagger-parser-v2-converter:2.0.22'
 }
 
 testIntegration {

--- a/src/main/java/uk/gov/justice/digital/delius/config/SwaggerConfig.java
+++ b/src/main/java/uk/gov/justice/digital/delius/config/SwaggerConfig.java
@@ -1,17 +1,17 @@
 package uk.gov.justice.digital.delius.config;
 
-import com.google.common.base.Predicates;
-import com.google.common.collect.ImmutableList;
 import io.swagger.util.ReferenceSerializationConfigurer;
 import lombok.AllArgsConstructor;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
 import springfox.bean.validators.configuration.BeanValidatorPluginsConfiguration;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.Contact;
+import springfox.documentation.service.Response;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.json.JacksonModuleRegistrar;
 import springfox.documentation.spring.web.plugins.Docket;
@@ -19,6 +19,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,18 +33,42 @@ public class SwaggerConfig {
     private final BuildProperties buildProperties;
 
     @Bean
-    public Docket offenderApi() {
+    public Docket communityAPI() {
         return new Docket(DocumentationType.SWAGGER_2)
                 .useDefaultResponseMessages(false)
+                .groupName("Community API")
                 .apiInfo(apiInfo())
                 .select()
                 .apis(RequestHandlerSelectors.any())
-                .paths(Predicates.or(ImmutableList.of(
-                        regex("(\\/ping.*)"),
-                        regex("(\\/info.*)"),
-                        regex("(\\/health.*)"),
-                        regex("(\\/api/.*)"),
-                        regex("(\\/secure/.*)"))))
+                .paths(
+                        regex("(\\/ping.*)")
+                                .or(regex("(\\/info.*)"))
+                                .or(regex("(\\/health.*)"))
+                                .or(regex("(\\/secure/.*)")))
+                .build()
+                .genericModelSubstitutes(Optional.class)
+                .directModelSubstitute(ZonedDateTime.class, java.util.Date.class)
+                .directModelSubstitute(LocalDateTime.class, java.util.Date.class)
+                .globalResponses(HttpMethod.GET, getCustomizedResponseMessages())
+                .globalResponses(HttpMethod.PUT, getCustomizedResponseMessages())
+                .globalResponses(HttpMethod.POST, getCustomizedResponseMessages())
+                .globalResponses(HttpMethod.DELETE, getCustomizedResponseMessages())
+                .forCodeGeneration(true);
+    }
+
+    @Bean
+    public Docket newTechAPI() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .useDefaultResponseMessages(false)
+                .groupName("NewTech Private APIs")
+                .apiInfo(newTechApiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(
+                        regex("(\\/ping.*)")
+                                .or(regex("(\\/info.*)"))
+                                .or(regex("(\\/health.*)"))
+                                .or(regex("(\\/api/.*)")))
                 .build()
                 .genericModelSubstitutes(Optional.class)
                 .directModelSubstitute(ZonedDateTime.class, java.util.Date.class)
@@ -61,11 +86,43 @@ public class SwaggerConfig {
     private ApiInfo apiInfo() {
         return new ApiInfo(
                 "Community API Documentation",
-                "REST service for accessing community probation information\nThis service serves two sets of APIs, those secured by OAuth2 (and marked as Secure) and those internal to the Probation New Tech Application which are not accessible to any other applications",
+                "<h2>REST service for accessing community probation information</h2>" +
+                        "<p>This service provides endpoints for accessing data primary sourced from National Delius about people that are of interest to HM Probation Service.</p>" +
+                        "<p>There is cross-over with the <b>prison-api</b> though suspects on remand will not be surfaced by this API unless that have previously been on probation.</p>" +
+                        "<div>" +
+                        "This service is secured by <b>OAuth2</b> with tokens supplied by HMPPS Auth. Most read-only endpoints require the <b>ROLE_COMMUNITY</b> to access, but check each endpoint where this differs." +
+                        "<p>This service can be accessed in a number environments. For each environment a different set of OAuth2 credentials from HMPPS Auth are required</p>" +
+                        "<ul>" +
+                        "<li>Test/Development: <b>https://community-api-secure.test.delius.probation.hmpps.dsd.io</b></li>" +
+                        "<li>Pre-production: <b>https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io</b></li>" +
+                        "<li>Production: <b>https://community-api-secure.probation.service.justice.gov.uk</b></li>" +
+                        "</ul>" +
+                        "<div>",
                 buildProperties.getVersion(),
                 "https://gateway.nomis-api.service.justice.gov.uk/auth/terms",
                 contactInfo(),
-                "Open Government Licence v3.0", "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/", List.of());
+                "Open Government Licence v3.0", "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/", List
+                .of());
+    }
+
+    private ApiInfo newTechApiInfo() {
+        return new ApiInfo(
+                "New Tech Private API Documentation",
+                "REST service for Probation API as used by New Tech. These APIs are not be available for clients other than NewTech. Please select Community API from the <b>Select a definition</b> dropdown.",
+                buildProperties.getVersion(),
+                "https://gateway.nomis-api.service.justice.gov.uk/auth/terms",
+                contactInfo(),
+                "Open Government Licence v3.0", "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/", List
+                .of());
+    }
+
+    private List<Response> getCustomizedResponseMessages() {
+        List<Response> responseMessages = new ArrayList<>();
+        responseMessages.add(new Response("401", "JWT supplied invalid or absent", true, List.of(), List.of(), List.of(), List
+                .of()));
+        responseMessages.add(new Response("403", "JWT supplied does not have the required role to access this service", true, List
+                .of(), List.of(), List.of(), List.of()));
+        return responseMessages;
     }
 
     @Bean

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/AttendanceResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/AttendanceResource.java
@@ -25,7 +25,7 @@ import java.time.LocalDate;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-@Api(tags = "Attendance resources (Secure)", authorizations = {@Authorization("ROLE_COMMUNITY")})
+@Api(tags = "Attendance", authorizations = {@Authorization("ROLE_COMMUNITY")})
 @RestController
 @Slf4j
 @RequestMapping(value = "secure", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -48,8 +48,6 @@ public class AttendanceResource {
     @ApiResponses(
             value = {
                     @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
-                    @ApiResponse(code = 401, message = "Unauthorised", response = ErrorResponse.class),
-                    @ApiResponse(code = 403, message = "Forbidden", response = ErrorResponse.class),
                     @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
             })
     public Attendances getAttendances(final @RequestHeader HttpHeaders httpHeaders,

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/CaseNoteController.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/CaseNoteController.java
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.delius.service.CaseNoteService;
 
 @RestController
 @Slf4j
-@Api(description = "Case note resources", tags = "case notes")
+@Api(tags = "Case notes")
 @RequestMapping(value = "secure", produces = MediaType.APPLICATION_JSON_VALUE)
 @PreAuthorize("hasRole('ROLE_DELIUS_CASE_NOTES')")
 @AllArgsConstructor

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/CourtAppearancesResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/CourtAppearancesResource.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 @RestController
 @Slf4j
-@Api(tags = {"Offender Court Appearances (Secure)"}, authorizations = {@Authorization("ROLE_COMMUNITY")})
+@Api(tags = {"Offender Court Appearances"}, authorizations = {@Authorization("ROLE_COMMUNITY")})
 @RequestMapping(value = "secure", produces = MediaType.APPLICATION_JSON_VALUE)
 @PreAuthorize("hasRole('ROLE_COMMUNITY')")
 public class CourtAppearancesResource {

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffenderDeltaControllerSecure.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffenderDeltaControllerSecure.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 @RestController
 @Slf4j
-@Api(tags = "Offender Events (Secure)", value = "Low level API for propagating significant events", authorizations = {@Authorization("ROLE_PROBATION_OFFENDER_EVENTS")})
+@Api(tags = "Offender Events", value = "Low level API for propagating significant events", authorizations = {@Authorization("ROLE_PROBATION_OFFENDER_EVENTS")})
 @RequestMapping(value = "secure", produces = MediaType.APPLICATION_JSON_VALUE)
 @AllArgsConstructor
 @PreAuthorize("hasRole('ROLE_PROBATION_OFFENDER_EVENTS')")

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffenderIdentifiersResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffenderIdentifiersResource.java
@@ -20,7 +20,7 @@ import uk.gov.justice.digital.delius.service.OffenderService;
 
 import java.util.Optional;
 
-@Api(tags = "Offender identifiers resource (Secure)")
+@Api(tags = "Offender identifiers resource")
 @RestController
 @Slf4j
 @RequestMapping(value = "secure", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffenderUpdatesResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffenderUpdatesResource.java
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.delius.controller.advice.ErrorResponse;
 import uk.gov.justice.digital.delius.data.api.OffenderUpdate;
 import uk.gov.justice.digital.delius.service.OffenderUpdatesService;
 
-@Api(tags = "Offender update resource (Secure) for retrieving updates to offenders")
+@Api(tags = "Offender update resource for retrieving updates to offenders")
 @RestController
 @Slf4j
 @RequestMapping(value = "secure", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
@@ -71,7 +71,7 @@ import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
 
-@Api(tags = "Offender resources (Secure)", authorizations = {@Authorization("ROLE_COMMUNITY")})
+@Api(tags = "Offender resources", authorizations = {@Authorization("ROLE_COMMUNITY")})
 @RestController
 @Slf4j
 @RequestMapping(value = "secure", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -483,11 +483,11 @@ public class OffendersResource {
 
     @ApiOperation(value = "Return pageable list of all offender identifiers that match the supplied filter")
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "page", dataType = "int", paramType = "query",
+            @ApiImplicitParam(name = "page", dataType = "java.lang.Integer", paramType = "query",
                     value = "Results page you want to retrieve (0..N)", example = "0", defaultValue = "0"),
-            @ApiImplicitParam(name = "size", dataType = "int", paramType = "query",
+            @ApiImplicitParam(name = "size", dataType = "java.lang.Integer", paramType = "query",
                     value = "Number of records per page.", example = "10", defaultValue = "10"),
-            @ApiImplicitParam(name = "sort", dataType = "string", paramType = "query", example = "crn,desc", defaultValue = "crn,asc",
+            @ApiImplicitParam(name = "sort",dataType = "java.lang.String", paramType = "query", example = "crn,desc", defaultValue = "crn,asc",
                     value = "Sort column and direction. Multiple sort params allowed.")})
     @GetMapping(value = "/offenders/primaryIdentifiers")
     public Page<PrimaryIdentifiers> getOffenderIds(

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/PersonalCircumstanceResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/PersonalCircumstanceResource.java
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.delius.service.PersonalCircumstanceService;
 
 import java.util.Optional;
 
-@Api(tags = "Offender personal circumstance resource (Secure)")
+@Api(tags = "Offender personal circumstance resource")
 @RestController
 @Slf4j
 @RequestMapping(value = "secure", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/ReferenceDataResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/ReferenceDataResource.java
@@ -24,7 +24,7 @@ import uk.gov.justice.digital.delius.data.api.ReferenceDataSets;
 import uk.gov.justice.digital.delius.service.ReferenceDataService;
 
 @Slf4j
-@Api(tags = "Reference Data API (Secure)", authorizations = {@Authorization("ROLE_COMMUNITY")})
+@Api(tags = "Reference Data", authorizations = {@Authorization("ROLE_COMMUNITY")})
 @RequestMapping(value = "secure", produces = MediaType.APPLICATION_JSON_VALUE)
 @AllArgsConstructor
 @RestController

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/RegistrationResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/RegistrationResource.java
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.delius.service.RegistrationService;
 
 import java.util.Optional;
 
-@Api(tags = "Offender registrations resource (Secure)")
+@Api(tags = "Offender registrations resource")
 @RestController
 @Slf4j
 @RequestMapping(value = "secure", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/RequirementsResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/RequirementsResource.java
@@ -20,7 +20,7 @@ import uk.gov.justice.digital.delius.data.api.PssRequirements;
 import uk.gov.justice.digital.delius.service.RequirementService;
 
 
-@Api(tags = "Requirements resources (Secure)", authorizations = {@Authorization("ROLE_COMMUNITY")})
+@Api(tags = "Requirements resources", authorizations = {@Authorization("ROLE_COMMUNITY")})
 @RestController
 @Slf4j
 @RequestMapping(value = "secure", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/StaffResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/StaffResource.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Set;
 
 @Slf4j
-@Api(tags = "Staff (Secure)", authorizations = {@Authorization("ROLE_COMMUNITY")})
+@Api(tags = "Staff", authorizations = {@Authorization("ROLE_COMMUNITY")})
 @RequestMapping(value = "secure", produces = MediaType.APPLICATION_JSON_VALUE)
 @AllArgsConstructor
 @RestController

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/api/SwaggerValidator.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/api/SwaggerValidator.java
@@ -13,8 +13,13 @@ public class SwaggerValidator {
     private int port;
 
     @Test
-    public void test() {
-        final var result = new SwaggerConverter().readLocation(String.format("http://localhost:%d/v2/api-docs", port), null, null);
+    public void communityAPiSwaggerShouldBeValid() {
+        final var result = new SwaggerConverter().readLocation(String.format("http://localhost:%d/v2/api-docs?group=Community API", port), null, null);
+        assertThat(result.getMessages()).isEmpty();
+    }
+    @Test
+    public void newTechAPiSwaggerShouldBeValid() {
+        final var result = new SwaggerConverter().readLocation(String.format("http://localhost:%d/v2/api-docs?group=NewTech Private APIs", port), null, null);
         assertThat(result.getMessages()).isEmpty();
     }
 }


### PR DESCRIPTION
The changes are:

1. Split out the OAuth2 protected documents from the private APIs used by NewTech into different document sets
2. Added documentation about the main base endpoints fir each environments
3. Cleaned up some of the section names - will do more in future PR
4. Added default messages for 401/403 responses
4. Upgrade to springfox 3