### PR TITLE
ALS-2724 Enabled deployments to ECS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,10 @@ version: 2.1
 
 orbs:
   hmpps: ministryofjustice/hmpps@3.0
+  aws-cli: circleci/aws-cli@1.4.0
+  aws-ecs: circleci/aws-ecs@2.0.0
+  mem: circleci/rememborb@0.0.1
+  queue: eddiewebb/queue@1.5.0
 
 jobs:
   validate-unit:
@@ -48,6 +52,45 @@ jobs:
           path: build/test-results
       - store_artifacts:
           path: build/reports/tests
+  deploy:
+    parameters:
+      container-name:
+        type: string
+        default: community-api
+      service-name:
+        type: string
+        default: $AWS_ECS_ENV_NAME-community-api-service
+      family:
+        type: string
+        default: $AWS_ECS_ENV_NAME-community-api-task-definition
+      env-vars:
+        type: string
+    docker:
+      - image: circleci/python
+    steps:
+      - mem/recall:
+          env_var: APP_VERSION
+      - queue/until_front_of_line:
+          consider-branch: false
+          time: '10'
+      - aws-cli/setup
+      - run:
+          name: Assume IAM role
+          # This is a workaround for the aws-ecs/update-service CircleCI command not taking a profile parameter, and the underlying aws cli command not honouring the AWS_PROFILE env var.
+          # See https://github.com/CircleCI-Public/aws-ecs-orb/issues/41 for further details
+          command: |
+            temp_role=$(aws sts assume-role --role-arn $AWS_ROLE_ARN --role-session-name "circleci-$CIRCLE_BUILD_NUM-$RANDOM")
+            echo "export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)" >> $BASH_ENV; source $BASH_ENV;
+            echo "export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)" >> $BASH_ENV; source $BASH_ENV;
+            echo "export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)" >> $BASH_ENV; source $BASH_ENV;
+            aws configure set aws_session_token "$(echo $temp_role | jq .Credentials.SessionToken | xargs)" --profile default
+      - aws-ecs/update-service:
+          cluster-name: $AWS_ECS_CLUSTER_NAME
+          family: << parameters.family >>
+          service-name: << parameters.service-name >>
+          container-image-name-updates: container=<< parameters.container-name >>,tag=$APP_VERSION
+          container-env-var-updates: << parameters.env-vars >>
+          verify-revision-is-deployed: true
 
 workflows:
   version: 2
@@ -63,10 +106,140 @@ workflows:
               ignore: /.*/
       - hmpps/build_docker:
           name: build_docker
+      - deploy:
+          name: deploy_to_dev
+          context: hmpps-delius-deploy-to-ecs-dev
+          env-vars: >-
+            container=community-api,name=SPRING_PROFILES_ACTIVE,                                value=oracle,
+            container=community-api,name=SPRING_DATASOURCE_USERNAME,                            value=delius_pool,
+            container=community-api,name=DELIUSAPI_BASEURL,                                     value=http://delius-api.ecs.cluster:8080/,
+            container=community-api,name=DEBUG,                                                 value=true,
+            container=community-api,name=SMOKE_TEST_AWARE,                                      value=true,
+            container=community-api,name=SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI, value=https://sign-in-dev.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json
+          requires:
+            - build_docker
+      - deploy:
+          name: deploy_to_test
+          context: hmpps-delius-deploy-to-ecs-test
+          container-name: offenderapi
+          service-name: del-delius-offapi-pri-ecs
+          family: del-delius-offapi-pri-ecs
+          env-vars: >-
+            container=offenderapi,name=SPRING_PROFILES_ACTIVE,                                      value=oracle,
+            container=offenderapi,name=SPRING_DATASOURCE_USERNAME,                                  value=delius_pool,
+            container=offenderapi,name=DELIUSAPI_BASEURL,                                           value=http://delius-api.ecs.cluster:8080/,
+            container=offenderapi,name=SMOKE_TEST_AWARE,                                            value=true,
+            container=offenderapi,name=SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI,       value=https://sign-in-dev.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_CUSTODY,                                value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_BOOKING_NUMBER,                         value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_KEYDATES,                               value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_NOMS_NUMBER,                            value=true,
+            container=offenderapi,name=FEATURES_APPLY_LIMITED_ACCESS_MARKERS,                       value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_MULTIPLE_EVENTS_UPDATE_BULK_KEY_DATES,  value=false,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_MULTIPLE_EVENTS_UPDATE_KEY_DATES,       value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_MULTIPLE_EVENTS_UPDATE_PRISON_LOCATION, value=true
+          requires:
+            - deploy_to_dev
           filters:
             branches:
