### PR TITLE
DT-1308 Allow for multiple Staff in a prison with the same name. 

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/StaffRepository.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/StaffRepository.java
@@ -21,7 +21,7 @@ public interface StaffRepository extends JpaRepository<Staff, Long> {
     @Query("select u.staff from User u where upper(u.distinguishedName) in (:usernames)")
     List<Staff> findByUsernames(@Param("usernames") Set<String> usernames);
 
-    Optional<Staff> findBySurnameAndForenameAndProbationArea(String surname, String forename, ProbationArea probationArea);
+    Optional<Staff> findFirstBySurnameAndForenameAndProbationArea(String surname, String forename, ProbationArea probationArea);
 
     @Query("select staff from Staff staff, StaffTeam staffTeam, Team team where staff.officerCode like '%U' and staffTeam.staffId = staff.staffId and staffTeam.teamId = :teamId" )
     Optional<Staff> findByUnallocatedByTeam(@Param("teamId") Long teamId);

--- a/src/main/java/uk/gov/justice/digital/delius/service/StaffService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/StaffService.java
@@ -81,7 +81,7 @@ public class StaffService {
 
     @Transactional
     public Staff findOrCreateStaffInArea(final Human staff, final ProbationArea probationArea) {
-        return staffRepository.findBySurnameAndForenameAndProbationArea(staff.getSurname(), firstNameIn(staff.getForenames()), probationArea)
+        return staffRepository.findFirstBySurnameAndForenameAndProbationArea(staff.getSurname(), firstNameIn(staff.getForenames()), probationArea)
                 .orElseGet(() -> createStaffInArea(staff.getSurname(), firstNameIn(staff.getForenames()), probationArea));
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/StaffServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/StaffServiceTest.java
@@ -210,8 +210,8 @@ public class StaffServiceTest {
 
         List<StaffDetails> staffDetailsList = staffService.getStaffDetailsByUsernames(usernames);
 
-        var frazierUserDetails = staffDetailsList.stream().filter(s -> s.getUsername().equals("joefrazier")).findFirst().get();
-        var foremanUserDetails = staffDetailsList.stream().filter(s -> s.getUsername().equals("georgeforeman")).findFirst().get();
+        var frazierUserDetails = staffDetailsList.stream().filter(s -> s.getUsername().equals("joefrazier")).findFirst().orElseThrow();
+        var foremanUserDetails = staffDetailsList.stream().filter(s -> s.getUsername().equals("georgeforeman")).findFirst().orElseThrow();
 
         assertThat(staffDetailsList.size()).isEqualTo(2);
         assertThat(frazierUserDetails.getEmail()).isEqualTo("joefrazier@service.com");
@@ -223,7 +223,7 @@ public class StaffServiceTest {
     @Test
     public void willReturnStaffIfFoundWithoutCreatingANewOne() {
         when(staffRepository
-                .findBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
+                .findFirstBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
                 .thenReturn(Optional.of(aStaff("N01A123456")));
 
         assertThat(staffService.findOrCreateStaffInArea(Human
@@ -232,14 +232,14 @@ public class StaffServiceTest {
                 .surname("Biggins")
                 .build(), aProbationArea()).getOfficerCode()).isEqualTo("N01A123456");
 
-        verify(staffRepository).findBySurnameAndForenameAndProbationArea(eq("Biggins"), eq("Sandra"), isA(ProbationArea.class));
+        verify(staffRepository).findFirstBySurnameAndForenameAndProbationArea(eq("Biggins"), eq("Sandra"), isA(ProbationArea.class));
         verify(staffRepository, never()).save(any());
     }
 
     @Test
     public void willLookupByFirstForenameWhenSpaceSeparatedWhenSearchingStaffByName() {
         when(staffRepository
-                .findBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
+                .findFirstBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
                 .thenReturn(Optional.of(aStaff("N01A123456")));
 
         assertThat(staffService.findOrCreateStaffInArea(Human
@@ -248,14 +248,14 @@ public class StaffServiceTest {
                 .surname("Biggins")
                 .build(), aProbationArea()).getOfficerCode()).isEqualTo("N01A123456");
 
-        verify(staffRepository).findBySurnameAndForenameAndProbationArea(eq("Biggins"), eq("Sandra"), isA(ProbationArea.class));
+        verify(staffRepository).findFirstBySurnameAndForenameAndProbationArea(eq("Biggins"), eq("Sandra"), isA(ProbationArea.class));
         verify(staffRepository, never()).save(any());
     }
 
     @Test
     public void willLookupByFirstForenameWhenCommaSeparatedWhenSearchingStaffByName() {
         when(staffRepository
-                .findBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
+                .findFirstBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
                 .thenReturn(Optional.of(aStaff("N01A123456")));
 
         assertThat(staffService.findOrCreateStaffInArea(Human
@@ -264,14 +264,14 @@ public class StaffServiceTest {
                 .surname("Biggins")
                 .build(), aProbationArea()).getOfficerCode()).isEqualTo("N01A123456");
 
-        verify(staffRepository).findBySurnameAndForenameAndProbationArea(eq("Biggins"), eq("Sandra"), isA(ProbationArea.class));
+        verify(staffRepository).findFirstBySurnameAndForenameAndProbationArea(eq("Biggins"), eq("Sandra"), isA(ProbationArea.class));
         verify(staffRepository, never()).save(any());
     }
 
     @Test
     public void willGenerateNewStaffCodeCreateNewStaffWhenNotFoundByName( ) {
         when(staffRepository
-                .findBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
+                .findFirstBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
                 .thenReturn(Optional.empty());
         when(staffHelperRepository.getNextStaffCode("N02")).thenReturn("N02A123456");
         when(staffRepository.save(any())).then(params -> params.getArgument(0));
@@ -291,7 +291,7 @@ public class StaffServiceTest {
     @Test
     public void willSetStaffNamesWhenCreateNewStaffWhenNotFoundByName( ) {
         when(staffRepository
-                .findBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
+                .findFirstBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
                 .thenReturn(Optional.empty());
         when(staffHelperRepository.getNextStaffCode(any())).thenReturn("N02A123456");
 
@@ -315,7 +315,7 @@ public class StaffServiceTest {
     @Test
     public void willSetProbationAreaWhenCreateNewStaffWhenNotFoundByName( ) {
         when(staffRepository
-                .findBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
+                .findFirstBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
                 .thenReturn(Optional.empty());
         when(staffHelperRepository.getNextStaffCode(any())).thenReturn("N02A123456");
 


### PR DESCRIPTION
Problem:

When MOiC assigns a POM a new Staff member is created with same name as the POM. This Staff member is reused when a POM is assigned to a new prisoner.

This was error if more than one Staff member was found with the same name (JPA error).

This change chooses the first one, since MOiC only cares that the correct name is assigned, the Staff entity has no meaning other than the name.