### PR TITLE
Dt 1439 prison location multiple custodial events

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/Custody.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/Custody.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @Data
 @Builder(toBuilder = true)
 @NoArgsConstructor
@@ -20,4 +22,6 @@ public class Custody {
     private CustodyRelatedKeyDates keyDates;
     @ApiModelProperty(value = "Custodial status")
     private KeyValue status;
+    @ApiModelProperty(value = "Date when related sentence started")
+    private LocalDate sentenceStartDate;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/service/ConvictionService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ConvictionService.java
@@ -183,7 +183,7 @@ public class ConvictionService {
         }
     }
 
-    public List<Event> getAllActiveConvictionByOffenderIdAndPrisonBookingNumber(long offenderId, String prisonBookingNumber) {
+    public List<Event> getAllActiveConvictionsByOffenderIdAndPrisonBookingNumber(long offenderId, String prisonBookingNumber) {
         return activeCustodyEvents(offenderId)
             .stream()
             .filter(event -> prisonBookingNumber.equals(event.getDisposal().getCustody().getPrisonerNumber()))

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformer.java
@@ -185,12 +185,12 @@ public class ConvictionTransformer {
 
     public static Custody custodyOf(uk.gov.justice.digital.delius.jpa.standard.entity.Custody custody) {
         return Custody.builder().bookingNumber(custody.getPrisonerNumber())
-            .institution(Optional.ofNullable(custody.getInstitution()).map(InstitutionTransformer::institutionOf)
-                .orElse(null))
-            .status(KeyValueTransformer.keyValueOf(custody.getCustodialStatus()))
-            .sentenceStartDate(custody.getDisposal().getStartDate())
-            .keyDates(Optional.ofNullable(custody.getKeyDates()).map(ConvictionTransformer::custodyRelatedKeyDatesOf)
-                .orElse(CustodyRelatedKeyDates.builder().build())).build();
+                .institution(Optional.ofNullable(custody.getInstitution()).map(InstitutionTransformer::institutionOf)
+                    .orElse(null))
+                .status(KeyValueTransformer.keyValueOf(custody.getCustodialStatus()))
+                .sentenceStartDate(custody.getDisposal().getStartDate())
+                .keyDates(Optional.ofNullable(custody.getKeyDates()).map(ConvictionTransformer::custodyRelatedKeyDatesOf)
+                    .orElse(CustodyRelatedKeyDates.builder().build())).build();
     }
 
     private static CustodyRelatedKeyDates custodyRelatedKeyDatesOf(List<KeyDate> keyDates) {

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformer.java
@@ -185,11 +185,12 @@ public class ConvictionTransformer {
 
     public static Custody custodyOf(uk.gov.justice.digital.delius.jpa.standard.entity.Custody custody) {
         return Custody.builder().bookingNumber(custody.getPrisonerNumber())
-                .institution(Optional.ofNullable(custody.getInstitution()).map(InstitutionTransformer::institutionOf)
-                        .orElse(null))
-                .status(KeyValueTransformer.keyValueOf(custody.getCustodialStatus()))
-                .keyDates(Optional.ofNullable(custody.getKeyDates()).map(ConvictionTransformer::custodyRelatedKeyDatesOf)
-                        .orElse(CustodyRelatedKeyDates.builder().build())).build();
+            .institution(Optional.ofNullable(custody.getInstitution()).map(InstitutionTransformer::institutionOf)
+                .orElse(null))
+            .status(KeyValueTransformer.keyValueOf(custody.getCustodialStatus()))
+            .sentenceStartDate(custody.getDisposal().getStartDate())
+            .keyDates(Optional.ofNullable(custody.getKeyDates()).map(ConvictionTransformer::custodyRelatedKeyDatesOf)
+                .orElse(CustodyRelatedKeyDates.builder().build())).build();
     }
 
     private static CustodyRelatedKeyDates custodyRelatedKeyDatesOf(List<KeyDate> keyDates) {

--- a/src/test/java/uk/gov/justice/digital/delius/entitybuilders/EventEntityBuilderTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/entitybuilders/EventEntityBuilderTest.java
@@ -211,6 +211,25 @@ public class EventEntityBuilderTest {
     }
 
     @Test
+    public void sentenceStartDateCopiedFromDisposalWithinCustody() {
+        final var sentenceStartDate = LocalDate.now();
+        assertThat(
+            ConvictionTransformer.convictionOf(
+                anEvent()
+                    .toBuilder()
+                    .disposal(Disposal
+                        .builder()
+                        .custody(aCustody()
+                            .toBuilder()
+                            .disposal(aDisposal().toBuilder().startDate(sentenceStartDate).build())
+                            .build())
+                        .build())
+                    .build()
+            ).getCustody().getSentenceStartDate()
+        ).isEqualTo(sentenceStartDate);
+    }
+
+    @Test
     public void institutionCopiedFromCustodyWhenPresent() {
         assertThat(
                 ConvictionTransformer.convictionOf(
@@ -581,7 +600,7 @@ public class EventEntityBuilderTest {
     }
 
     private Custody aCustody() {
-        return Custody.builder().build();
+        return Custody.builder().disposal(aDisposal()).build();
     }
 
     private RInstitution anInstitution() {

--- a/src/test/java/uk/gov/justice/digital/delius/service/CustodyServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/CustodyServiceTest.java
@@ -69,7 +69,7 @@ public class CustodyServiceTest {
     public void setup() throws ConvictionService.DuplicateActiveCustodialConvictionsException {
         custodyService = new CustodyService(true, true, telemetryClient, offenderRepository, convictionService, institutionRepository, custodyHistoryRepository, referenceDataService, spgNotificationService, offenderManagerService, contactService, offenderPrisonerService);
         when(offenderRepository.findByNomsNumber(anyString())).thenReturn(Optional.of(Offender.builder().offenderId(99L).build()));
-        when(convictionService.getAllActiveConvictionByOffenderIdAndPrisonBookingNumber(anyLong(), anyString()))
+        when(convictionService.getAllActiveConvictionsByOffenderIdAndPrisonBookingNumber(anyLong(), anyString()))
                 .thenReturn(List.of(EntityHelper.aCustodyEvent()));
     }
 
@@ -131,7 +131,7 @@ public class CustodyServiceTest {
 
         @Test
         public void willCreateTelemetryEventWhenConvictionNotFound() {
-            when(convictionService.getAllActiveConvictionByOffenderIdAndPrisonBookingNumber(99L, "44463B")).thenReturn(List.of());
+            when(convictionService.getAllActiveConvictionsByOffenderIdAndPrisonBookingNumber(99L, "44463B")).thenReturn(List.of());
 
             assertThatThrownBy(() ->
                     custodyService.updateCustodyPrisonLocation("G9542VP", "44463B", UpdateCustody.builder().nomsPrisonInstitutionCode("MDI").build()));
@@ -141,7 +141,7 @@ public class CustodyServiceTest {
 
         @Test
         public void willThrowExceptionWhenBookingNumberNotFound() {
-            when(convictionService.getAllActiveConvictionByOffenderIdAndPrisonBookingNumber(99L, "44463B")).thenReturn(List.of());
+            when(convictionService.getAllActiveConvictionsByOffenderIdAndPrisonBookingNumber(99L, "44463B")).thenReturn(List.of());
 
             assertThatThrownBy(() ->
                     custodyService.updateCustodyPrisonLocation("G9542VP", "44463B", UpdateCustody.builder().nomsPrisonInstitutionCode("MDI").build()))
@@ -155,7 +155,7 @@ public class CustodyServiceTest {
             final LocalDate latestEventSentenceStartDate = LocalDate.now();
             @BeforeEach
             void setUp() {
-                when(convictionService.getAllActiveConvictionByOffenderIdAndPrisonBookingNumber(anyLong(), anyString()))
+                when(convictionService.getAllActiveConvictionsByOffenderIdAndPrisonBookingNumber(anyLong(), anyString()))
                     .thenReturn(List.of(EntityHelper.aCustodyEvent(latestEventSentenceStartDate), EntityHelper.aCustodyEvent(LocalDate.now().minusYears(1))));
 
             }
@@ -175,7 +175,7 @@ public class CustodyServiceTest {
             }
 
             @Test
-            @DisplayName("will return the updated custody record")
+            @DisplayName("will return the latest updated custody record")
             public void willReturnLatestUpdatedEvent() {
                 when(institutionRepository.findByNomisCdeCode("MDI")).thenReturn(Optional.of(anInstitution().toBuilder().description("HMP Highland").build()));
 
@@ -217,9 +217,9 @@ public class CustodyServiceTest {
             }
 
             @Test
-            @DisplayName("will ignore Events with the incorrect status will be but others will be updated")
+            @DisplayName("will ignore events with the incorrect status but others will be updated")
             public void willUpdateOneEventEvenWhenTheOtherIsInWrongStatus() {
-                when(convictionService.getAllActiveConvictionByOffenderIdAndPrisonBookingNumber(anyLong(), anyString()))
+                when(convictionService.getAllActiveConvictionsByOffenderIdAndPrisonBookingNumber(anyLong(), anyString()))
                     .thenReturn(List.of(
                         EntityHelper.aCustodyEvent(),
                         EntityHelper.aCustodyEvent(StandardReference.builder().codeValue("B").codeDescription("Released on Licence").build())));
@@ -259,7 +259,7 @@ public class CustodyServiceTest {
             final var currentInstitution = aPrisonInstitution();
             final var event = EntityHelper.aCustodyEvent();
             event.getDisposal().getCustody().setInstitution(currentInstitution);
-            when(convictionService.getAllActiveConvictionByOffenderIdAndPrisonBookingNumber(anyLong(), anyString())).thenReturn(List
+            when(convictionService.getAllActiveConvictionsByOffenderIdAndPrisonBookingNumber(anyLong(), anyString())).thenReturn(List
                 .of(event));
 
             when(institutionRepository.findByNomisCdeCode("MDI")).thenReturn(Optional.of(newInstitution));
@@ -313,7 +313,7 @@ public class CustodyServiceTest {
             final var offender = anOffender();
             final var event = aCustodyEvent();
             when(offenderRepository.findMostLikelyByNomsNumber("G9542VP")).thenReturn(Either.right(Optional.of(offender)));
-            when(convictionService.getAllActiveConvictionByOffenderIdAndPrisonBookingNumber(anyLong(), anyString())).thenReturn(List.of(event));
+            when(convictionService.getAllActiveConvictionsByOffenderIdAndPrisonBookingNumber(anyLong(), anyString())).thenReturn(List.of(event));
 
             custodyService.updateCustodyPrisonLocation("G9542VP", "44463B", UpdateCustody.builder().nomsPrisonInstitutionCode("MDI").build());
 
@@ -347,7 +347,7 @@ public class CustodyServiceTest {
 
         @Test
         public void willCreateCustodyHistoryChangeCustodyStatusWhenCurrentlyOnlySentenced() {
-            when(convictionService.getAllActiveConvictionByOffenderIdAndPrisonBookingNumber(anyLong(), anyString()))
+            when(convictionService.getAllActiveConvictionsByOffenderIdAndPrisonBookingNumber(anyLong(), anyString()))
                 .thenReturn(List.of(EntityHelper.aCustodyEvent(StandardReference.builder().codeValue("A").codeDescription("Sentenced in custody").build())));
 
             custodyService.updateCustodyPrisonLocation("G9542VP", "44463B", UpdateCustody.builder().nomsPrisonInstitutionCode("MDI").build());
@@ -367,7 +367,7 @@ public class CustodyServiceTest {
 
         @Test
         public void willGetInCustodyStatusWhenCurrentlyOnlySentenced() {
-            when(convictionService.getAllActiveConvictionByOffenderIdAndPrisonBookingNumber(anyLong(), anyString()))
+            when(convictionService.getAllActiveConvictionsByOffenderIdAndPrisonBookingNumber(anyLong(), anyString()))
                 .thenReturn(List.of(EntityHelper.aCustodyEvent(StandardReference.builder().codeValue("A").codeDescription("Sentenced in custody").build())));
 
             custodyService.updateCustodyPrisonLocation("G9542VP", "44463B", UpdateCustody.builder().nomsPrisonInstitutionCode("MDI").build());
@@ -377,7 +377,7 @@ public class CustodyServiceTest {
 
         @Test
         public void willNotifySPGOfCustodyLocationChangeWhenCurrentlyOnlySentenced() {
-            when(convictionService.getAllActiveConvictionByOffenderIdAndPrisonBookingNumber(anyLong(), anyString()))
+            when(convictionService.getAllActiveConvictionsByOffenderIdAndPrisonBookingNumber(anyLong(), anyString()))
                 .thenReturn(List.of(EntityHelper.aCustodyEvent(StandardReference.builder().codeValue("A").codeDescription("Sentenced in custody").build())));
 
             custodyService.updateCustodyPrisonLocation("G9542VP", "44463B", UpdateCustody.builder().nomsPrisonInstitutionCode("MDI").build());
@@ -387,7 +387,7 @@ public class CustodyServiceTest {
 
         @Test
         public void willNotifySPGOfCustodyLocationChangeWhenCurrentlyInCustody() {
-            when(convictionService.getAllActiveConvictionByOffenderIdAndPrisonBookingNumber(anyLong(), anyString()))
+            when(convictionService.getAllActiveConvictionsByOffenderIdAndPrisonBookingNumber(anyLong(), anyString()))
                 .thenReturn(List.of(EntityHelper.aCustodyEvent(StandardReference.builder().codeValue("D").codeDescription("In Custody").build())));
 
             custodyService.updateCustodyPrisonLocation("G9542VP", "44463B", UpdateCustody.builder().nomsPrisonInstitutionCode("MDI").build());
@@ -397,7 +397,7 @@ public class CustodyServiceTest {
 
         @Test
         public void willCreateTelemetryEventWhenPrisonLocationChangesButStatusNotCurrentlyInPrison() {
-            when(convictionService.getAllActiveConvictionByOffenderIdAndPrisonBookingNumber(anyLong(), anyString()))
+            when(convictionService.getAllActiveConvictionsByOffenderIdAndPrisonBookingNumber(anyLong(), anyString()))
                 .thenReturn(List.of(EntityHelper.aCustodyEvent(StandardReference.builder().codeValue("B").codeDescription("Released on Licence").build())));
 
             when(institutionRepository.findByNomisCdeCode("MDI")).thenReturn(Optional.of(anInstitution().toBuilder().description("HMP Highland").build()));

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformerTest.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.digital.delius.data.api.Conviction;
-import uk.gov.justice.digital.delius.data.api.CourtCase;
 import uk.gov.justice.digital.delius.data.api.Sentence;
 import uk.gov.justice.digital.delius.data.api.UnpaidWork;
 import uk.gov.justice.digital.delius.jpa.standard.entity.AdditionalOffence;
@@ -436,13 +435,6 @@ public class ConvictionTransformerTest {
                 .build();
     }
 
-    private uk.gov.justice.digital.delius.data.api.Offence anApiMainOffence() {
-        return uk.gov.justice.digital.delius.data.api.Offence
-                .builder()
-                .mainOffence(true)
-                .build();
-    }
-
     private Event anEvent() {
         return Event
                 .builder()
@@ -464,16 +456,8 @@ public class ConvictionTransformerTest {
                 .softDeleted(0L);
     }
 
-    private CourtCase aCourtCase() {
-        return CourtCase
-                .builder()
-                .offences(ImmutableList.of(anApiMainOffence()))
-                .orderManager(uk.gov.justice.digital.delius.data.api.OrderManager.builder().build())
-                .build();
-    }
-
     private Custody aCustody() {
-        return Custody.builder().build();
+        return Custody.builder().disposal(aDisposal()).build();
     }
 
     private RInstitution anInstitution() {

--- a/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
+++ b/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
@@ -178,6 +178,11 @@ public class EntityHelper {
     public static Event aCustodyEvent() {
         return aCustodyEvent(100L, 99L, new ArrayList<>());
     }
+    public static Event aCustodyEvent(LocalDate sentenceStartDate) {
+        final var event = aCustodyEvent();
+        final var disposal = event.getDisposal().toBuilder().startDate(sentenceStartDate).build();
+        return event.toBuilder().disposal(disposal).build();
+    }
 
     public static Event aCustodyEvent(final StandardReference custodialStatus) {
         return aCustodyEvent(100L, 99L, new ArrayList<>(), custodialStatus);


### PR DESCRIPTION
Previous if an offender had multiple sentences (events) we would not update the prison location on any of the events but return an error, this change will updated each active custodial event (based on current rules around custodial status)