### PR TITLE
DAPI-88 Interventions Capi Integration Improvements

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/config/DeliusIntegrationContextConfig.java
+++ b/src/main/java/uk/gov/justice/digital/delius/config/DeliusIntegrationContextConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 @Configuration
 @ConfigurationProperties(prefix = "delius-integration-context")
@@ -30,7 +31,7 @@ public class DeliusIntegrationContextConfig {
     @Data
     public static class NsiMapping {
         private String nsiStatus;
-        private Map<String, String> serviceCategoryToNsiType;
+        private Map<UUID, String> serviceCategoryToNsiType;
     }
 
     @Data

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentCreateRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentCreateRequest.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.delius.data.api;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -8,8 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.OffsetDateTime;
 
 @Data
 @Builder
@@ -19,18 +17,11 @@ public class AppointmentCreateRequest {
 
     @NotNull
     @ApiModelProperty(required = true)
-    @JsonFormat(pattern="yyyy-MM-dd")
-    private LocalDate appointmentDate;
+    private OffsetDateTime appointmentStart;
 
     @NotNull
     @ApiModelProperty(required = true)
-    @JsonFormat(pattern="HH:mm:ss")
-    private LocalTime appointmentStartTime;
-
-    @NotNull
-    @ApiModelProperty(required = true)
-    @JsonFormat(pattern="HH:mm:ss")
-    private LocalTime appointmentEndTime;
+    private OffsetDateTime appointmentEnd;
 
     @NotNull
     @ApiModelProperty(required = true)

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ReferralSentRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ReferralSentRequest.java
@@ -34,5 +34,9 @@ public class ReferralSentRequest {
     @ApiModelProperty(required = true)
     private Long sentenceId;
 
+    @NotNull
     private String notes;
+
+    @NotNull
+    private String context;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ReferralSentRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ReferralSentRequest.java
@@ -8,10 +8,10 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.With;
 
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import java.time.LocalDate;
+import java.util.UUID;
 
 @Data
 @With
@@ -25,9 +25,9 @@ public class ReferralSentRequest {
     @JsonFormat(pattern="yyyy-MM-dd")
     private LocalDate date;
 
-    @NotEmpty
+    @NotNull
     @ApiModelProperty(required = true)
-    private String serviceCategory;
+    private UUID serviceCategoryId;
 
     @Positive
     @NotNull

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ReferralSentRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ReferralSentRequest.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.delius.data.api;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,7 +9,7 @@ import lombok.With;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
-import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @Data
@@ -22,8 +21,7 @@ public class ReferralSentRequest {
 
     @NotNull
     @ApiModelProperty(required = true)
-    @JsonFormat(pattern="yyyy-MM-dd")
-    private LocalDate date;
+    private OffsetDateTime sentAt;
 
     @NotNull
     @ApiModelProperty(required = true)

--- a/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.springframework.data.domain.Sort.Direction.DESC;
+import static uk.gov.justice.digital.delius.utils.DateConverter.toLondonLocalDate;
+import static uk.gov.justice.digital.delius.utils.DateConverter.toLondonLocalTime;
 
 @Service
 public class AppointmentService {
@@ -67,9 +69,9 @@ public class AppointmentService {
             .team(context.getTeamCode())
             .staff(context.getStaffCode())
             .officeLocation(request.getOfficeLocationCode())
-            .date(request.getAppointmentDate())
-            .startTime(request.getAppointmentStartTime())
-            .endTime(request.getAppointmentEndTime())
+            .date(toLondonLocalDate(request.getAppointmentStart()))
+            .startTime(toLondonLocalTime(request.getAppointmentStart()))
+            .endTime(toLondonLocalTime(request.getAppointmentEnd()))
             .notes(request.getNotes())
             .eventId(sentenceId)
             .requirementId(requirement.getRequirementId())

--- a/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
@@ -18,6 +18,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static java.util.stream.Collectors.toList;
+import static uk.gov.justice.digital.delius.utils.DateConverter.toLondonLocalDate;
+import static uk.gov.justice.digital.delius.utils.DateConverter.toLondonLocalDateTime;
 
 @Service
 public class ReferralService {
@@ -61,9 +63,9 @@ public class ReferralService {
                 .offenderCrn(crn)
                 .eventId(referralSent.getSentenceId())
                 .requirementId(requirementId)
-                .referralDate(referralSent.getDate())
+                .referralDate(toLondonLocalDate(referralSent.getSentAt()))
                 .status(nsiMapping.getNsiStatus())
-                .statusDate(referralSent.getDate().atStartOfDay())
+                .statusDate(toLondonLocalDateTime(referralSent.getSentAt()))
                 .notes(referralSent.getNotes())
                 .intendedProvider(context.getProviderCode())
                 .manager(NewNsiManager.builder()
@@ -86,7 +88,7 @@ public class ReferralService {
         var existingNsis = nsiService.getNsiByCodes(offenderId, referralSent.getSentenceId(), Collections.singletonList(getNsiType(nsiMapping, referralSent.getServiceCategoryId())))
             .map(wrapper -> wrapper.getNsis().stream()
                 // eventID, offenderID, nsiID, and callerID are handled in the NSI service
-                .filter(nsi -> Optional.ofNullable(nsi.getReferralDate()).map(n -> n.equals(referralSent.getDate())).orElse(false))
+                .filter(nsi -> Optional.ofNullable(nsi.getReferralDate()).map(n -> n.equals(toLondonLocalDate(referralSent.getSentAt()))).orElse(false))
                 .filter(nsi -> Optional.ofNullable(nsi.getNsiStatus()).map(n -> n.getCode().equals(nsiMapping.getNsiStatus())).orElse(false))
                 .filter(nsi -> Optional.ofNullable(nsi.getRequirement()).map(n -> nsi.getRequirement().getRequirementId().equals(requirementId)).orElse(false))
                 .filter(nsi -> Optional.ofNullable(nsi.getIntendedProvider()).map(n -> n.getCode().equals(context.getProviderCode())).orElse(false))

--- a/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
@@ -21,10 +21,6 @@ import static java.util.stream.Collectors.toList;
 @Service
 public class ReferralService {
 
-    // TODO: This must be provided in request from the consumer so that
-    // alternative contexts can be used by different consumers
-    private static final String CRS_DELIUS_INTEGRATION_CONTEXT = "commissioned-rehabilitation-services";
-
     private final DeliusApiClient deliusApiClient;
 
     private final NsiService nsiService;
@@ -51,8 +47,8 @@ public class ReferralService {
     @Transactional
     public ReferralSentResponse createNsiReferral(final String crn,
                                                   final ReferralSentRequest referralSent) {
-        // TODO context name should come from request
-        var context = getContext(CRS_DELIUS_INTEGRATION_CONTEXT);
+
+        var context = getContext(referralSent.getContext());
         var nsiMapping = context.getNsiMapping();
 
         Long requirementId = getRequirement(crn, referralSent.getSentenceId(), context);
@@ -83,8 +79,7 @@ public class ReferralService {
         // determine if there is an existing suitable NSI
         var offenderId = offenderService.offenderIdOfCrn(crn).orElseThrow(() -> new BadRequestException("Offender CRN not found"));
 
-        // TODO context name should come from request
-        var context = getContext(CRS_DELIUS_INTEGRATION_CONTEXT);
+        var context = getContext(referralSent.getContext());
         var nsiMapping = context.getNsiMapping();
 
         var existingNsis = nsiService.getNsiByCodes(offenderId, referralSent.getSentenceId(), Collections.singletonList(getNsiType(nsiMapping, referralSent.getServiceCategory())))

--- a/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.delius.data.api.deliusapi.NewNsiManager;
 
 import java.util.Collections;
 import java.util.Optional;
+import java.util.UUID;
 
 import static java.util.stream.Collectors.toList;
 
@@ -56,7 +57,7 @@ public class ReferralService {
 
         return ReferralSentResponse.builder().nsiId(existingNsi.map(Nsi::getNsiId).orElseGet(() -> {
             var newNsiRequest = NewNsi.builder()
-                .type(getNsiType(nsiMapping, referralSent.getServiceCategory()))
+                .type(getNsiType(nsiMapping, referralSent.getServiceCategoryId()))
                 .offenderCrn(crn)
                 .eventId(referralSent.getSentenceId())
                 .requirementId(requirementId)
@@ -82,7 +83,7 @@ public class ReferralService {
         var context = getContext(referralSent.getContext());
         var nsiMapping = context.getNsiMapping();
 
-        var existingNsis = nsiService.getNsiByCodes(offenderId, referralSent.getSentenceId(), Collections.singletonList(getNsiType(nsiMapping, referralSent.getServiceCategory())))
+        var existingNsis = nsiService.getNsiByCodes(offenderId, referralSent.getSentenceId(), Collections.singletonList(getNsiType(nsiMapping, referralSent.getServiceCategoryId())))
             .map(wrapper -> wrapper.getNsis().stream()
                 // eventID, offenderID, nsiID, and callerID are handled in the NSI service
                 .filter(nsi -> Optional.ofNullable(nsi.getReferralDate()).map(n -> n.equals(referralSent.getDate())).orElse(false))
@@ -108,9 +109,9 @@ public class ReferralService {
         return requirementService.getRequirement(crn, sentenceId, context.getRequirementRehabilitationActivityType()).getRequirementId();
     }
 
-    String getNsiType(final NsiMapping nsiMapping, final String referralType) {
-        return Optional.ofNullable(nsiMapping.getServiceCategoryToNsiType().get(referralType)).orElseThrow(
-            () -> new IllegalArgumentException("Nsi Type mapping from referralType does not exist for: " + referralType)
+    String getNsiType(final NsiMapping nsiMapping, final UUID serviceCategoryId) {
+        return Optional.ofNullable(nsiMapping.getServiceCategoryToNsiType().get(serviceCategoryId)).orElseThrow(
+            () -> new IllegalArgumentException("Nsi Type mapping from referralType does not exist for: " + serviceCategoryId)
         );
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/utils/DateConverter.java
+++ b/src/main/java/uk/gov/justice/digital/delius/utils/DateConverter.java
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.delius.utils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+public class DateConverter {
+
+    private static final String LOCAL_TIMEZONE = "Europe/London";
+
+    public static LocalDate toLondonLocalDate(OffsetDateTime offsetDateTime) {
+        return offsetDateTime.atZoneSameInstant(ZoneId.of(LOCAL_TIMEZONE)).toLocalDate();
+    }
+
+    public static LocalDateTime toLondonLocalDateTime(OffsetDateTime offsetDateTime) {
+        return offsetDateTime.atZoneSameInstant(ZoneId.of(LOCAL_TIMEZONE)).toLocalDateTime();
+    }
+
+    public static LocalTime toLondonLocalTime(OffsetDateTime offsetDateTime) {
+        return offsetDateTime.atZoneSameInstant(ZoneId.of(LOCAL_TIMEZONE)).toLocalTime();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -110,10 +110,10 @@ delius-integration-context:
       nsi-mapping:
         nsi-status: INPROG
         service-category-to-nsi-type:
-          "[Accommodation]": CRS01
-          "[Education, Training and Employment (ETE)]": CRS02
-          "[Finance, Benefits and Debt (FBD)]": CRS03
-          "[Dependency and Recovery (D&R)]": CRS04
+          428ee70f-3001-4399-95a6-ad25eaaede16: CRS01
+          ca374ac3-84eb-4b91-bea7-9005398f426f: CRS02
+          96a63c39-4371-4f17-a6ec-265755f0cf7b: CRS03
+          76bcdb97-1dea-41c1-a4f8-899d88e5d679: CRS04
       contact-mapping:
         appointment-contact-type: CRSAPT
 

--- a/src/test/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingControllerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingControllerTest.java
@@ -14,8 +14,9 @@ import uk.gov.justice.digital.delius.jpa.filters.AppointmentFilter;
 import uk.gov.justice.digital.delius.service.AppointmentService;
 import uk.gov.justice.digital.delius.service.OffenderService;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
@@ -44,10 +45,11 @@ public class AppointmentBookingControllerTest {
 
     @Test
     public void createsAppointment() {
+        OffsetDateTime now = Instant.now().atZone(ZoneId.of("UTC")).toOffsetDateTime().truncatedTo(ChronoUnit.SECONDS);
+
         AppointmentCreateRequest appointmentCreateRequest = AppointmentCreateRequest.builder()
-            .appointmentDate(LocalDate.now())
-            .appointmentStartTime(LocalTime.now().truncatedTo(ChronoUnit.SECONDS))
-            .appointmentEndTime(LocalTime.now().truncatedTo(ChronoUnit.SECONDS))
+            .appointmentStart(now)
+            .appointmentEnd(now.plusHours(1))
             .officeLocationCode("CRSSHEF")
             .notes("http://url")
             .context("commissioned-rehabilitation-services")

--- a/src/test/java/uk/gov/justice/digital/delius/controller/secure/ReferralControllerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/controller/secure/ReferralControllerTest.java
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.delius.data.api.ReferralSentRequest;
 import uk.gov.justice.digital.delius.service.ReferralService;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 import static io.restassured.config.EncoderConfig.encoderConfig;
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
@@ -51,7 +52,7 @@ public class ReferralControllerTest {
             .contentType(APPLICATION_JSON_VALUE)
             .body(ReferralSentRequest.builder()
                 .date(LocalDate.now())
-                .serviceCategory("Dependency and Recovery (D&R)")
+                .serviceCategoryId(UUID.fromString("76bcdb97-1dea-41c1-a4f8-899d88e5d679"))
                 .sentenceId(12354L)
                 .notes("comes notes")
                 .context(INTEGRATION_CONTEXT)

--- a/src/test/java/uk/gov/justice/digital/delius/controller/secure/ReferralControllerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/controller/secure/ReferralControllerTest.java
@@ -22,6 +22,7 @@ public class ReferralControllerTest {
 
     private ReferralService referralService = mock(ReferralService.class);
     private static final String SOME_OFFENDER_CRN = "X0OOM";
+    private static final String INTEGRATION_CONTEXT = "commissioned-rehabilitation-services";
 
     @BeforeEach
     public void setup() {
@@ -51,7 +52,10 @@ public class ReferralControllerTest {
             .body(ReferralSentRequest.builder()
                 .date(LocalDate.now())
                 .serviceCategory("Dependency and Recovery (D&R)")
-                .sentenceId(12354L).build()
+                .sentenceId(12354L)
+                .notes("comes notes")
+                .context(INTEGRATION_CONTEXT)
+                .build()
             )
             .when()
             .post(String.format("/secure/offenders/crn/%s/referral/sent", SOME_OFFENDER_CRN))

--- a/src/test/java/uk/gov/justice/digital/delius/controller/secure/ReferralControllerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/controller/secure/ReferralControllerTest.java
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.delius.controller.advice.SecureControllerAdvice;
 import uk.gov.justice.digital.delius.data.api.ReferralSentRequest;
 import uk.gov.justice.digital.delius.service.ReferralService;
 
-import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 import static io.restassured.config.EncoderConfig.encoderConfig;
@@ -51,7 +51,7 @@ public class ReferralControllerTest {
         given()
             .contentType(APPLICATION_JSON_VALUE)
             .body(ReferralSentRequest.builder()
-                .date(LocalDate.now())
+                .sentAt(OffsetDateTime.now())
                 .serviceCategoryId(UUID.fromString("76bcdb97-1dea-41c1-a4f8-899d88e5d679"))
                 .sentenceId(12354L)
                 .notes("comes notes")

--- a/src/test/java/uk/gov/justice/digital/delius/service/AppointmentServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/AppointmentServiceTest.java
@@ -21,14 +21,15 @@ import uk.gov.justice.digital.delius.jpa.filters.AppointmentFilter;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Contact;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactRepository;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.justice.digital.delius.utils.DateConverter.toLondonLocalDate;
+import static uk.gov.justice.digital.delius.utils.DateConverter.toLondonLocalTime;
 
 @ExtendWith(MockitoExtension.class)
 public class AppointmentServiceTest {
@@ -83,7 +84,7 @@ public class AppointmentServiceTest {
         Requirement requirement = Requirement.builder().requirementId(99L).build();
         when(requirementService.getRequirement("X007", 1L, RAR_TYPE_CODE)).thenReturn(requirement);
 
-        var startTime = LocalTime.now().truncatedTo(ChronoUnit.SECONDS);
+        var startTime = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
         var endTime = startTime.plusHours(1);
 
         NewContact deliusNewContactRequest = aDeliusNewContactRequest(startTime, endTime);
@@ -98,7 +99,7 @@ public class AppointmentServiceTest {
         assertThat(response.getAppointmentId()).isEqualTo(3L);
     }
 
-    private NewContact aDeliusNewContactRequest(LocalTime startTime, LocalTime endTime) {
+    private NewContact aDeliusNewContactRequest(OffsetDateTime startTime, OffsetDateTime endTime) {
         NewContact deliusNewContactRequest = NewContact.builder()
             .offenderCrn("X007")
             .type(CRSAPT_CONTACT_TYPE)
@@ -107,9 +108,9 @@ public class AppointmentServiceTest {
             .team(TEAM_CODE)
             .staff(STAFF_CODE)
             .officeLocation("CRSSHEF")
-            .date(LocalDate.now())
-            .startTime(startTime)
-            .endTime(endTime)
+            .date(toLondonLocalDate(startTime))
+            .startTime(toLondonLocalTime(startTime))
+            .endTime(toLondonLocalTime(endTime))
             .alert(null)
             .sensitive(null)
             .notes("/url")
@@ -120,11 +121,10 @@ public class AppointmentServiceTest {
         return deliusNewContactRequest;
     }
 
-    private AppointmentCreateRequest aAppointmentCreateRequest(LocalTime startTime, LocalTime endTime) {
+    private AppointmentCreateRequest aAppointmentCreateRequest(OffsetDateTime startTime, OffsetDateTime endTime) {
         AppointmentCreateRequest request = AppointmentCreateRequest.builder()
-            .appointmentDate(LocalDate.now())
-            .appointmentStartTime(startTime)
-            .appointmentEndTime(endTime)
+            .appointmentStart(startTime)
+            .appointmentEnd(endTime)
             .officeLocationCode("CRSSHEF")
             .notes("/url")
             .context(CONTEXT)

--- a/src/test/java/uk/gov/justice/digital/delius/service/AppointmentServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/AppointmentServiceTest.java
@@ -32,8 +32,6 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class AppointmentServiceTest {
-    private static final String SERVICE_CATEGORY = "Accommodation";
-    private static final String NSI_TYPE = "CR01";
     private static final String PROVIDER_CODE = "CRS";
     private static final String STAFF_CODE = "CRSUATU";
     private static final String TEAM_CODE = "CRSUAT";

--- a/src/test/java/uk/gov/justice/digital/delius/service/ReferralServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ReferralServiceTest.java
@@ -26,6 +26,8 @@ import uk.gov.justice.digital.delius.data.api.deliusapi.NsiDto;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -78,7 +80,7 @@ public class ReferralServiceTest {
     private static final ReferralSentRequest NSI_REQUEST = ReferralSentRequest
         .builder()
         .serviceCategoryId(SERVICE_CATEGORY_ID)
-        .date(LocalDate.of(2021, 1, 20))
+        .sentAt(OffsetDateTime.of(2021, 1, 20, 12, 0, 0, 0, ZoneOffset.UTC))
         .sentenceId(SENTENCE_ID)
         .notes("A test note")
         .context(INTEGRATION_CONTEXT)
@@ -169,7 +171,7 @@ public class ReferralServiceTest {
             .endDate(null)
             .length(null)
             .status(NSI_STATUS)
-            .statusDate(LocalDateTime.of(2021, 1, 20, 0, 0))
+            .statusDate(LocalDateTime.of(2021, 1, 20, 12, 0))
             .outcome(null)
             .notes("A test note")
             .intendedProvider(PROVIDER_CODE)
@@ -207,7 +209,7 @@ public class ReferralServiceTest {
     private static Stream<Arguments> nsis() {
         return Stream.of(
             Arguments.of(NSI_REQUEST, MATCHING_NSI, true),
-            Arguments.of(NSI_REQUEST.withDate(LocalDate.of(2017, 1, 1)), MATCHING_NSI, false),
+            Arguments.of(NSI_REQUEST.withSentAt(OffsetDateTime.of(2017, 1, 1, 12, 0, 0, 0, ZoneOffset.UTC)), MATCHING_NSI, false),
             Arguments.of(NSI_REQUEST, MATCHING_NSI.withRequirement(Requirement.builder().requirementId(999L).build()), false),
             Arguments.of(NSI_REQUEST, MATCHING_NSI.withRequirement(null), false)
         );

--- a/src/test/java/uk/gov/justice/digital/delius/service/ReferralServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ReferralServiceTest.java
@@ -57,6 +57,7 @@ public class ReferralServiceTest {
     private static final Map <String, String> SERVICE_CATEGORY_TO_NSI_TYPE_MAPPING = new HashMap<>(){{
         this.put(SERVICE_CATEGORY, NSI_TYPE);
     }};
+    private static final String INTEGRATION_CONTEXT = "commissioned-rehabilitation-services";
 
     private static final Nsi MATCHING_NSI = Nsi.builder()
         .nsiId(12345L)
@@ -79,6 +80,7 @@ public class ReferralServiceTest {
         .date(LocalDate.of(2021, 1, 20))
         .sentenceId(SENTENCE_ID)
         .notes("A test note")
+        .context(INTEGRATION_CONTEXT)
         .build();
 
     @Mock
@@ -99,7 +101,7 @@ public class ReferralServiceTest {
     public void setup() {
         DeliusIntegrationContextConfig integrationContextConfig = new DeliusIntegrationContextConfig();
         IntegrationContext integrationContext = new IntegrationContext();
-        integrationContextConfig.getIntegrationContexts().put("commissioned-rehabilitation-services", integrationContext);
+        integrationContextConfig.getIntegrationContexts().put(INTEGRATION_CONTEXT, integrationContext);
         integrationContext.setProviderCode(PROVIDER_CODE);
         integrationContext.setStaffCode(STAFF_CODE);
         integrationContext.setTeamCode(TEAM_CODE);

--- a/src/test/java/uk/gov/justice/digital/delius/service/ReferralServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ReferralServiceTest.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
@@ -47,15 +48,15 @@ public class ReferralServiceTest {
     private static final String OFFENDER_CRN = "X123456";
     private static final Long SENTENCE_ID = 2500295343L;
     private static final Long REQUIREMENT_ID = 2500083652L;
-    private static final String SERVICE_CATEGORY = "Accommodation";
+    private static final UUID SERVICE_CATEGORY_ID = UUID.fromString("428ee70f-3001-4399-95a6-ad25eaaede16");
     private static final String NSI_TYPE = "CR01";
     private static final String PROVIDER_CODE = "CRS";
     private static final String STAFF_CODE = "CRSUATU";
     private static final String TEAM_CODE = "CRSUAT";
     private static final String NSI_STATUS = "INPROG";
     private static final String RAR_TYPE_CODE = "F";
-    private static final Map <String, String> SERVICE_CATEGORY_TO_NSI_TYPE_MAPPING = new HashMap<>(){{
-        this.put(SERVICE_CATEGORY, NSI_TYPE);
+    private static final Map <UUID, String> SERVICE_CATEGORY_TO_NSI_TYPE_MAPPING = new HashMap<>(){{
+        this.put(SERVICE_CATEGORY_ID, NSI_TYPE);
     }};
     private static final String INTEGRATION_CONTEXT = "commissioned-rehabilitation-services";
 
@@ -76,7 +77,7 @@ public class ReferralServiceTest {
 
     private static final ReferralSentRequest NSI_REQUEST = ReferralSentRequest
         .builder()
-        .serviceCategory(SERVICE_CATEGORY)
+        .serviceCategoryId(SERVICE_CATEGORY_ID)
         .date(LocalDate.of(2021, 1, 20))
         .sentenceId(SENTENCE_ID)
         .notes("A test note")
@@ -197,7 +198,7 @@ public class ReferralServiceTest {
 
         var nsiRequest = NSI_REQUEST
             .toBuilder()
-            .serviceCategory("invalid one")
+            .serviceCategoryId(UUID.fromString("999ee70f-3001-4399-95a6-ad25eaaed999"))
             .build();
 
         assertThrows(IllegalArgumentException.class, () -> referralService.createNsiReferral(OFFENDER_CRN, nsiRequest));

--- a/src/test/java/uk/gov/justice/digital/delius/utils/DateConverterTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/utils/DateConverterTest.java
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.delius.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DateConverterTest {
+
+    private static final OffsetDateTime BEFORE_BST = OffsetDateTime.of(2021, 1, 31, 23, 30, 1, 0, ZoneOffset.UTC);
+    private static final OffsetDateTime AFTER_BST = OffsetDateTime.of(2021, 3, 31, 23, 30, 1, 0, ZoneOffset.UTC);
+
+    @Test
+    public void europeLondonZoneExists() {
+        assertThat(ZoneId.getAvailableZoneIds().contains("Europe/London")).isTrue();
+    }
+
+    @Test
+    public void londonAndGMTAreSameBeforeBST() {
+        assertThat(DateConverter.toLondonLocalDate(BEFORE_BST)).isEqualTo(LocalDate.of(2021, 1, 31));
+        assertThat(DateConverter.toLondonLocalTime(BEFORE_BST)).isEqualTo(LocalTime.of(23, 30, 1));
+        assertThat(DateConverter.toLondonLocalDateTime(BEFORE_BST)).isEqualTo(LocalDateTime.of(2021, 1, 31, 23, 30, 1));
+    }
+
+    @Test
+    public void londonTimeAndGMTAreNotSameAfterBST() {
+        assertThat(DateConverter.toLondonLocalDate(AFTER_BST)).isEqualTo(LocalDate.of(2021, 4, 1));
+        assertThat(DateConverter.toLondonLocalTime(AFTER_BST)).isEqualTo(LocalTime.of(0, 30, 1));
+        assertThat(DateConverter.toLondonLocalDateTime(AFTER_BST)).isEqualTo(LocalDateTime.of(2021, 4, 1, 0, 30, 1));
+    }
+}

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingAPITest.java
@@ -18,9 +18,7 @@ import uk.gov.justice.digital.delius.controller.wiremock.DeliusApiMockServer;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
 
 import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -61,9 +59,8 @@ public class AppointmentBookingAPITest extends IntegrationTestBase {
                 .auth().oauth2(token)
                 .contentType(String.valueOf(ContentType.APPLICATION_JSON))
                 .body(writeValueAsString(AppointmentCreateRequest.builder()
-                    .appointmentDate(LocalDate.now())
-                    .appointmentStartTime(LocalTime.now().truncatedTo(ChronoUnit.SECONDS))
-                    .appointmentEndTime(LocalTime.now().truncatedTo(ChronoUnit.SECONDS))
+                    .appointmentStart(OffsetDateTime.now())
+                    .appointmentEnd(OffsetDateTime.now())
                     .officeLocationCode("CRSSHEF")
                     .notes("http://url")
                     .context("commissioned-rehabilitation-services")

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/ReferralAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/ReferralAPITest.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
@@ -31,6 +32,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class ReferralAPITest extends IntegrationTestBase {
 
     private static final String INTEGRATION_CONTEXT = "commissioned-rehabilitation-services";
+    private static final UUID SERVICE_CATEGORY_ID = UUID.fromString("428ee70f-3001-4399-95a6-ad25eaaede16");
 
     private static final DeliusApiMockServer deliusApiMockServer = new DeliusApiMockServer(7999);
 
@@ -63,7 +65,7 @@ public class ReferralAPITest extends IntegrationTestBase {
                 .body(writeValueAsString(ReferralSentRequest
                     .builder()
                     .date(LocalDate.now())
-                    .serviceCategory("Accommodation")
+                    .serviceCategoryId(SERVICE_CATEGORY_ID)
                     .sentenceId(2500295343L)
                     .notes("A test note")
                     .context(INTEGRATION_CONTEXT)
@@ -89,7 +91,7 @@ public class ReferralAPITest extends IntegrationTestBase {
             .body(writeValueAsString(ReferralSentRequest
                 .builder()
                 .date(LocalDate.of(2019,9,2))
-                .serviceCategory("Accommodation")
+                .serviceCategoryId(SERVICE_CATEGORY_ID)
                 .sentenceId(2500295345L)
                 .notes("A test note")
                 .context(INTEGRATION_CONTEXT)

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/ReferralAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/ReferralAPITest.java
@@ -18,7 +18,8 @@ import uk.gov.justice.digital.delius.controller.wiremock.DeliusApiMockServer;
 import uk.gov.justice.digital.delius.data.api.ReferralSentRequest;
 
 import java.time.Duration;
-import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -64,7 +65,7 @@ public class ReferralAPITest extends IntegrationTestBase {
                 .contentType(String.valueOf(ContentType.APPLICATION_JSON))
                 .body(writeValueAsString(ReferralSentRequest
                     .builder()
-                    .date(LocalDate.now())
+                    .sentAt(OffsetDateTime.now())
                     .serviceCategoryId(SERVICE_CATEGORY_ID)
                     .sentenceId(2500295343L)
                     .notes("A test note")
@@ -90,7 +91,7 @@ public class ReferralAPITest extends IntegrationTestBase {
             .contentType(String.valueOf(ContentType.APPLICATION_JSON))
             .body(writeValueAsString(ReferralSentRequest
                 .builder()
-                .date(LocalDate.of(2019,9,2))
+                .sentAt(OffsetDateTime.of(2019,9,2, 12, 0, 1, 2, ZoneOffset.UTC))
                 .serviceCategoryId(SERVICE_CATEGORY_ID)
                 .sentenceId(2500295345L)
                 .notes("A test note")

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/ReferralAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/ReferralAPITest.java
@@ -30,6 +30,8 @@ import static org.hamcrest.Matchers.equalTo;
 @ExtendWith(SpringExtension.class)
 public class ReferralAPITest extends IntegrationTestBase {
 
+    private static final String INTEGRATION_CONTEXT = "commissioned-rehabilitation-services";
+
     private static final DeliusApiMockServer deliusApiMockServer = new DeliusApiMockServer(7999);
 
     @RegisterExtension
@@ -64,6 +66,7 @@ public class ReferralAPITest extends IntegrationTestBase {
                     .serviceCategory("Accommodation")
                     .sentenceId(2500295343L)
                     .notes("A test note")
+                    .context(INTEGRATION_CONTEXT)
                     .build()))
                 .post("offenders/crn/X320741/referral/sent")
                 .then()
@@ -89,6 +92,7 @@ public class ReferralAPITest extends IntegrationTestBase {
                 .serviceCategory("Accommodation")
                 .sentenceId(2500295345L)
                 .notes("A test note")
+                .context(INTEGRATION_CONTEXT)
                 .build()))
             .post("offenders/crn/X320741/referral/sent")
             .then()

--- a/src/testIntegration/resources/application.properties
+++ b/src/testIntegration/resources/application.properties
@@ -28,8 +28,8 @@ delius-integration-context.integration-contexts[commissioned-rehabilitation-serv
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].team-code=CRSUAT
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].requirement-rehabilitation-activity-type=F
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.nsi-status=INPROG
-delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi_mapping.service-category-to-nsi-type[Accommodation]=CRS01
-delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.service-category-to-nsi-type[Education,\ Training\ and\ Employment\ (ETE)]=CRS02
-delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.service-category-to-nsi-type[Finance,\ Benefits\ and\ Debt\ (FBD)]=CRS03
-delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.service-category-to-nsi-type[Dependency\ and\ Recovery\ (D&R)]=CRS04
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi_mapping.service-category-to-nsi-type[428ee70f-3001-4399-95a6-ad25eaaede16]=CRS01
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.service-category-to-nsi-type[ca374ac3-84eb-4b91-bea7-9005398f426f]=CRS02
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.service-category-to-nsi-type[96a63c39-4371-4f17-a6ec-265755f0cf7b]=CRS03
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.service-category-to-nsi-type[76bcdb97-1dea-41c1-a4f8-899d88e5d679]=CRS04
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.appointment-contact-type=CRSAPT


### PR DESCRIPTION
**What does this pull request do?**

After completing the end to end integration between Interventions and Delius UI (via community-api and delius-api) a number of improvements were identified in order to have a working integration. These comprise:

- Interventions to provide offsets with dates and times so that appointments and referrals can be converted correctly for Delius which relies on Europe/London local dates and times
- Use UUIDs over long text to identify reference data (e.g. service category). The use of descriptions was deemed fragile ( business codes are not available for service categories)
- Provide integration context in all requests to identify the correct mapping configuration for a client of community-api

**What is the intent behind these changes?**

To achieve a workable integration between new Interventions Service and the existing Case Management System Delius for both referrals and appointments creation.