### PR TITLE
Dt 1801 500 errors registrations

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
@@ -136,19 +136,32 @@ public class OffendersResource {
     @ApiResponses(
             value = {
                     @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
-                    @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
+                    @ApiResponse(code = 409, message = "Multiple offenders found in the same state ", response = ErrorResponse.class)
             })
     @GetMapping(path = "/offenders/nomsNumber/{nomsNumber}/convictions")
-    public ResponseEntity<List<Conviction>> getConvictionsForOffender(
+    public List<Conviction> getConvictionsForOffender(
             @ApiParam(name = "nomsNumber", value = "Nomis number for the offender", example = "G9542VP", required = true)
             @NotNull @PathVariable(value = "nomsNumber") final String nomsNumber,
             @ApiParam(name = "activeOnly", value = "retrieve only active convictions", example = "true")
-            @RequestParam(name = "activeOnly", required = false, defaultValue = "false") final boolean activeOnly) {
+            @RequestParam(name = "activeOnly", required = false, defaultValue = "false") final boolean activeOnly,
+            @ApiParam(name = "failOnDuplicate", value = "Should fail if multiple offenders found regardless of status", example = "true", defaultValue = "false")
+            final @RequestParam(value = "failOnDuplicate", defaultValue = "false") boolean failOnDuplicate) {
 
+        final Optional<Long> mayBeOffenderId;
+        if (failOnDuplicate) {
+            mayBeOffenderId = offenderService
+                .singleOffenderIdOfNomsNumber(nomsNumber)
+                .getOrElseThrow(error -> new ConflictingRequestException(error.getMessage()));
 
-        return offenderService.offenderIdOfNomsNumber(nomsNumber)
-                .map(offenderId -> new ResponseEntity<>(convictionService.convictionsFor(offenderId, activeOnly), HttpStatus.OK))
-                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+        } else {
+            mayBeOffenderId = offenderService
+                .mostLikelyOffenderIdOfNomsNumber(nomsNumber)
+                .getOrElseThrow(error -> new ConflictingRequestException(error.getMessage()));
+        }
+
+        return mayBeOffenderId
+                .map(offenderId -> convictionService.convictionsFor(offenderId, activeOnly))
+                .orElseThrow(() -> new NotFoundException(String.format("Offender with nomsNumber %s not found", nomsNumber)));
     }
 
     @ApiOperation(value = "Return the details for an offender. If multiple offenders found the active one wll be returned", tags = "-- Popular core APIs --")

--- a/src/main/java/uk/gov/justice/digital/delius/service/OffenderService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/OffenderService.java
@@ -108,6 +108,11 @@ public class OffenderService {
         return offenderRepository.findByNomsNumber(nomsNumber).map(Offender::getOffenderId);
     }
 
+    public Either<DuplicateOffenderException, Optional<Long>> singleOffenderIdOfNomsNumber(String nomsNumber) {
+        return tryToGetSingleOffenderByNomsNumber(nomsNumber).fold(Either::left,
+            offender -> Either.right(offender.map(Offender::getOffenderId)));
+    }
+
     public Either<DuplicateOffenderException, Optional<Long>> mostLikelyOffenderIdOfNomsNumber(String nomsNumber) {
         return offenderRepository.findMostLikelyByNomsNumber(nomsNumber).fold(Either::left,
                 offender -> Either.right(offender.map(Offender::getOffenderId)));

--- a/src/test/java/uk/gov/justice/digital/delius/controller/secure/RegistrationsResourceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/controller/secure/RegistrationsResourceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.delius.controller.secure;
 
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.vavr.control.Either;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -198,15 +199,15 @@ class RegistrationsResourceTest {
     class GetOffenderRegistrationsByNomsNumber {
         @BeforeEach
         void setUp() {
-            when(offenderService.offenderIdOfNomsNumber(any()))
-                    .thenReturn(Optional.of(99L));
+            when(offenderService.mostLikelyOffenderIdOfNomsNumber(any())).thenReturn(Either.right(Optional.of(99L)));
+
             when(registrationService.registrationsFor(any())).thenReturn(List.of());
         }
 
         @Test
         @DisplayName("Will return 404 when offender not found")
         void WillReturn404WhenOffenderNotFound() {
-            when(offenderService.offenderIdOfNomsNumber(any())).thenReturn(Optional.empty());
+            when(offenderService.mostLikelyOffenderIdOfNomsNumber(any())).thenReturn(Either.right(Optional.empty()));
 
             given()
                     .contentType(APPLICATION_JSON_VALUE)
@@ -216,7 +217,7 @@ class RegistrationsResourceTest {
                     .statusCode(404)
                     .body("developerMessage", containsString("No offender found"));
 
-            verify(offenderService).offenderIdOfNomsNumber("G9542VP");
+            verify(offenderService).mostLikelyOffenderIdOfNomsNumber("G9542VP");
         }
 
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/OffenderServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/OffenderServiceTest.java
@@ -200,4 +200,37 @@ class OffenderServiceTest {
         }
 
     }
+    @Nested
+    @DisplayName("singleOffenderIdOfNomsNumber")
+    class SingleOffenderIdOfNomsNumber {
+        @Test
+        @DisplayName("will return offender id of the most likely offender")
+        void willReturnOffenderIdOfTheMostLikelyOffender() {
+            when(offenderRepository.findAllByNomsNumber(any()))
+                .thenReturn(List.of(anOffender().toBuilder().offenderId(99L).build()));
+
+            assertThat(service.singleOffenderIdOfNomsNumber("A1234ZZ").get()).isPresent();
+        }
+
+        @Test
+        @DisplayName("will return empty if no offender found")
+        void willReturnEmptyWhenNoFoundFound() {
+            when(offenderRepository.findAllByNomsNumber(any()))
+                .thenReturn(List.of());
+
+            assertThat(service.singleOffenderIdOfNomsNumber("A1234ZZ").get()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("will return error if duplicates found")
+        void willReturnAnErrorForDuplicates() {
+            when(offenderRepository.findAllByNomsNumber(any()))
+                .thenReturn(List.of(
+                    anOffender().toBuilder().offenderId(99L).build(),
+                    anOffender().toBuilder().offenderId(98L).build()
+                    ));
+
+            assertThat(service.singleOffenderIdOfNomsNumber("A1234ZZ").isLeft()).isTrue();
+        }
+    }
 }

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/RegistrationsAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/RegistrationsAPITest.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.delius.controller.secure;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -68,5 +70,55 @@ public class RegistrationsAPITest extends IntegrationTestBase {
                 .body("registrations[2].register.description", is("Public Protection"))
                 .body("registrations[2].deregisteringNotes", nullValue())
                 .body("registrations[3].deregisteringNotes", is("Ok again now"));
+    }
+
+    @Nested
+    @DisplayName("When multiple records match the same noms number")
+    class DuplicateNOMSNumbers{
+        @Nested
+        @DisplayName("When only one of the records is current")
+        class OnlyOneActive{
+            @Test
+            @DisplayName("will return the active record")
+            void willReturnTheActiveRecord() {
+                given()
+                    .auth()
+                    .oauth2(tokenWithRoleCommunity())
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .when()
+                    .get("/offenders/nomsNumber/G3232DD/registrations")
+                    .then()
+                    .statusCode(200);
+            }
+            @Test
+            @DisplayName("will return a conflict response when fail on duplicate is set to true")
+            void willReturnAConflictResponseWhenFailureOnDuplicate() {
+                given()
+                    .auth()
+                    .oauth2(tokenWithRoleCommunity())
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .when()
+                    .get("/offenders/nomsNumber/G3232DD/registrations?failOnDuplicate=true")
+                    .then()
+                    .statusCode(409);
+            }
+
+        }
+        @Nested
+        @DisplayName("When both records have the same active state")
+        class BothActive{
+            @Test
+            @DisplayName("will return a conflict response")
+            void willReturnAConflictResponse() {
+                given()
+                    .auth()
+                    .oauth2(tokenWithRoleCommunity())
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .when()
+                    .get("/offenders/nomsNumber/G3636DD/registrations")
+                    .then()
+                    .statusCode(409);
+            }
+        }
     }
 }


### PR DESCRIPTION
This brings
/offender/nomsNumber/:nomsNumber/registrations
/offender/nomsNumber/:nomsNumber/convictions
in line with 
/offender/nomsNumber/:nomsNumber
/offender/nomsNumber/:nomsNumber/all

It assumes if there are duplicate records for the same NOMS number it will return the active one else error will be 409 rather than 500 error.
Old behaviour can be restored using additional parameter (though unlikely anybody would want the old behaviour)

