### PR TITLE
DT-1613 extract jwt scopes

### DIFF
--- a/src/testIntegration/java/uk/gov/justice/digital/delius/config/AuthAwareTokenConverterTest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/config/AuthAwareTokenConverterTest.java
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.delius.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import uk.gov.justice.digital.delius.JwtAuthenticationHelper;
+import uk.gov.justice.digital.delius.JwtParameters;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = {JwtAuthenticationHelper.class})
+public class AuthAwareTokenConverterTest {
+
+    @Autowired
+    private JwtAuthenticationHelper jwtAuthenticationHelper;
+
+    private AuthAwareTokenConverter authenticationConverter = new AuthAwareTokenConverter();
+
+    @Test
+    public void thatScopesAreAddedToAuthorities() {
+        final var token = jwtAuthenticationHelper.createJwt(JwtParameters.builder().build());
+        final var jwt = Jwt.withTokenValue(token)
+            .subject("some_subject")
+            .claim("client_id", "some_client")
+            .claim("authorities", List.of("ROLE_some_role"))
+            .claim("scope", List.of("some_scope"))
+            .expiresAt(Instant.now().plusSeconds(3600))
+            .header("typ", "JWT")
+            .build();
+
+        final var authToken = authenticationConverter.convert(jwt);
+
+        assertThat(authToken.getAuthorities().toArray(new GrantedAuthority[]{})).extracting(GrantedAuthority::getAuthority).containsExactlyInAnyOrder("ROLE_some_role", "SCOPE_some_scope");
+    }
+}

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/IntegrationTestBase.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/IntegrationTestBase.java
@@ -56,6 +56,13 @@ public class IntegrationTestBase {
                 .expiryTime(Duration.ofDays(1));
     }
 
+    protected JwtParametersBuilder createJwtBuilderWithScope(final String scope, final String... roles) {
+        return JwtParameters.builder()
+                .roles(List.of(roles))
+                .scope(Arrays.asList("read", "write", scope))
+                .expiryTime(Duration.ofDays(1));
+    }
+
     protected String tokenWithRoleCommunity() {
         return createJwt("ROLE_COMMUNITY");
     }
@@ -89,6 +96,14 @@ public class IntegrationTestBase {
     protected String createJwtWithUsername(final String username, final String... roles ) {
         return jwtAuthenticationHelper.createJwt(
                 createJwtBuilder(roles)
+                        .username(username)
+                        .clientId("system-client-id")
+                        .build());
+    }
+
+    protected String createJwtWithUsernameAndScope(final String username, final String scope, final String... roles ) {
+        return jwtAuthenticationHelper.createJwt(
+                createJwtBuilderWithScope(scope, roles)
                         .username(username)
                         .clientId("system-client-id")
                         .build());

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderByCrn.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderByCrn.java
@@ -76,7 +76,7 @@ public class OffendersResource_getOffenderByCrn extends IntegrationTestBase {
         final var username = "bob.jones";
         final var path = "/offenders/crn/X440877";
 
-        assertAccessAllowedFor(path, createJwtWithUsername(username, "ROLE_COMMUNITY", "SCOPE_IGNORE_DELIUS_EXCLUSIONS_ALWAYS"));
+        assertAccessAllowedFor(path, createJwtWithUsernameAndScope(username,  "IGNORE_DELIUS_EXCLUSIONS_ALWAYS", "ROLE_COMMUNITY"));
 
     }
 
@@ -101,7 +101,7 @@ public class OffendersResource_getOffenderByCrn extends IntegrationTestBase {
         final var username = "bob.jones";
         final var path = "/offenders/crn/X440890";
 
-        assertAccessAllowedFor(path, createJwtWithUsername(username, "ROLE_COMMUNITY", "SCOPE_IGNORE_DELIUS_INCLUSIONS_ALWAYS"));
+        assertAccessAllowedFor(path, createJwtWithUsernameAndScope(username,  "IGNORE_DELIUS_INCLUSIONS_ALWAYS", "ROLE_COMMUNITY"));
     }
 
     @Test


### PR DESCRIPTION
Fixes a bug where the JWT scopes were not being copied into authorities and so didn't work.