### PR TITLE
Dt 1271 smoke test data rest

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/CustodyResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/CustodyResource.java
@@ -96,4 +96,30 @@ public class CustodyResource {
 
         return offenderIdentifierService.replaceNomsNumber(originalNomsNumber, updateOffenderNomsNumber);
     }
+
+
+    @RequestMapping(value = "offenders/nomsNumber/{nomsNumber}/custody/bookingNumber/{bookingNumber}", method = RequestMethod.GET, consumes = "application/json")
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "Requires role ROLE_COMMUNITY"),
+            @ApiResponse(code = 404, message = "Either the requested offender was not found or the conviction associated the booking number.")
+    })
+    @ApiOperation(value = "Gets the current custody record")
+    @PreAuthorize("hasRole('ROLE_COMMUNITY')")
+    public Custody getCustodyByBookNumber(final @PathVariable String nomsNumber,
+                                 final @PathVariable String bookingNumber) {
+        return custodyService.getCustodyByBookNumber(nomsNumber, bookingNumber);
+    }
+
+    @RequestMapping(value = "offenders/crn/{crn}/custody/convictionId/{convictionId}", method = RequestMethod.GET, consumes = "application/json")
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "Requires role ROLE_COMMUNITY"),
+            @ApiResponse(code = 404, message = "Either the requested offender was not found or the conviction associated the conviction id.")
+    })
+    @ApiOperation(value = "Gets the current custody record")
+    @PreAuthorize("hasRole('ROLE_COMMUNITY')")
+    public Custody getCustodyByConvictionId(final @PathVariable String crn,
+                                 final @PathVariable Long convictionId) {
+        return custodyService.getCustodyByConvictionId(crn, convictionId);
+    }
+
 }

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/SmokeTestHelperResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/SmokeTestHelperResource.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.justice.digital.delius.service.SmokeTestHelperService;
 
 @Api(tags = "Smoke test")
 @RestController
