### PR TITLE
DT-1334 Capitalise POMs names and find existing Staff regardless of case

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/Human.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/Human.java
@@ -6,8 +6,10 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import static org.apache.commons.text.WordUtils.capitalizeFully;
+
 @Data
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class Human {
@@ -15,4 +17,11 @@ public class Human {
     private String forenames;
     @ApiModelProperty(value = "Family name", example = "Hancock")    
     private String surname;
+
+    public Human capitalise() {
+        return this.toBuilder()
+                .surname(capitalizeFully(surname))
+                .forenames(capitalizeFully(forenames))
+                .build();
+    }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/StaffRepository.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/StaffRepository.java
@@ -21,7 +21,7 @@ public interface StaffRepository extends JpaRepository<Staff, Long> {
     @Query("select u.staff from User u where upper(u.distinguishedName) in (:usernames)")
     List<Staff> findByUsernames(@Param("usernames") Set<String> usernames);
 
-    Optional<Staff> findFirstBySurnameAndForenameAndProbationArea(String surname, String forename, ProbationArea probationArea);
+    Optional<Staff> findFirstBySurnameIgnoreCaseAndForenameIgnoreCaseAndProbationArea(String surname, String forename, ProbationArea probationArea);
 
     @Query("select staff from Staff staff, StaffTeam staffTeam, Team team where staff.officerCode like '%U' and staffTeam.staffId = staff.staffId and staffTeam.teamId = :teamId" )
     Optional<Staff> findByUnallocatedByTeam(@Param("teamId") Long teamId);

--- a/src/main/java/uk/gov/justice/digital/delius/service/OffenderManagerService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/OffenderManagerService.java
@@ -79,7 +79,7 @@ public class OffenderManagerService {
         return maybeOffender.map(offender ->
                 allocatePrisonOffenderManager(
                         probationArea,
-                        staffService.findOrCreateStaffInArea(prisonOffenderManager.getOfficer(), probationArea),
+                        staffService.findOrCreateStaffInArea(prisonOffenderManager.getOfficer().capitalise(), probationArea),
                         offender));
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/service/StaffService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/StaffService.java
@@ -81,7 +81,7 @@ public class StaffService {
 
     @Transactional
     public Staff findOrCreateStaffInArea(final Human staff, final ProbationArea probationArea) {
-        return staffRepository.findFirstBySurnameAndForenameAndProbationArea(staff.getSurname(), firstNameIn(staff.getForenames()), probationArea)
+        return staffRepository.findFirstBySurnameIgnoreCaseAndForenameIgnoreCaseAndProbationArea(staff.getSurname(), firstNameIn(staff.getForenames()), probationArea)
                 .orElseGet(() -> createStaffInArea(staff.getSurname(), firstNameIn(staff.getForenames()), probationArea));
     }
 

--- a/src/main/resources/db/schema/V1_0__schema.sql
+++ b/src/main/resources/db/schema/V1_0__schema.sql
@@ -96,7 +96,7 @@ create sequence SC_PROVIDER_ID_SEQ
     ;
 
 create sequence STAFF_ID_SEQ
-    minvalue 2500000000
+    minvalue 2600000000
     maxvalue 900000000000000000
     cache 500
     ;

--- a/src/test/java/uk/gov/justice/digital/delius/data/api/HumanTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/data/api/HumanTest.java
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.delius.data.api;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class HumanTest {
+
+    @Test
+    @DisplayName("Will capitalise first letter in each name")
+    void capitalise() {
+        final var human = Human.builder().forenames("JOHN barry").surname("SmItH").build().capitalise();
+
+        assertThat(human.getForenames()).isEqualTo("John Barry");
+        assertThat(human.getSurname()).isEqualTo("Smith");
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/delius/service/OffenderManagerService_allocatePrisonOffenderManagerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/OffenderManagerService_allocatePrisonOffenderManagerTest.java
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.delius.service;
 
 import com.microsoft.applicationinsights.TelemetryClient;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -80,502 +82,588 @@ public class OffenderManagerService_allocatePrisonOffenderManagerTest {
                 referenceDataService,
                 contactService,
                 telemetryClient);
+    }
 
-        when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(anOffender()));
-        when(staffService.findByStaffId(anyLong())).thenReturn(Optional.of(aStaff()));
-        when(probationAreaRepository.findByInstitutionByNomsCDECode(any())).thenAnswer(args -> {
-            final var code = args.getArgument(0).toString();
-            return Optional.of(aPrisonProbationArea()
+    @Nested
+    @DisplayName("allocatePrisonOffenderManagerByStaffId")
+    class AllocatePrisonOffenderManagerByStaffId {
+        @BeforeEach
+        public void setup() {
+            when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(anOffender()));
+            when(staffService.findByStaffId(anyLong())).thenReturn(Optional.of(aStaff()));
+            when(probationAreaRepository.findByInstitutionByNomsCDECode(any())).thenAnswer(args -> {
+                final var code = args.getArgument(0).toString();
+                return Optional.of(aPrisonProbationArea()
+                        .toBuilder()
+                        .code(code)
+                        .build());
+            });
+        }
+
+
+        @Test
+        public void willReturnEmptyWhenOffenderNotFound() {
+            when(offenderRepository.findByNomsNumber("G9542VP")).thenReturn(Optional.empty());
+            when(staffService.findByStaffId(anyLong())).thenReturn(Optional.of(aStaff()));
+            when(probationAreaRepository.findByInstitutionByNomsCDECode("BWI")).thenReturn(Optional.of(aProbationArea()));
+
+            assertThat(offenderManagerService.allocatePrisonOffenderManagerByStaffId(
+                    "G9542VP",
+                    12345L,
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("BWI")
+                            .build()))
+                    .isNotPresent();
+        }
+
+        @Test
+        public void willReturnEmptyWhenStaffNotFound() {
+            when(offenderRepository.findByNomsNumber("G9542VP")).thenReturn(Optional.of(anOffender()));
+            when(staffService.findByStaffId(anyLong())).thenReturn(Optional.empty());
+            when(probationAreaRepository.findByInstitutionByNomsCDECode("BWI")).thenReturn(Optional.of(aProbationArea()));
+
+            assertThat(offenderManagerService.allocatePrisonOffenderManagerByStaffId(
+                    "G9542VP",
+                    12345L,
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("BWI")
+                            .build()))
+                    .isNotPresent();
+        }
+
+        @Test
+        public void willThrowInvalidRequestWhenPrisonProbationAreaNotFound() {
+            when(offenderRepository.findByNomsNumber("G9542VP")).thenReturn(Optional.of(anOffender()));
+            when(staffService.findByStaffId(anyLong())).thenReturn(Optional.of(aStaff()));
+            when(probationAreaRepository.findByInstitutionByNomsCDECode("BWI")).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> offenderManagerService.allocatePrisonOffenderManagerByStaffId(
+                    "G9542VP",
+                    12345L,
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("BWI")
+                            .build()))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("Prison NOMS code BWI not found");
+        }
+
+        @Test
+        public void willNotAllowAllocationOfStaffInDifferentProbationArea() {
+            when(offenderRepository.findByNomsNumber("G9542VP")).thenReturn(Optional.of(anOffender()));
+            when(staffService.findByStaffId(anyLong())).thenReturn(Optional.of(aStaff()
                     .toBuilder()
-                    .code(code)
+                    .probationArea(
+                            aProbationArea()
+                                    .toBuilder()
+                                    .code("BWI")
+                                    .probationAreaId(99L)
+                                    .build()
+                    )
+                    .build())
+            );
+            when(probationAreaRepository.findByInstitutionByNomsCDECode("N01"))
+                    .thenReturn(Optional.of(
+                            aProbationArea()
+                                    .toBuilder()
+                                    .code("N01")
+                                    .probationAreaId(88L)
+                                    .build()
+                    ));
+            when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
+
+            assertThatThrownBy(() -> offenderManagerService.allocatePrisonOffenderManagerByStaffId(
+                    "G9542VP",
+                    12345L,
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("N01")
+                            .build()))
+                    .isInstanceOf(InvalidRequestException.class);
+
+        }
+
+        @Test
+        public void shouldAddStaffToTeamIfNotMemberAlready() {
+            final var staff = aStaff()
+                    .toBuilder()
+                    .teams(new ArrayList<>())
+                    .build();
+            when(staffService.findByStaffId(anyLong())).thenReturn(Optional.of(staff));
+
+            final var team = aTeam()
+                    .toBuilder()
+                    .teamId(99L)
+                    .build();
+            when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(
+                    team);
+            when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+
+            offenderManagerService.allocatePrisonOffenderManagerByStaffId(
+                    "G9542VP",
+                    12345L,
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("N01")
+                            .build());
+
+            verify(teamService).addStaffToTeam(staff, team);
+
+        }
+
+        @Test
+        public void allocationReasonIsAutomaticTransferWhenExistingPOMIsNotPresent() {
+            when(referenceDataService.pomAllocationAutoTransferReason()).thenReturn(StandardReference
+                    .builder()
+                    .codeValue("AUT")
                     .build());
-        });
+
+            when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
+                    anOffender()
+                            .toBuilder()
+                            .prisonOffenderManagers(List.of())
+                            .build()
+            ));
+            when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
+
+            offenderManagerService.allocatePrisonOffenderManagerByStaffId(
+                    "G9542VP",
+                    12345L,
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("N01")
+                            .build());
+
+
+            verify(prisonOffenderManagerRepository).save(prisonOffenderManagerArgumentCaptor.capture());
+            assertThat(prisonOffenderManagerArgumentCaptor
+                    .getValue()
+                    .getAllocationReason()
+                    .getCodeValue()).isEqualTo("AUT");
+        }
+
+        @Test
+        public void allocationReasonIsInternalTransferWhenExistingAndNewPOMInSameArea() {
+            when(referenceDataService.pomAllocationInternalTransferReason()).thenReturn(StandardReference
+                    .builder()
+                    .codeValue("INA")
+                    .build());
+
+
+            final var existingPOM = anActivePrisonOffenderManager()
+                    .toBuilder()
+                    .probationArea(aPrisonProbationArea()
+                            .toBuilder()
+                            .code("BWI")
+                            .build())
+                    .build();
+
+            when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
+                    anOffender()
+                            .toBuilder()
+                            .prisonOffenderManagers(List.of(existingPOM))
+                            .build()
+            ));
+            when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
+
+            offenderManagerService.allocatePrisonOffenderManagerByStaffId(
+                    "G9542VP",
+                    12345L,
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("BWI")
+                            .build());
+
+
+            verify(prisonOffenderManagerRepository).save(prisonOffenderManagerArgumentCaptor.capture());
+            assertThat(prisonOffenderManagerArgumentCaptor
+                    .getValue()
+                    .getAllocationReason()
+                    .getCodeValue()).isEqualTo("INA");
+        }
+
+        @Test
+        public void allocationReasonIsExternalTransferWhenExistingAndNewPOMDifferentSameArea() {
+            when(referenceDataService.pomAllocationExternalTransferReason()).thenReturn(StandardReference
+                    .builder()
+                    .codeValue("EXT")
+                    .build());
+
+
+            final var existingPOM = anActivePrisonOffenderManager()
+                    .toBuilder()
+                    .probationArea(aPrisonProbationArea()
+                            .toBuilder()
+                            .code("BWI")
+                            .build())
+                    .build();
+
+            when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
+                    anOffender()
+                            .toBuilder()
+                            .prisonOffenderManagers(List.of(existingPOM))
+                            .build()
+            ));
+            when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
+
+            offenderManagerService.allocatePrisonOffenderManagerByStaffId(
+                    "G9542VP",
+                    12345L,
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("BRI")
+                            .build());
+
+
+            verify(prisonOffenderManagerRepository).save(prisonOffenderManagerArgumentCaptor.capture());
+            assertThat(prisonOffenderManagerArgumentCaptor
+                    .getValue()
+                    .getAllocationReason()
+                    .getCodeValue()).isEqualTo("EXT");
+        }
+
+
+        @Test
+        public void existingPrisonerOffenderManagerIsDeactivated() {
+            final var existingPOM = anActivePrisonOffenderManager();
+
+            when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
+                    anOffender()
+                            .toBuilder()
+                            .prisonOffenderManagers(List.of(existingPOM))
+                            .build()
+            ));
+            when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
+
+            offenderManagerService.allocatePrisonOffenderManagerByStaffId(
+                    "G9542VP",
+                    12345L,
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("N01")
+                            .build());
+
+            assertThat(existingPOM.getEndDate()).isNotNull();
+            assertThat(existingPOM.getActiveFlag()).isEqualTo(0L);
+        }
+
+        @Test
+        public void existingResponsibleOfficerIsDeactivatedWhenActivePOM() {
+            final var existingPOMResponsibleOfficer = aResponsibleOfficer()
+                    .toBuilder()
+                    .endDateTime(null)
+                    .build();
+            final var existingPOM = anActivePrisonOffenderManager()
+                    .toBuilder()
+                    .responsibleOfficers(List.of(existingPOMResponsibleOfficer))
+                    .build();
+
+            when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
+                    anOffender()
+                            .toBuilder()
+                            .prisonOffenderManagers(List.of(existingPOM))
+                            .build()
+            ));
+            when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
+
+            offenderManagerService.allocatePrisonOffenderManagerByStaffId(
+                    "G9542VP",
+                    12345L,
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("N01")
+                            .build());
+
+
+            assertThat(existingPOMResponsibleOfficer.getEndDateTime()).isNotNull();
+        }
+
+        @Test
+        public void newPrisonerOffenderManagerIsMadeResponsibleOfficerWhenExistingPOMIsAlsoCurrentRO() {
+            final var existingPOMResponsibleOfficer = aResponsibleOfficer()
+                    .toBuilder()
+                    .endDateTime(null)
+                    .build();
+            final var existingPOM = anActivePrisonOffenderManager()
+                    .toBuilder()
+                    .responsibleOfficers(List.of(existingPOMResponsibleOfficer))
+                    .build();
+
+            when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
+                    anOffender()
+                            .toBuilder()
+                            .prisonOffenderManagers(List.of(existingPOM))
+                            .build()
+            ));
+
+            when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> {
+                final PrisonOffenderManager newPOM = args.getArgument(0);
+                newPOM.setPrisonOffenderManagerId(99L);
+                return newPOM;
+            });
+            when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
+
+            final var newPrisonOffenderManager = offenderManagerService.allocatePrisonOffenderManagerByStaffId(
+                    "G9542VP",
+                    12345L,
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("N01")
+                            .build());
+
+
+            verify(responsibleOfficerRepository).save(responsibleOfficerArgumentCaptor.capture());
+            assertThat(responsibleOfficerArgumentCaptor.getValue().getPrisonOffenderManagerId()).isEqualTo(99L);
+            assertThat(newPrisonOffenderManager.orElseThrow().getIsResponsibleOfficer()).isTrue();
+        }
+
+        @Test
+        public void shouldAddAPOMAllocationContact() {
+            when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
+                    anOffender()
+                            .toBuilder()
+                            .prisonOffenderManagers(List.of())
+                            .build()));
+            when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
+
+            offenderManagerService.allocatePrisonOffenderManagerByStaffId(
+                    "G9542VP",
+                    12345L,
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("N01")
+                            .build());
+
+
+            verify(contactService).addContactForPOMAllocation(isA(PrisonOffenderManager.class));
+        }
+
+        @Test
+        public void shouldAddTelemetryEventForPOMAllocation() {
+            when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
+                    anOffender()
+                            .toBuilder()
+                            .prisonOffenderManagers(List.of())
+                            .crn("X12345")
+                            .build()));
+            when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam()
+                    .toBuilder()
+                    .probationArea(aPrisonProbationArea().toBuilder().code("N01").build())
+                    .build());
+            when(staffService.findByStaffId(anyLong())).thenReturn(Optional.of(aStaff("N01ABC")));
+
+            offenderManagerService.allocatePrisonOffenderManagerByStaffId(
+                    "G9542VP",
+                    12345L,
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("N01")
+                            .build());
+
+            verify(telemetryClient).trackEvent(eq("POMAllocated"), eq(Map.of("probationArea", "N01", "crn", "X12345", "staffCode", "N01ABC")), isNull());
+        }
+
+        @Test
+        public void shouldAddAPOMAllocationContactNotingOldPOM() {
+            final var existingPOM = anActivePrisonOffenderManager();
+            when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
+                    anOffender()
+                            .toBuilder()
+                            .prisonOffenderManagers(List.of(existingPOM))
+                            .build()));
+            when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
+
+            offenderManagerService.allocatePrisonOffenderManagerByStaffId(
+                    "G9542VP",
+                    12345L,
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("N01")
+                            .build());
+
+
+            verify(contactService).addContactForPOMAllocation(isA(PrisonOffenderManager.class), eq(existingPOM));
+        }
+
+        @Test
+        public void shouldAddAResponsibleOfficeMoveContactNotingOldPOM() {
+            final var existingPOMResponsibleOfficer = aResponsibleOfficer()
+                    .toBuilder()
+                    .endDateTime(null)
+                    .build();
+            final var existingPOM = anActivePrisonOffenderManager()
+                    .toBuilder()
+                    .responsibleOfficers(List.of(existingPOMResponsibleOfficer))
+                    .build();
+
+            when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
+                    anOffender()
+                            .toBuilder()
+                            .prisonOffenderManagers(List.of(existingPOM))
+                            .build()
+            ));
+
+            when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> {
+                final PrisonOffenderManager newPOM = args.getArgument(0);
+                newPOM.setPrisonOffenderManagerId(99L);
+                return newPOM;
+            });
+            when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
+
+            offenderManagerService.allocatePrisonOffenderManagerByStaffId(
+                    "G9542VP",
+                    12345L,
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("N01")
+                            .build());
+
+            verify(contactService).addContactForResponsibleOfficerChange(isA(PrisonOffenderManager.class), eq(existingPOM));
+        }
+
+        @Test
+        public void shouldAddTelemetryEventForROAllocation() {
+            final var existingPOMResponsibleOfficer = aResponsibleOfficer()
+                    .toBuilder()
+                    .endDateTime(null)
+                    .build();
+            final var existingPOM = anActivePrisonOffenderManager()
+                    .toBuilder()
+                    .responsibleOfficers(List.of(existingPOMResponsibleOfficer))
+                    .build();
+
+            when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
+                    anOffender()
+                            .toBuilder()
+                            .crn("X12345")
+                            .prisonOffenderManagers(List.of(existingPOM))
+                            .build()
+            ));
+
+            when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> {
+                final PrisonOffenderManager newPOM = args.getArgument(0);
+                newPOM.setPrisonOffenderManagerId(99L);
+                return newPOM;
+            });
+            when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+            when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
+            when(staffService.findByStaffId(anyLong())).thenReturn(Optional.of(aStaff("N01ABC")));
+
+            offenderManagerService.allocatePrisonOffenderManagerByStaffId(
+                    "G9542VP",
+                    12345L,
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("N01")
+                            .build());
+
+            verify(telemetryClient).trackEvent(eq("POMResponsibleOfficerSet"), eq(Map.of("probationArea", "N01", "crn", "X12345", "staffCode", "N01ABC")), isNull());
+        }
     }
 
