### PR TITLE
✨ PIC-830 add status date to NSI response

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/Nsi.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/Nsi.java
@@ -19,7 +19,7 @@ public class Nsi {
     private KeyValue nsiSubType;
     private Requirement requirement;
     private KeyValue nsiStatus;
-    private LocalDateTime statusDate;
+    private LocalDateTime statusDateTime;
     private LocalDate actualStartDate;
     private LocalDate expectedStartDate;
     private LocalDate referralDate;

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/Nsi.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/Nsi.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
@@ -18,6 +19,7 @@ public class Nsi {
     private KeyValue nsiSubType;
     private Requirement requirement;
     private KeyValue nsiStatus;
+    private LocalDateTime statusDate;
     private LocalDate actualStartDate;
     private LocalDate expectedStartDate;
     private LocalDate referralDate;

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Nsi.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Nsi.java
@@ -35,7 +35,7 @@ public class Nsi {
     private LocalDate actualStartDate;
 
     @Column(name = "NSI_STATUS_DATE")
-    private LocalDateTime nsiStatusDate;
+    private LocalDateTime nsiStatusDateTime;
 
     @Column(name = "EXPECTED_START_DATE")
     private LocalDate expectedStartDate;

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Nsi.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Nsi.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
@@ -32,6 +33,9 @@ public class Nsi {
 
     @Column(name = "ACTUAL_START_DATE")
     private LocalDate actualStartDate;
+
+    @Column(name = "NSI_STATUS_DATE")
+    private LocalDateTime nsiStatusDate;
 
     @Column(name = "EXPECTED_START_DATE")
     private LocalDate expectedStartDate;

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/NsiTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/NsiTransformer.java
@@ -27,6 +27,7 @@ public class NsiTransformer {
                 .actualStartDate(n.getActualStartDate())
                 .expectedStartDate(n.getExpectedStartDate())
                 .referralDate(n.getReferralDate())
+                .statusDate(n.getNsiStatusDate())
                 .length(n.getLength())
                 .lengthUnit(NSI_LENGTH_UNIT)
                 .nsiManagers(nsiManagersOf(n.getNsiManagers()))

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/NsiTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/NsiTransformer.java
@@ -27,7 +27,7 @@ public class NsiTransformer {
                 .actualStartDate(n.getActualStartDate())
                 .expectedStartDate(n.getExpectedStartDate())
                 .referralDate(n.getReferralDate())
-                .statusDate(n.getNsiStatusDate())
+                .statusDateTime(n.getNsiStatusDateTime())
                 .length(n.getLength())
                 .lengthUnit(NSI_LENGTH_UNIT)
                 .nsiManagers(nsiManagersOf(n.getNsiManagers()))

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/NsiTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/NsiTransformerTest.java
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 import uk.gov.justice.digital.delius.util.EntityHelper;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.Arrays;
 import java.util.List;
@@ -26,8 +27,9 @@ class NsiTransformerTest {
         final LocalDate expectedStartDate = LocalDate.of(2020, Month.APRIL, 1);
         final LocalDate actualStartDate = LocalDate.of(2020, Month.APRIL, 1);
         final LocalDate referralDate = LocalDate.of(2020, Month.FEBRUARY, 1);
+        final LocalDateTime statusDate = LocalDateTime.of(2020, Month.MAY, 1, 9, 0, 0);
 
-        final var nsiEntity = buildNsiEntity(expectedStartDate, actualStartDate, referralDate)
+        final var nsiEntity = buildNsiEntity(expectedStartDate, actualStartDate, referralDate, statusDate)
                 .toBuilder()
                 .nsiManagers(List.of(
                         EntityHelper.aNsiManager()
@@ -56,6 +58,7 @@ class NsiTransformerTest {
         assertThat(nsi.getExpectedStartDate()).isEqualTo(expectedStartDate);
         assertThat(nsi.getNsiStatus().getCode()).isEqualTo("STX");
         assertThat(nsi.getReferralDate()).isEqualTo(referralDate);
+        assertThat(nsi.getStatusDate()).isEqualTo(statusDate);
         assertThat(nsi.getNsiType()).isEqualTo(KeyValue.builder().code("TYPE").description("Type Desc").build());
         assertThat(nsi.getNsiSubType()).isEqualTo(KeyValue.builder().code("STC").description("Sub Type Desc").build());
         assertThat(nsi.getRequirement().getActive()).isEqualTo(true);
@@ -81,7 +84,10 @@ class NsiTransformerTest {
 
     }
 
-   private uk.gov.justice.digital.delius.jpa.standard.entity.Nsi buildNsiEntity(LocalDate expectedStartDate, LocalDate actualStartDate, LocalDate referralDate) {
+   private uk.gov.justice.digital.delius.jpa.standard.entity.Nsi buildNsiEntity(LocalDate expectedStartDate,
+                                                                                LocalDate actualStartDate,
+                                                                                LocalDate referralDate,
+                                                                                LocalDateTime statusDate) {
         return uk.gov.justice.digital.delius.jpa.standard.entity.Nsi.builder()
                 .nsiId(100L)
                 .nsiStatus(NsiStatus.builder().code("STX").description("").build())
@@ -89,6 +95,7 @@ class NsiTransformerTest {
                 .nsiType(NsiType.builder().code("TYPE").description("Type Desc").build())
                 .actualStartDate(actualStartDate)
                 .expectedStartDate(expectedStartDate)
+                .nsiStatusDate(statusDate)
                 .referralDate(referralDate)
                 .nsiManagers(Arrays.asList(EntityHelper.aNsiManager(), EntityHelper.aNsiManager()))
                 .length(12L)

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/NsiTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/NsiTransformerTest.java
@@ -58,7 +58,7 @@ class NsiTransformerTest {
         assertThat(nsi.getExpectedStartDate()).isEqualTo(expectedStartDate);
         assertThat(nsi.getNsiStatus().getCode()).isEqualTo("STX");
         assertThat(nsi.getReferralDate()).isEqualTo(referralDate);
-        assertThat(nsi.getStatusDate()).isEqualTo(statusDate);
+        assertThat(nsi.getStatusDateTime()).isEqualTo(statusDate);
         assertThat(nsi.getNsiType()).isEqualTo(KeyValue.builder().code("TYPE").description("Type Desc").build());
         assertThat(nsi.getNsiSubType()).isEqualTo(KeyValue.builder().code("STC").description("Sub Type Desc").build());
         assertThat(nsi.getRequirement().getActive()).isEqualTo(true);
@@ -95,7 +95,7 @@ class NsiTransformerTest {
                 .nsiType(NsiType.builder().code("TYPE").description("Type Desc").build())
                 .actualStartDate(actualStartDate)
                 .expectedStartDate(expectedStartDate)
-                .nsiStatusDate(statusDate)
+                .nsiStatusDateTime(statusDate)
                 .referralDate(referralDate)
                 .nsiManagers(Arrays.asList(EntityHelper.aNsiManager(), EntityHelper.aNsiManager()))
                 .length(12L)

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderNsisByCrn.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderNsisByCrn.java
@@ -47,7 +47,7 @@ public class OffendersResource_getOffenderNsisByCrn extends IntegrationTestBase 
                 .as(Nsi.class);
 
         assertThat(nsi.getNsiId()).isEqualTo(KNOWN_NSI_ID);
-        assertThat(nsi.getStatusDate()).isEqualTo(LocalDateTime.of(2019, Month.SEPTEMBER, 16, 0, 0));
+        assertThat(nsi.getStatusDateTime()).isEqualTo(LocalDateTime.of(2019, Month.SEPTEMBER, 16, 0, 0));
         assertThat(nsi.getReferralDate()).isEqualTo(LocalDate.of(2019, Month.SEPTEMBER, 2));
         assertThat(nsi.getExpectedStartDate()).isEqualTo(LocalDate.of(2019, Month.SEPTEMBER, 20));
         assertThat(nsi.getActualStartDate()).isEqualTo(LocalDate.of(2019, Month.OCTOBER, 2));

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderNsisByCrn.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderNsisByCrn.java
@@ -1,7 +1,11 @@
 package uk.gov.justice.digital.delius.controller.secure;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.data.api.Nsi;
 import uk.gov.justice.digital.delius.data.api.NsiWrapper;
 
@@ -43,7 +47,15 @@ public class OffendersResource_getOffenderNsisByCrn extends IntegrationTestBase 
                 .as(Nsi.class);
 
         assertThat(nsi.getNsiId()).isEqualTo(KNOWN_NSI_ID);
+        assertThat(nsi.getStatusDate()).isEqualTo(LocalDateTime.of(2019, Month.SEPTEMBER, 16, 0, 0));
+        assertThat(nsi.getReferralDate()).isEqualTo(LocalDate.of(2019, Month.SEPTEMBER, 2));
+        assertThat(nsi.getExpectedStartDate()).isEqualTo(LocalDate.of(2019, Month.SEPTEMBER, 20));
+        assertThat(nsi.getActualStartDate()).isEqualTo(LocalDate.of(2019, Month.OCTOBER, 2));
         assertThat(nsi.getLength()).isEqualTo(20L);
+        assertThat(nsi.getNsiStatus()).isEqualTo(KeyValue.builder().code("BRE01").description("Breach Initiated").build());
+        assertThat(nsi.getNsiType()).isEqualTo(KeyValue.builder().code("BRE").description("Breach Request").build());
+        assertThat(nsi.getNsiSubType()).isEqualTo(KeyValue.builder().code("BRE01").description("Community Order / SSO").build());
+        assertThat(nsi.getLengthUnit()).isEqualTo("Months");
         assertThat(nsi.getNsiManagers().get(0).getProbationArea().getDescription()).isEqualTo("NPS North East");
         assertThat(nsi.getNsiManagers().get(0).getProbationArea().getCode()).isEqualTo("N02");
         assertThat(nsi.getNsiManagers().get(0).getTeam().getDescription()).isEqualTo("Unallocated Team(N02)");


### PR DESCRIPTION
Unlike the other dates in this object (start, referral, actual start), there is a time component stored in the database. Don't want to throw away - consumers can disregard if they wish