### PR TITLE
Revert profile group change to run flyway migrations on dev profile

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    include: dev-seed
+
   jpa:
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,9 +10,6 @@ spring:
       leak-detection-threshold: 20000
   profiles:
     include: stdout
-    group:
-      dev:
-        - "dev-seed"
 
   jpa:
     hibernate:


### PR DESCRIPTION
I'm not sure why the profile groups are not working but this reinstates the flyway migrations pending further investigation