-    @Test
-    public void willReturnEmptyWhenOffenderNotFound() {
-        when(offenderRepository.findByNomsNumber("G9542VP")).thenReturn(Optional.empty());
-        when(staffService.findByStaffId(anyLong())).thenReturn(Optional.of(aStaff()));
-        when(probationAreaRepository.findByInstitutionByNomsCDECode("BWI")).thenReturn(Optional.of(aProbationArea()));
+    @Nested
+    @DisplayName("allocatePrisonOffenderManagerByName")
+    class AllocatePrisonOffenderManagerByName {
+        @Captor
+        private ArgumentCaptor<Human> humanCaptor;
 
-        assertThat(offenderManagerService.allocatePrisonOffenderManagerByStaffId(
-                "G9542VP",
-                12345L,
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("BWI")
-                        .build()))
-                .isNotPresent();
-        assertThat(offenderManagerService.allocatePrisonOffenderManagerByName(
-                "G9542VP",
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("BWI")
-                        .officer(Human
+        @BeforeEach
+        public void setup() {
+            when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
+                    anOffender()
+                            .toBuilder()
+                            .prisonOffenderManagers(List.of())
+                            .build()));
+            when(probationAreaRepository.findByInstitutionByNomsCDECode(any())).thenAnswer(args -> {
+                final var code = args.getArgument(0).toString();
+                return Optional.of(aPrisonProbationArea()
+                        .toBuilder()
+                        .code(code)
+                        .build());
+            });
+        }
+
+        @Test
+        public void willReturnEmptyWhenOffenderNotFound() {
+            when(offenderRepository.findByNomsNumber("G9542VP")).thenReturn(Optional.empty());
+
+            assertThat(offenderManagerService.allocatePrisonOffenderManagerByName(
+                    "G9542VP",
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("BWI")
+                            .officer(Human
+                                    .builder()
+                                    .surname("Smith")
+                                    .forenames("John")
+                                    .build())
+                            .build()))
+                    .isNotPresent();
+        }
+
+        @Test
+        public void willThrowInvalidRequestWhenPrisonProbationAreaNotFound() {
+            when(probationAreaRepository.findByInstitutionByNomsCDECode("BWI")).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> offenderManagerService.allocatePrisonOffenderManagerByName(
+                    "G9542VP",
+                    CreatePrisonOffenderManager
+                            .builder()
+                            .nomsPrisonInstitutionCode("BWI")
+                            .officer(Human
+                                    .builder()
+                                    .build())
+                            .build()))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("Prison NOMS code BWI not found");
+        }
+
+        @Nested
+        @DisplayName("When successful")
+        class OnSuccess {
+            @BeforeEach
+            void setUp() {
+                when(staffService.findOrCreateStaffInArea(any(), any())).thenReturn(aStaff());
+            }
+
+            @Test
+            public void willCapitaliseStaffName() {
+                when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
+
+                offenderManagerService.allocatePrisonOffenderManagerByName(
+                        "G9542VP",
+                        CreatePrisonOffenderManager
                                 .builder()
-                                .build())
-                        .build()))
-                .isNotPresent();
+                                .nomsPrisonInstitutionCode("N01")
+                                .officer(Human
+                                        .builder()
+                                        .surname("SMITH")
+                                        .forenames("JOHN")
+                                        .build())
+                                .build());
+
+                verify(staffService).findOrCreateStaffInArea(humanCaptor.capture(), any());
+                assertThat(humanCaptor.getValue().getSurname()).isEqualTo("Smith");
+                assertThat(humanCaptor.getValue().getForenames()).isEqualTo("John");
+            }
+        }
     }