@@ -20,14 +21,20 @@ import org.springframework.web.bind.annotation.RestController;
 @PreAuthorize("hasRole('ROLE_SMOKE_TEST')")
 @ConditionalOnProperty(name = "smoke.test.aware", havingValue = "true")
 public class SmokeTestHelperResource {
-    @RequestMapping(value = "offenders/nomsNumber/{nomsNumber}/smoketest/custody/reset", method = RequestMethod.POST, consumes = "application/json")
+    private final SmokeTestHelperService smokeTestHelperService;
+
+    public SmokeTestHelperResource(SmokeTestHelperService smokeTestHelperService) {
+        this.smokeTestHelperService = smokeTestHelperService;
+    }
+
+    @RequestMapping(value = "offenders/crn/{crn}/smoketest/custody/reset", method = RequestMethod.POST, consumes = "application/json")
     @ApiResponses(value = {
             @ApiResponse(code = 403, message = "Requires role ROLE_SMOKE_TEST"),
             @ApiResponse(code = 404, message = "Either the requested offender was not found or no active custodial sentences were found")
     })
     @ApiOperation(value = "Resets custody data to the state before a Delius offender record has been matched to a NOMIS record")
-    public void resetCustodySmokeTestData(@PathVariable String nomsNumber) {
-
+    public void resetCustodySmokeTestData(@PathVariable String crn) {
+        smokeTestHelperService.resetCustodySmokeTestData(crn);
     }
 
 }

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/SmokeTestHelperResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/SmokeTestHelperResource.java
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.delius.controller.secure;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@Api(tags = "Smoke test")
+@RestController
+@Slf4j
+@RequestMapping(value = "secure", produces = MediaType.APPLICATION_JSON_VALUE)
+@PreAuthorize("hasRole('ROLE_SMOKE_TEST')")
+@ConditionalOnProperty(name = "smoke.test.aware", havingValue = "true")
+public class SmokeTestHelperResource {
+    @RequestMapping(value = "offenders/nomsNumber/{nomsNumber}/smoketest/custody/reset", method = RequestMethod.POST, consumes = "application/json")
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "Requires role ROLE_SMOKE_TEST"),
+            @ApiResponse(code = 404, message = "Either the requested offender was not found or no active custodial sentences were found")
+    })
+    @ApiOperation(value = "Resets custody data to the state before a Delius offender record has been matched to a NOMIS record")
+    public void resetCustodySmokeTestData(@PathVariable String nomsNumber) {
+
+    }
+
+}

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/Custody.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/Custody.java
@@ -18,4 +18,6 @@ public class Custody {
     private Institution institution;
     @ApiModelProperty(value = "Key sentence dates of particular interest to custody")
     private CustodyRelatedKeyDates keyDates;
+    @ApiModelProperty(value = "Custodial status")
+    private KeyValue status;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/InstitutionRepository.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/InstitutionRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface InstitutionRepository extends JpaRepository<RInstitution, Long> {
     Optional<RInstitution> findByNomisCdeCode(String nomisCdeCode);
+    Optional<RInstitution> findByCode(String code);
 }

--- a/src/main/java/uk/gov/justice/digital/delius/service/CustodyService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/CustodyService.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.justice.digital.delius.controller.BadRequestException;
 import uk.gov.justice.digital.delius.controller.NotFoundException;
 import uk.gov.justice.digital.delius.data.api.Custody;
 import uk.gov.justice.digital.delius.data.api.UpdateCustody;
@@ -148,6 +149,25 @@ public class CustodyService {
             return ConvictionTransformer
                     .custodyOf(updateBookingNumberFor(offender, event, updateCustodyBookingNumber.getBookingNumber()).getDisposal().getCustody());
         }
+    }
+
+
+    @Transactional(readOnly = true)
+    public Custody getCustodyByBookNumber(String nomsNumber, String bookingNumber) {
+        final var offender = offenderRepository.findByNomsNumber(nomsNumber).orElseThrow(() -> new NotFoundException(String.format("offender with nomsNumber %s not found", nomsNumber)));
+        try {
+            final var event = convictionService.getSingleActiveConvictionByOffenderIdAndPrisonBookingNumber(offender.getOffenderId(), bookingNumber).orElseThrow(() -> new NotFoundException(String.format("conviction with bookNumber %s not found", bookingNumber)));
+            return ConvictionTransformer.custodyOf(event.getDisposal().getCustody());
+        } catch (ConvictionService.DuplicateActiveCustodialConvictionsException e) {
+            throw new NotFoundException(String.format("no single conviction with bookingNumber %s found, instead %d duplicates found", bookingNumber, e.getConvictionCount()));
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public Custody getCustodyByConvictionId(String crn, Long convictionId) {
+        final var offender = offenderRepository.findByCrn(crn).orElseThrow(() -> new NotFoundException(String.format("offender with crn %s not found", crn)));
+        return Optional.ofNullable(convictionService.convictionFor(offender.getOffenderId(), convictionId).orElseThrow(() -> new NotFoundException(String.format("conviction with convictionId %d not found", convictionId))).getCustody()).orElseThrow(() -> new BadRequestException(String
+                .format("The conviction with convictionId %d is not a custodial sentence", convictionId)));
     }
 
     private Event updateBookingNumberFor(Offender offender, Event event, String bookingNumber) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/CustodyService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/CustodyService.java
@@ -154,9 +154,11 @@ public class CustodyService {
 
     @Transactional(readOnly = true)
     public Custody getCustodyByBookNumber(String nomsNumber, String bookingNumber) {
-        final var offender = offenderRepository.findByNomsNumber(nomsNumber).orElseThrow(() -> new NotFoundException(String.format("offender with nomsNumber %s not found", nomsNumber)));
+        final var offender = offenderRepository.findByNomsNumber(nomsNumber)
+                .orElseThrow(() -> new NotFoundException(String.format("offender with nomsNumber %s not found", nomsNumber)));
         try {
-            final var event = convictionService.getSingleActiveConvictionByOffenderIdAndPrisonBookingNumber(offender.getOffenderId(), bookingNumber).orElseThrow(() -> new NotFoundException(String.format("conviction with bookNumber %s not found", bookingNumber)));
+            final var event = convictionService.getSingleActiveConvictionByOffenderIdAndPrisonBookingNumber(offender.getOffenderId(), bookingNumber)
+                    .orElseThrow(() -> new NotFoundException(String.format("conviction with bookNumber %s not found", bookingNumber)));
             return ConvictionTransformer.custodyOf(event.getDisposal().getCustody());
         } catch (ConvictionService.DuplicateActiveCustodialConvictionsException e) {
             throw new NotFoundException(String.format("no single conviction with bookingNumber %s found, instead %d duplicates found", bookingNumber, e.getConvictionCount()));
@@ -165,9 +167,11 @@ public class CustodyService {
 
     @Transactional(readOnly = true)
     public Custody getCustodyByConvictionId(String crn, Long convictionId) {
-        final var offender = offenderRepository.findByCrn(crn).orElseThrow(() -> new NotFoundException(String.format("offender with crn %s not found", crn)));
-        return Optional.ofNullable(convictionService.convictionFor(offender.getOffenderId(), convictionId).orElseThrow(() -> new NotFoundException(String.format("conviction with convictionId %d not found", convictionId))).getCustody()).orElseThrow(() -> new BadRequestException(String
-                .format("The conviction with convictionId %d is not a custodial sentence", convictionId)));
+        final var offender = offenderRepository.findByCrn(crn)
+                .orElseThrow(() -> new NotFoundException(String.format("offender with crn %s not found", crn)));
+        return Optional.ofNullable(convictionService.convictionFor(offender.getOffenderId(), convictionId)
+                .orElseThrow(() -> new NotFoundException(String.format("conviction with convictionId %d not found", convictionId))).getCustody())
+                .orElseThrow(() -> new BadRequestException(String.format("The conviction with convictionId %d is not a custodial sentence", convictionId)));
     }
 
     private Event updateBookingNumberFor(Offender offender, Event event, String bookingNumber) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/SmokeTestHelperService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/SmokeTestHelperService.java
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.delius.service;
+
+import org.springframework.stereotype.Service;
+import uk.gov.justice.digital.delius.controller.NotFoundException;
+import uk.gov.justice.digital.delius.jpa.standard.repository.InstitutionRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
+import uk.gov.justice.digital.delius.jpa.standard.repository.StandardReferenceRepository;
+
+import javax.transaction.Transactional;
+
+@Service
+public class SmokeTestHelperService {
+    private final OffenderRepository offenderRepository;
+    private final ConvictionService convictionService;
+    private final StandardReferenceRepository standardReferenceRepository;
+    private final InstitutionRepository institutionRepository;
+
+    private static final String CUSTODY_STATUS_DATASET = "THROUGHCARE STATUS";
+    private static final String SENTENCED_IN_CUSTODY = "A";
+
+
+    public SmokeTestHelperService(OffenderRepository offenderRepository, ConvictionService convictionService, StandardReferenceRepository standardReferenceRepository, InstitutionRepository institutionRepository) {
+        this.offenderRepository = offenderRepository;
+        this.convictionService = convictionService;
+        this.standardReferenceRepository = standardReferenceRepository;
+        this.institutionRepository = institutionRepository;
+    }
+
+    @Transactional
+    public void resetCustodySmokeTestData(String crn) {
+        final var offender = offenderRepository
+                .findByCrn(crn)
+                .orElseThrow(() -> new NotFoundException(String.format("Offender with crn %s not found", crn)));
+
+        final var custody = convictionService.getActiveCustodialEvent(offender.getOffenderId()).getDisposal().getCustody();
+        custody.setPrisonerNumber(null);
+        custody.getKeyDates().clear();
+        custody.setInstitution(institutionRepository.findByCode("UNKNOW").orElseThrow());
+        custody.setCustodialStatus(standardReferenceRepository.findByCodeAndCodeSetName(SENTENCED_IN_CUSTODY, CUSTODY_STATUS_DATASET).orElseThrow());
+        offender.setNomsNumber(null);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformer.java
@@ -45,7 +45,7 @@ public class ConvictionTransformer {
         RO_HANDOVER_DATE("POM2", CustodyRelatedKeyDatesBuilder::expectedPrisonOffenderManagerHandoverDate);
 
         private final BiConsumer<CustodyRelatedKeyDatesBuilder, LocalDate> consumer;
-        private String code;
+        private final String code;
 
         KeyDateTypes(String code, BiConsumer<CustodyRelatedKeyDatesBuilder, LocalDate> consumer) {
             this.code = code;
@@ -187,6 +187,7 @@ public class ConvictionTransformer {
         return Custody.builder().bookingNumber(custody.getPrisonerNumber())
                 .institution(Optional.ofNullable(custody.getInstitution()).map(InstitutionTransformer::institutionOf)
                         .orElse(null))
+                .status(KeyValueTransformer.keyValueOf(custody.getCustodialStatus()))
                 .keyDates(Optional.ofNullable(custody.getKeyDates()).map(ConvictionTransformer::custodyRelatedKeyDatesOf)
                         .orElse(CustodyRelatedKeyDates.builder().build())).build();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -94,3 +94,7 @@ features:
       booking.number: false
       keydates: false
       noms.number: false
+
+smoke:
+  test:
+    aware: false

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyGetAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyGetAPITest.java
@@ -1,0 +1,95 @@
+package uk.gov.justice.digital.delius.controller.secure;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class CustodyGetAPITest extends IntegrationTestBase {
+    private static final String NOMS_NUMBER = "G9542VP";
+    private static final String CRN = "X320741";
+    private static final long CONVICTION_ID = 2500295345L;
+    private static final String PRISON_BOOKING_NUMBER = "V74111";
+
+    @Nested
+    @DisplayName("GET offenders/nomsNumber/{nomsNumber}/custody/bookingNumber/{bookingNumber}")
+    class getCustodyByBookNumber {
+        @Test
+        @DisplayName("must have role ROLE_COMMUNITY")
+        public void mustHaveRoleCommunity() {
+            final var token = createJwt("ROLE_BANANAS");
+
+            given()
+                    .auth().oauth2(token)
+                    .contentType("application/json")
+                    .when()
+                    .get("offenders/nomsNumber/{nomsNumber}/custody/bookingNumber/{bookingNumber}", NOMS_NUMBER, PRISON_BOOKING_NUMBER)
+                    .then()
+                    .statusCode(403);
+        }
+
+        @Test
+        @DisplayName("can get custody information by noms number and book number")
+        public void canGetByNomsNumberAndBookNumber() {
+            final var token = createJwt("ROLE_COMMUNITY");
+
+            given()
+                    .auth().oauth2(token)
+                    .contentType("application/json")
+                    .when()
+                    .get("offenders/nomsNumber/{nomsNumber}/custody/bookingNumber/{bookingNumber}", NOMS_NUMBER, PRISON_BOOKING_NUMBER)
+                    .then()
+                    .statusCode(200)
+                    .body("bookingNumber", equalTo("V74111"))
+                    .body("institution.code", equalTo("BWIHMP"))
+                    .body("institution.description", equalTo("Berwyn (HMP)"))
+                    .body("status.code", equalTo("D"))
+                    .body("status.description", equalTo("In Custody"))
+                    .body("keyDates.size()", equalTo(0))
+            ;
+        }
+
+    }
+
+    @Nested
+    @DisplayName("GET offenders/crn/{crn}/custody/convictionId/{convictionId}")
+    class getCustodyByConvictionId {
+        @Test
+        @DisplayName("must have role ROLE_COMMUNITY")
+        public void mustHaveRoleCommunity() {
+            final var token = createJwt("ROLE_BANANAS");
+
+            given()
+                    .auth().oauth2(token)
+                    .contentType("application/json")
+                    .when()
+                    .get("offenders/crn/{crn}/custody/convictionId/{convictionId}", CRN, CONVICTION_ID)
+                    .then()
+                    .statusCode(403);
+        }
+
+        @Test
+        @DisplayName("can get custody information by noms number and book number")
+        public void canGetByNomsNumberAndBookNumber() {
+            final var token = createJwt("ROLE_COMMUNITY");
+
+            given()
+                    .auth().oauth2(token)
+                    .contentType("application/json")
+                    .when()
+                    .get("offenders/crn/{crn}/custody/convictionId/{convictionId}", CRN, CONVICTION_ID)
+                    .then()
+                    .statusCode(200)
+                    .body("bookingNumber", equalTo("V74111"))
+                    .body("institution.code", equalTo("BWIHMP"))
+                    .body("institution.description", equalTo("Berwyn (HMP)"))
+                    .body("status.code", equalTo("D"))
+                    .body("status.description", equalTo("In Custody"))
+                    .body("keyDates.size()", equalTo(0))
+            ;
+        }
+
+    }
+}

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyGetAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/CustodyGetAPITest.java
@@ -71,7 +71,7 @@ public class CustodyGetAPITest extends IntegrationTestBase {
         }
 
         @Test
-        @DisplayName("can get custody information by noms number and book number")
+        @DisplayName("can get custody information by crn and conviction id")
         public void canGetByNomsNumberAndBookNumber() {
             final var token = createJwt("ROLE_COMMUNITY");
 

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/SmokeTestHelperAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/SmokeTestHelperAPITest.java
@@ -1,43 +1,145 @@
 package uk.gov.justice.digital.delius.controller.secure;
 
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.justice.digital.delius.FlywayRestoreExtension;
+import uk.gov.justice.digital.delius.data.api.ReplaceCustodyKeyDates;
+import uk.gov.justice.digital.delius.data.api.UpdateCustody;
+
+import java.time.LocalDate;
 
 import static io.restassured.RestAssured.given;
+import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+@ExtendWith({SpringExtension.class, FlywayRestoreExtension.class})
+@DisplayName("POST /offenders/crn/{crn}/smoketest/custody/reset")
 public class SmokeTestHelperAPITest extends IntegrationTestBase {
-    @Nested
-    @DisplayName("POST /offenders/nomsNumber/{nomsNumber}/smoketest/custody/reset")
-    class NextUpdate {
+    private static final String NOMS_NUMBER = "G9542VP";
+    private static final String CRN = "X320741";
+    private static final long CONVICTION_ID = 2500295345L;
+    private static final String PRISON_BOOKING_NUMBER = "V74111";
 
-        @Test
-        @DisplayName("must have `ROLE_SMOKE_TEST` to access this service")
-        public void mustHaveCommunityRole() {
-            final var token = createJwt("ROLE_COMMUNITY");
+    @Test
+    @DisplayName("must have `ROLE_SMOKE_TEST` to access this service")
+    public void mustHaveCommunityRole() {
+        final var token = createJwt("ROLE_COMMUNITY");
 
-            given()
-                    .auth().oauth2(token)
-                    .contentType(APPLICATION_JSON_VALUE)
-                    .when()
-                    .post("/offenders/nomsNumber/{nomsNumber}/smoketest/custody/reset", "G4106UN")
-                    .then()
-                    .statusCode(403);
-        }
-
-        @Test
-        @DisplayName("Can reset custody data")
-        public void canGetNextUpdateWithDateChanged() {
-            given()
-                    .auth().oauth2(createJwt("ROLE_SMOKE_TEST"))
-                    .contentType(APPLICATION_JSON_VALUE)
-                    .when()
-                    .post("/offenders/nomsNumber/{nomsNumber}/smoketest/custody/reset", "G4106UN")
-                    .then()
-                    .statusCode(200);
-
-
-        }
+        given()
+                .auth().oauth2(token)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .post("/offenders/crn/{crn}/smoketest/custody/reset", CRN)
+                .then()
+                .statusCode(403);
     }
+
+    @Test
+    @DisplayName("Can reset custody data")
+    public void canGetNextUpdateWithDateChanged() {
+        final var token = createJwt("ROLE_COMMUNITY_CUSTODY_UPDATE", "ROLE_COMMUNITY", "ROLE_SMOKE_TEST");
+
+        // Given current location is HMP Moorland
+        given()
+                .auth().oauth2(token)
+                .contentType("application/json")
+                .body(createUpdateCustody("MDI"))
+                .when()
+                .put(format("offenders/nomsNumber/%s/custody/bookingNumber/%s", NOMS_NUMBER, PRISON_BOOKING_NUMBER))
+                .then()
+                .statusCode(200);
+
+        // AND the conviction has some keys dates
+        given()
+                .auth().oauth2(token)
+                .contentType("application/json")
+                .body(createReplaceCustodyKeyDates(ReplaceCustodyKeyDates
+                        .builder()
+                        .conditionalReleaseDate(LocalDate.now())
+                        .licenceExpiryDate(LocalDate.now())
+                        .hdcEligibilityDate(LocalDate.now())
+                        .paroleEligibilityDate(LocalDate.now())
+                        .sentenceExpiryDate(LocalDate.now())
+                        .expectedReleaseDate(LocalDate.now())
+                        .postSentenceSupervisionEndDate(LocalDate.now())
+                        .build()))
+                .when()
+                .post(String.format("offenders/nomsNumber/%s/bookingNumber/%s/custody/keyDates", NOMS_NUMBER, PRISON_BOOKING_NUMBER))
+                .then()
+                .statusCode(200);
+
+        // AND I verify that data has been set
+        given()
+                .auth().oauth2(token)
+                .contentType("application/json")
+                .when()
+                .get("offenders/crn/{crn}/custody/convictionId/{convictionId}", CRN, CONVICTION_ID)
+                .then()
+                .statusCode(200)
+                .body("bookingNumber", equalTo("V74111"))
+                .body("institution.code", equalTo("MDIHMP"))
+                .body("status.code", equalTo("D"))
+                .body("status.description", equalTo("In Custody"))
+                .body("keyDates.size()", equalTo(7))
+        ;
+
+
+        // WHEN when I reset this data
+        given()
+                .auth().oauth2(token)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .post("/offenders/crn/{crn}/smoketest/custody/reset", CRN)
+                .then()
+                .statusCode(200);
+
+
+        // THEN the custody data is set to initial defaults
+        given()
+                .auth().oauth2(token)
+                .contentType("application/json")
+                .when()
+                .get("offenders/crn/{crn}/custody/convictionId/{convictionId}", CRN, CONVICTION_ID)
+                .then()
+                .statusCode(200)
+                .body("bookingNumber", nullValue())
+                .body("institution.code", equalTo("UNKNOW"))
+                .body("status.code", equalTo("A"))
+                .body("keyDates.size()", equalTo(0));
+
+        // AND the offender no longer has a NOMS number
+        given()
+                .auth()
+                .oauth2(tokenWithRoleCommunity())
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .get("/offenders/nomsNumber/{nomsNumber}/all", NOMS_NUMBER)
+                .then()
+                .statusCode(404);
+
+        // AND I can reset again with no errors
+        given()
+                .auth().oauth2(token)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .post("/offenders/crn/{crn}/smoketest/custody/reset", CRN)
+                .then()
+                .statusCode(200);
+    }
+
+    private String createUpdateCustody(@SuppressWarnings("SameParameterValue") String prisonCode) {
+        return writeValueAsString(UpdateCustody
+                .builder()
+                .nomsPrisonInstitutionCode(prisonCode)
+                .build());
+    }
+
+    private String createReplaceCustodyKeyDates(ReplaceCustodyKeyDates replaceCustodyKeyDates) {
+        return writeValueAsString(replaceCustodyKeyDates);
+    }
+
 }

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/SmokeTestHelperAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/SmokeTestHelperAPITest.java
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.delius.controller.secure;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+public class SmokeTestHelperAPITest extends IntegrationTestBase {
+    @Nested
+    @DisplayName("POST /offenders/nomsNumber/{nomsNumber}/smoketest/custody/reset")
+    class NextUpdate {
+
+        @Test
+        @DisplayName("must have `ROLE_SMOKE_TEST` to access this service")
+        public void mustHaveCommunityRole() {
+            final var token = createJwt("ROLE_COMMUNITY");
+
+            given()
+                    .auth().oauth2(token)
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .when()
+                    .post("/offenders/nomsNumber/{nomsNumber}/smoketest/custody/reset", "G4106UN")
+                    .then()
+                    .statusCode(403);
+        }
+
+        @Test
+        @DisplayName("Can reset custody data")
+        public void canGetNextUpdateWithDateChanged() {
+            given()
+                    .auth().oauth2(createJwt("ROLE_SMOKE_TEST"))
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .when()
+                    .post("/offenders/nomsNumber/{nomsNumber}/smoketest/custody/reset", "G4106UN")
+                    .then()
+                    .statusCode(200);
+
+
+        }
+    }
+}

--- a/src/testIntegration/resources/application.properties
+++ b/src/testIntegration/resources/application.properties
@@ -14,3 +14,5 @@ features.noms.update.noms.number=true
 spring.security.oauth2.resourceserver.jwt.public-key-location=classpath:local-public-key.pub
 
 logging.level.org.hibernate.SQL=DEBUG
+
+smoke.test.aware=true


### PR DESCRIPTION
The purpose of this PR is to provide and endpoint that would allow a test client to "reset" custody data as if the prison-to-probation-update had never been called. This involves

- removing the NOMS number and book number
- setting the prison location back to unknown
- setting the custodial status back to "Sentenced"
- removing the key dates


To also help a test client new endpoints have been added (which are generally useful) which can help to assert that data has been successful reset and set for a successful test