-              only:
-                - main
+              only: main
+      - request-pre-prod-approval:
+          type: approval
+          requires:
+            - deploy_to_test
+      - deploy:
+          name: deploy_to_stage
+          context: hmpps-delius-deploy-to-ecs-stage
+          container-name: offenderapi
+          service-name: del-delius-offapi-pri-ecs
+          family: del-delius-offapi-pri-ecs
+          env-vars: >-
+            container=offenderapi,name=SPRING_PROFILES_ACTIVE,                                      value=oracle,
+            container=offenderapi,name=SPRING_DATASOURCE_USERNAME,                                  value=delius_pool,
+            container=offenderapi,name=DELIUSAPI_BASEURL,                                           value=http://delius-api.ecs.cluster:8080/,
+            container=offenderapi,name=SMOKE_TEST_AWARE,                                            value=true,
+            container=offenderapi,name=SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI,       value=https://sign-in-preprod.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_CUSTODY,                                value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_BOOKING_NUMBER,                         value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_KEYDATES,                               value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_NOMS_NUMBER,                            value=true,
+            container=offenderapi,name=FEATURES_APPLY_LIMITED_ACCESS_MARKERS,                       value=false,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_MULTIPLE_EVENTS_UPDATE_BULK_KEY_DATES,  value=false,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_MULTIPLE_EVENTS_UPDATE_KEY_DATES,       value=false,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_MULTIPLE_EVENTS_UPDATE_PRISON_LOCATION, value=false
+          requires:
+            - request-pre-prod-approval
+      - deploy:
+          name: deploy_to_perf
+          context: hmpps-delius-deploy-to-ecs-perf
+          container-name: offenderapi
+          service-name: del-delius-offapi-pri-ecs
+          family: del-delius-offapi-pri-ecs
+          env-vars: >-
+            container=offenderapi,name=SPRING_PROFILES_ACTIVE,                                      value=oracle,
+            container=offenderapi,name=SPRING_DATASOURCE_USERNAME,                                  value=delius_pool,
+            container=offenderapi,name=DELIUSAPI_BASEURL,                                           value=http://delius-api.ecs.cluster:8080/,
+            container=offenderapi,name=SMOKE_TEST_AWARE,                                            value=true,
+            container=offenderapi,name=SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI,       value=https://sign-in-preprod.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_CUSTODY,                                value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_BOOKING_NUMBER,                         value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_KEYDATES,                               value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_NOMS_NUMBER,                            value=true,
+            container=offenderapi,name=FEATURES_APPLY_LIMITED_ACCESS_MARKERS,                       value=false,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_MULTIPLE_EVENTS_UPDATE_BULK_KEY_DATES,  value=false,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_MULTIPLE_EVENTS_UPDATE_KEY_DATES,       value=false,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_MULTIPLE_EVENTS_UPDATE_PRISON_LOCATION, value=false
+          requires:
+            - request-pre-prod-approval
+      - deploy:
+          name: deploy_to_pre_prod
+          context: hmpps-delius-deploy-to-ecs-pre-prod
+          container-name: offenderapi
+          service-name: del-delius-offapi-pri-ecs
+          family: del-delius-offapi-pri-ecs
+          env-vars: >-
+            container=offenderapi,name=SPRING_PROFILES_ACTIVE,                                      value=oracle,
+            container=offenderapi,name=SPRING_DATASOURCE_USERNAME,                                  value=delius_pool,
+            container=offenderapi,name=DELIUSAPI_BASEURL,                                           value=http://delius-api.ecs.cluster:8080/,
+            container=offenderapi,name=SMOKE_TEST_AWARE,                                            value=false,
+            container=offenderapi,name=SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI,       value=https://sign-in-preprod.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_CUSTODY,                                value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_BOOKING_NUMBER,                         value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_KEYDATES,                               value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_NOMS_NUMBER,                            value=true,
+            container=offenderapi,name=FEATURES_APPLY_LIMITED_ACCESS_MARKERS,                       value=false,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_MULTIPLE_EVENTS_UPDATE_BULK_KEY_DATES,  value=false,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_MULTIPLE_EVENTS_UPDATE_KEY_DATES,       value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_MULTIPLE_EVENTS_UPDATE_PRISON_LOCATION, value=true
+          requires:
+            - request-pre-prod-approval
+      - request-prod-approval:
+          type: approval
+          requires:
+            - deploy_to_stage
+            - deploy_to_pre_prod
+      - deploy:
+          name: deploy_to_production
+          context: hmpps-delius-deploy-to-ecs-prod
+          container-name: offenderapi
+          service-name: del-delius-offapi-pri-ecs
+          family: del-delius-offapi-pri-ecs
+          env-vars: >-
+            container=offenderapi,name=SPRING_PROFILES_ACTIVE,                                      value=oracle,
+            container=offenderapi,name=SPRING_DATASOURCE_USERNAME,                                  value=delius_pool,
+            container=offenderapi,name=DELIUSAPI_BASEURL,                                           value=http://delius-api.ecs.cluster:8080/,
+            container=offenderapi,name=SMOKE_TEST_AWARE,                                            value=false,
+            container=offenderapi,name=SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI,       value=https://sign-in.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_CUSTODY,                                value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_BOOKING_NUMBER,                         value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_KEYDATES,                               value=true,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_NOMS_NUMBER,                            value=true,
+            container=offenderapi,name=FEATURES_APPLY_LIMITED_ACCESS_MARKERS,                       value=false,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_MULTIPLE_EVENTS_UPDATE_BULK_KEY_DATES,  value=false,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_MULTIPLE_EVENTS_UPDATE_KEY_DATES,       value=false,
+            container=offenderapi,name=FEATURES_NOMS_UPDATE_MULTIPLE_EVENTS_UPDATE_PRISON_LOCATION, value=false
+          requires:
+            - request-prod-approval
 
   security:
     triggers:


### PR DESCRIPTION
Uses the [aws-ecs](https://circleci.com/developer/orbs/orb/circleci/aws-ecs) orb, with AWS credentials stored in CircleCI contexts, to enable deployment to the various Delius environments.

This enables automatic deployment to the `delius-core-dev` environment on every git push, to enable better feedback against pull requests. This may be contentious so feel free to remove it if it's a problem.


<img width="508" alt="Screenshot 2021-04-01 at 13 43 10" src="https://user-images.githubusercontent.com/39557241/113295913-b74cc480-92f0-11eb-9850-100ddc895f1e.png">