-
-    @Test
-    public void willReturnEmptyWhenStaffNotFound() {
-        when(offenderRepository.findByNomsNumber("G9542VP")).thenReturn(Optional.of(anOffender()));
-        when(staffService.findByStaffId(anyLong())).thenReturn(Optional.empty());
-        when(probationAreaRepository.findByInstitutionByNomsCDECode("BWI")).thenReturn(Optional.of(aProbationArea()));
-
-        assertThat(offenderManagerService.allocatePrisonOffenderManagerByStaffId(
-                "G9542VP",
-                12345L,
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("BWI")
-                        .build()))
-                .isNotPresent();
-    }
-
-    @Test
-    public void willThrowInvalidRequestWhenPrisonProbationAreaNotFound() {
-        when(offenderRepository.findByNomsNumber("G9542VP")).thenReturn(Optional.of(anOffender()));
-        when(staffService.findByStaffId(anyLong())).thenReturn(Optional.of(aStaff()));
-        when(probationAreaRepository.findByInstitutionByNomsCDECode("BWI")).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> offenderManagerService.allocatePrisonOffenderManagerByStaffId(
-                "G9542VP",
-                12345L,
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("BWI")
-                        .build()))
-                .isInstanceOf(InvalidRequestException.class)
-                .hasMessageContaining("Prison NOMS code BWI not found");
-
-        assertThatThrownBy(() -> offenderManagerService.allocatePrisonOffenderManagerByName(
-                "G9542VP",
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("BWI")
-                        .officer(Human
-                                .builder()
-                                .build())
-                        .build()))
-                .isInstanceOf(InvalidRequestException.class)
-                .hasMessageContaining("Prison NOMS code BWI not found");
-    }
-
-    @Test
-    public void willNotAllowAllocationOfStaffInDifferentProbationArea() {
-        when(offenderRepository.findByNomsNumber("G9542VP")).thenReturn(Optional.of(anOffender()));
-        when(staffService.findByStaffId(anyLong())).thenReturn(Optional.of(aStaff()
-                .toBuilder()
-                .probationArea(
-                        aProbationArea()
-                                .toBuilder()
-                                .code("BWI")
-                                .probationAreaId(99L)
-                                .build()
-                )
-                .build())
-        );
-        when(probationAreaRepository.findByInstitutionByNomsCDECode("N01"))
-                .thenReturn(Optional.of(
-                        aProbationArea()
-                                .toBuilder()
-                                .code("N01")
-                                .probationAreaId(88L)
-                                .build()
-                ));
-        when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
-
-        assertThatThrownBy(() -> offenderManagerService.allocatePrisonOffenderManagerByStaffId(
-                "G9542VP",
-                12345L,
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("N01")
-                        .build()))
-                .isInstanceOf(InvalidRequestException.class);
-
-    }
-    @Test
-    public void shouldAddStaffToTeamIfNotMemberAlready() {
-        final var staff = aStaff()
-                .toBuilder()
-                .teams(new ArrayList<>())
-                .build();
-        when(staffService.findByStaffId(anyLong())).thenReturn(Optional.of(staff));
-
-        final var team = aTeam()
-                .toBuilder()
-                .teamId(99L)
-                .build();
-        when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(
-                team);
-        when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-
-        offenderManagerService.allocatePrisonOffenderManagerByStaffId(
-                "G9542VP",
-                12345L,
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("N01")
-                        .build());
-
-        verify(teamService).addStaffToTeam(staff, team);
-
-    }
-
-    @Test
-    public void allocationReasonIsAutomaticTransferWhenExistingPOMIsNotPresent() {
-        when(referenceDataService.pomAllocationAutoTransferReason()).thenReturn(StandardReference
-                .builder()
-                .codeValue("AUT")
-                .build());
-
-        when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
-                anOffender()
-                        .toBuilder()
-                        .prisonOffenderManagers(List.of())
-                        .build()
-        ));
-        when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
-
-        offenderManagerService.allocatePrisonOffenderManagerByStaffId(
-                "G9542VP",
-                12345L,
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("N01")
-                        .build());
-
-
-        verify(prisonOffenderManagerRepository).save(prisonOffenderManagerArgumentCaptor.capture());
-        assertThat(prisonOffenderManagerArgumentCaptor.getValue().getAllocationReason().getCodeValue()).isEqualTo("AUT");
-    }
-
-    @Test
-    public void allocationReasonIsInternalTransferWhenExistingAndNewPOMInSameArea() {
-        when(referenceDataService.pomAllocationInternalTransferReason()).thenReturn(StandardReference
-                .builder()
-                .codeValue("INA")
-                .build());
-
-
-        final var existingPOM = anActivePrisonOffenderManager()
-                .toBuilder()
-                .probationArea(aPrisonProbationArea()
-                        .toBuilder()
-                        .code("BWI")
-                        .build())
-                .build();
-
-        when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
-                anOffender()
-                        .toBuilder()
-                        .prisonOffenderManagers(List.of(existingPOM))
-                        .build()
-        ));
-        when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
-
-        offenderManagerService.allocatePrisonOffenderManagerByStaffId(
-                "G9542VP",
-                12345L,
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("BWI")
-                        .build());
-
-
-        verify(prisonOffenderManagerRepository).save(prisonOffenderManagerArgumentCaptor.capture());
-        assertThat(prisonOffenderManagerArgumentCaptor.getValue().getAllocationReason().getCodeValue()).isEqualTo("INA");
-    }
-
-    @Test
-    public void allocationReasonIsExternalTransferWhenExistingAndNewPOMDifferentSameArea() {
-        when(referenceDataService.pomAllocationExternalTransferReason()).thenReturn(StandardReference
-                .builder()
-                .codeValue("EXT")
-                .build());
-
-
-        final var existingPOM = anActivePrisonOffenderManager()
-                .toBuilder()
-                .probationArea(aPrisonProbationArea()
-                        .toBuilder()
-                        .code("BWI")
-                        .build())
-                .build();
-
-        when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
-                anOffender()
-                        .toBuilder()
-                        .prisonOffenderManagers(List.of(existingPOM))
-                        .build()
-        ));
-        when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
-
-        offenderManagerService.allocatePrisonOffenderManagerByStaffId(
-                "G9542VP",
-                12345L,
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("BRI")
-                        .build());
-
-
-        verify(prisonOffenderManagerRepository).save(prisonOffenderManagerArgumentCaptor.capture());
-        assertThat(prisonOffenderManagerArgumentCaptor.getValue().getAllocationReason().getCodeValue()).isEqualTo("EXT");
-    }
-
-
-
-    @Test
-    public void existingPrisonerOffenderManagerIsDeactivated() {
-        final var existingPOM = anActivePrisonOffenderManager();
-
-        when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
-                anOffender()
-                        .toBuilder()
-                        .prisonOffenderManagers(List.of(existingPOM))
-                        .build()
-        ));
-        when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
-
-        offenderManagerService.allocatePrisonOffenderManagerByStaffId(
-                "G9542VP",
-                12345L,
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("N01")
-                        .build());
-
-        assertThat(existingPOM.getEndDate()).isNotNull();
-        assertThat(existingPOM.getActiveFlag()).isEqualTo(0L);
-    }
-
-    @Test
-    public void existingResponsibleOfficerIsDeactivatedWhenActivePOM() {
-        final var existingPOMResponsibleOfficer = aResponsibleOfficer()
-                .toBuilder()
-                .endDateTime(null)
-                .build();
-        final var existingPOM = anActivePrisonOffenderManager()
-                .toBuilder()
-                .responsibleOfficers(List.of(existingPOMResponsibleOfficer))
-                .build();
-
-        when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
-                anOffender()
-                        .toBuilder()
-                        .prisonOffenderManagers(List.of(existingPOM))
-                        .build()
-        ));
-        when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
-
-        offenderManagerService.allocatePrisonOffenderManagerByStaffId(
-                "G9542VP",
-                12345L,
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("N01")
-                        .build());
-
-
-        assertThat(existingPOMResponsibleOfficer.getEndDateTime()).isNotNull();
-    }
-
-    @Test
-    public void newPrisonerOffenderManagerIsMadeResponsibleOfficerWhenExistingPOMIsAlsoCurrentRO() {
-        final var existingPOMResponsibleOfficer = aResponsibleOfficer()
-                .toBuilder()
-                .endDateTime(null)
-                .build();
-        final var existingPOM = anActivePrisonOffenderManager()
-                .toBuilder()
-                .responsibleOfficers(List.of(existingPOMResponsibleOfficer))
-                .build();
-
-        when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
-                anOffender()
-                        .toBuilder()
-                        .prisonOffenderManagers(List.of(existingPOM))
-                        .build()
-        ));
-
-        when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> {
-            final PrisonOffenderManager newPOM = args.getArgument(0);
-            newPOM.setPrisonOffenderManagerId(99L);
-            return newPOM;
-        });
-        when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
-
-        final var newPrisonOffenderManager = offenderManagerService.allocatePrisonOffenderManagerByStaffId(
-                "G9542VP",
-                12345L,
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("N01")
-                        .build());
-
-
-        verify(responsibleOfficerRepository).save(responsibleOfficerArgumentCaptor.capture());
-        assertThat(responsibleOfficerArgumentCaptor.getValue().getPrisonOffenderManagerId()).isEqualTo(99L);
-        assertThat(newPrisonOffenderManager.orElseThrow().getIsResponsibleOfficer()).isTrue();
-    }
-
-    @Test
-    public void shouldAddAPOMAllocationContact() {
-        when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
-                anOffender()
-                        .toBuilder()
-                        .prisonOffenderManagers(List.of())
-                        .build()));
-        when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
-
-        offenderManagerService.allocatePrisonOffenderManagerByStaffId(
-                "G9542VP",
-                12345L,
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("N01")
-                        .build());
-
-
-        verify(contactService).addContactForPOMAllocation(isA(PrisonOffenderManager.class));
-    }
-    @Test
-    public void shouldAddTelemetryEventForPOMAllocation() {
-        when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
-                anOffender()
-                        .toBuilder()
-                        .prisonOffenderManagers(List.of())
-                        .crn("X12345")
-                        .build()));
-        when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam().toBuilder().probationArea(aPrisonProbationArea().toBuilder().code("N01").build()).build());
-        when(staffService.findByStaffId(anyLong())).thenReturn(Optional.of(aStaff("N01ABC")));
-
-        offenderManagerService.allocatePrisonOffenderManagerByStaffId(
-                "G9542VP",
-                12345L,
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("N01")
-                        .build());
-
-        verify(telemetryClient).trackEvent(eq("POMAllocated"), eq(Map.of("probationArea", "N01", "crn", "X12345", "staffCode", "N01ABC")), isNull());
-    }
-
-    @Test
-    public void shouldAddAPOMAllocationContactNotingOldPOM() {
-        final var existingPOM = anActivePrisonOffenderManager();
-        when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
-                anOffender()
-                        .toBuilder()
-                        .prisonOffenderManagers(List.of(existingPOM))
-                        .build()));
-        when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
-
-        offenderManagerService.allocatePrisonOffenderManagerByStaffId(
-                "G9542VP",
-                12345L,
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("N01")
-                        .build());
-
-
-        verify(contactService).addContactForPOMAllocation(isA(PrisonOffenderManager.class), eq(existingPOM));
-    }
-
-    @Test
-    public void shouldAddAResponsibleOfficeMoveContactNotingOldPOM() {
-        final var existingPOMResponsibleOfficer = aResponsibleOfficer()
-                .toBuilder()
-                .endDateTime(null)
-                .build();
-        final var existingPOM = anActivePrisonOffenderManager()
-                .toBuilder()
-                .responsibleOfficers(List.of(existingPOMResponsibleOfficer))
-                .build();
-
-        when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
-                anOffender()
-                        .toBuilder()
-                        .prisonOffenderManagers(List.of(existingPOM))
-                        .build()
-        ));
-
-        when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> {
-            final PrisonOffenderManager newPOM = args.getArgument(0);
-            newPOM.setPrisonOffenderManagerId(99L);
-            return newPOM;
-        });
-        when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
-
-        offenderManagerService.allocatePrisonOffenderManagerByStaffId(
-                "G9542VP",
-                12345L,
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("N01")
-                        .build());
-
-        verify(contactService).addContactForResponsibleOfficerChange(isA(PrisonOffenderManager.class), eq(existingPOM));
-    }
-
-    @Test
-    public void shouldAddTelemetryEventForROAllocation() {
-        final var existingPOMResponsibleOfficer = aResponsibleOfficer()
-                .toBuilder()
-                .endDateTime(null)
-                .build();
-        final var existingPOM = anActivePrisonOffenderManager()
-                .toBuilder()
-                .responsibleOfficers(List.of(existingPOMResponsibleOfficer))
-                .build();
-
-        when(offenderRepository.findByNomsNumber(any())).thenReturn(Optional.of(
-                anOffender()
-                        .toBuilder()
-                        .crn("X12345")
-                        .prisonOffenderManagers(List.of(existingPOM))
-                        .build()
-        ));
-
-        when(prisonOffenderManagerRepository.save(any())).thenAnswer(args -> {
-            final PrisonOffenderManager newPOM = args.getArgument(0);
-            newPOM.setPrisonOffenderManagerId(99L);
-            return newPOM;
-        });
-        when(responsibleOfficerRepository.save(any())).thenAnswer(args -> args.getArgument(0));
-        when(teamService.findOrCreatePrisonOffenderManagerTeamInArea(any())).thenReturn(aTeam());
-        when(staffService.findByStaffId(anyLong())).thenReturn(Optional.of(aStaff("N01ABC")));
-
-        offenderManagerService.allocatePrisonOffenderManagerByStaffId(
-                "G9542VP",
-                12345L,
-                CreatePrisonOffenderManager
-                        .builder()
-                        .nomsPrisonInstitutionCode("N01")
-                        .build());
-
-        verify(telemetryClient).trackEvent(eq("POMResponsibleOfficerSet"), eq(Map.of("probationArea", "N01", "crn", "X12345", "staffCode", "N01ABC")), isNull());
-    }
-
 }

