### PR TITLE
DT-1440 Update all matching custodial events that have book number

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/Custody.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/Custody.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.delius.data.api;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,5 +24,6 @@ public class Custody {
     @ApiModelProperty(value = "Custodial status")
     private KeyValue status;
     @ApiModelProperty(value = "Date when related sentence started")
+    @JsonFormat(pattern="yyyy-MM-dd")
     private LocalDate sentenceStartDate;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/service/ConvictionService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ConvictionService.java
@@ -286,6 +286,14 @@ public class ConvictionService {
         return activeCustodyEvents(offenderId);
     }
 
+    @Transactional(readOnly = true)
+    public List<Event> getAllActiveCustodialEventsWithBookingNumber(Long offenderId, String bookingNumber) {
+        return activeCustodyEvents(offenderId)
+            .stream()
+            .filter(event -> bookingNumber.equals(event.getDisposal().getCustody().getPrisonerNumber()))
+            .collect(toList());
+    }
+
     @Transactional
     public Custody addOrReplaceOrDeleteCustodyKeyDates(Long offenderId, Long convictionId, ReplaceCustodyKeyDates replaceCustodyKeyDates) {
         var event = eventRepository.findById(convictionId).orElseThrow();

--- a/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
+++ b/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
@@ -192,6 +192,16 @@ public class EntityHelper {
         return aCustodyEvent(eventId, 99L, keyDates);
     }
 
+    public static Event aCustodyEvent(final Long eventId, LocalDate sentenceStartDate) {
+        final var event = aCustodyEvent(eventId);
+        final var disposal = event.getDisposal().toBuilder().startDate(sentenceStartDate).build();
+        return event.toBuilder().disposal(disposal).build();
+    }
+
+    public static Event aCustodyEvent(final Long eventId) {
+        return aCustodyEvent(eventId, 99L, List.of());
+    }
+
     public static Event aCustodyEvent(final Long eventId, final Long offenderId, final List<KeyDate> keyDates) {
         final var disposal = aDisposal(eventId);
         return anEvent(eventId, offenderId)
@@ -215,6 +225,7 @@ public class EntityHelper {
                         .builder()
                         .sentenceType("NC")
                         .build())
+                .startDate(LocalDate.now())
                 .custody(aCustody(disposal, keyDates, custodialStatus))
                 .build();
     }


### PR DESCRIPTION
Previously for NOMIS date changes we would update no dates if there were multiple active custodial events; this reverses this decision to update dates for all events associated with the prison the booking, therefore indicating all sentences active are affected by the date change