--- a/src/test/java/uk/gov/justice/digital/delius/service/StaffServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/StaffServiceTest.java
@@ -223,7 +223,7 @@ public class StaffServiceTest {
     @Test
     public void willReturnStaffIfFoundWithoutCreatingANewOne() {
         when(staffRepository
-                .findFirstBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
+                .findFirstBySurnameIgnoreCaseAndForenameIgnoreCaseAndProbationArea(any(), any(), any(ProbationArea.class)))
                 .thenReturn(Optional.of(aStaff("N01A123456")));
 
         assertThat(staffService.findOrCreateStaffInArea(Human
@@ -232,14 +232,14 @@ public class StaffServiceTest {
                 .surname("Biggins")
                 .build(), aProbationArea()).getOfficerCode()).isEqualTo("N01A123456");
 
-        verify(staffRepository).findFirstBySurnameAndForenameAndProbationArea(eq("Biggins"), eq("Sandra"), isA(ProbationArea.class));
+        verify(staffRepository).findFirstBySurnameIgnoreCaseAndForenameIgnoreCaseAndProbationArea(eq("Biggins"), eq("Sandra"), isA(ProbationArea.class));
         verify(staffRepository, never()).save(any());
     }
 
     @Test
     public void willLookupByFirstForenameWhenSpaceSeparatedWhenSearchingStaffByName() {
         when(staffRepository
-                .findFirstBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
+                .findFirstBySurnameIgnoreCaseAndForenameIgnoreCaseAndProbationArea(any(), any(), any(ProbationArea.class)))
                 .thenReturn(Optional.of(aStaff("N01A123456")));
 
         assertThat(staffService.findOrCreateStaffInArea(Human
@@ -248,14 +248,14 @@ public class StaffServiceTest {
                 .surname("Biggins")
                 .build(), aProbationArea()).getOfficerCode()).isEqualTo("N01A123456");
 
-        verify(staffRepository).findFirstBySurnameAndForenameAndProbationArea(eq("Biggins"), eq("Sandra"), isA(ProbationArea.class));
+        verify(staffRepository).findFirstBySurnameIgnoreCaseAndForenameIgnoreCaseAndProbationArea(eq("Biggins"), eq("Sandra"), isA(ProbationArea.class));
         verify(staffRepository, never()).save(any());
     }
 
     @Test
     public void willLookupByFirstForenameWhenCommaSeparatedWhenSearchingStaffByName() {
         when(staffRepository
-                .findFirstBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
+                .findFirstBySurnameIgnoreCaseAndForenameIgnoreCaseAndProbationArea(any(), any(), any(ProbationArea.class)))
                 .thenReturn(Optional.of(aStaff("N01A123456")));
 
         assertThat(staffService.findOrCreateStaffInArea(Human
@@ -264,14 +264,14 @@ public class StaffServiceTest {
                 .surname("Biggins")
                 .build(), aProbationArea()).getOfficerCode()).isEqualTo("N01A123456");
 
-        verify(staffRepository).findFirstBySurnameAndForenameAndProbationArea(eq("Biggins"), eq("Sandra"), isA(ProbationArea.class));
+        verify(staffRepository).findFirstBySurnameIgnoreCaseAndForenameIgnoreCaseAndProbationArea(eq("Biggins"), eq("Sandra"), isA(ProbationArea.class));
         verify(staffRepository, never()).save(any());
     }
 
     @Test
     public void willGenerateNewStaffCodeCreateNewStaffWhenNotFoundByName( ) {
         when(staffRepository
-                .findFirstBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
+                .findFirstBySurnameIgnoreCaseAndForenameIgnoreCaseAndProbationArea(any(), any(), any(ProbationArea.class)))
                 .thenReturn(Optional.empty());
         when(staffHelperRepository.getNextStaffCode("N02")).thenReturn("N02A123456");
         when(staffRepository.save(any())).then(params -> params.getArgument(0));
@@ -291,7 +291,7 @@ public class StaffServiceTest {
     @Test
     public void willSetStaffNamesWhenCreateNewStaffWhenNotFoundByName( ) {
         when(staffRepository
-                .findFirstBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
+                .findFirstBySurnameIgnoreCaseAndForenameIgnoreCaseAndProbationArea(any(), any(), any(ProbationArea.class)))
                 .thenReturn(Optional.empty());
         when(staffHelperRepository.getNextStaffCode(any())).thenReturn("N02A123456");
 
@@ -315,7 +315,7 @@ public class StaffServiceTest {
     @Test
     public void willSetProbationAreaWhenCreateNewStaffWhenNotFoundByName( ) {
         when(staffRepository
-                .findFirstBySurnameAndForenameAndProbationArea(any(), any(), any(ProbationArea.class)))
+                .findFirstBySurnameIgnoreCaseAndForenameIgnoreCaseAndProbationArea(any(), any(), any(ProbationArea.class)))
                 .thenReturn(Optional.empty());
         when(staffHelperRepository.getNextStaffCode(any())).thenReturn("N02A123456");
 


### PR DESCRIPTION
OMiC will supply POM names in upper case; e.g JOHN SMITH

This resolves two issues:
1) When Staff already exists regardless of case - use that existing staff, so JOHN SMITH will match an existing john smith
2) When creating a new staff member capitalise - e.g transform to John Smith

