### PR TITLE
DAPI-171 Update of Appointment with Outcome for Context of CRS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'io.swagger:swagger-core:1.6.2'
     implementation 'com.oracle.database.jdbc:ojdbc10:19.10.0.0'
     implementation 'io.vavr:vavr:0.10.3'
+    implementation 'com.github.java-json-tools:json-patch:1.13'
 
     annotationProcessor 'org.projectlombok:lombok:1.18.20'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/src/main/java/uk/gov/justice/digital/delius/config/DeliusIntegrationContextConfig.java
+++ b/src/main/java/uk/gov/justice/digital/delius/config/DeliusIntegrationContextConfig.java
@@ -37,6 +37,7 @@ public class DeliusIntegrationContextConfig {
     @Data
     public static class ContactMapping {
         private String appointmentContactType;
+        private Map<String, Map<Boolean, String>> attendanceAndBehaviourNotifiedMappingToOutcomeType;
     }
 
     private Map<String, IntegrationContext> integrationContexts = new HashMap<>();

--- a/src/main/java/uk/gov/justice/digital/delius/config/DeliusIntegrationContextConfig.java
+++ b/src/main/java/uk/gov/justice/digital/delius/config/DeliusIntegrationContextConfig.java
@@ -37,6 +37,7 @@ public class DeliusIntegrationContextConfig {
     @Data
     public static class ContactMapping {
         private String appointmentContactType;
+        private String enforcementReferToOffenderManager;
         private Map<String, Map<Boolean, String>> attendanceAndBehaviourNotifiedMappingToOutcomeType;
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingController.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingController.java
@@ -86,12 +86,11 @@ public class AppointmentBookingController {
         })
 
     @ApiOperation(value = "Updates an Contact appointment")
-    public ResponseEntity<AppointmentUpdateResponse> patchAppointmentWithContext(final @PathVariable("crn") String crn,
-                                                                                 final @PathVariable("appointmentId") Long appointmentId,
-                                                                                 final @PathVariable("contextName") String context,
-                                                                                 final @RequestBody JsonPatch jsonPatch) {
+    public AppointmentUpdateResponse patchAppointmentWithContext(final @PathVariable("crn") String crn,
+                                                                 final @PathVariable("appointmentId") Long appointmentId,
+                                                                 final @PathVariable("contextName") String context,
+                                                                 final @RequestBody JsonPatch jsonPatch) {
 
-        AppointmentUpdateResponse response = appointmentService.patchAppointment(crn, appointmentId, context, jsonPatch);
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        return appointmentService.patchAppointment(crn, appointmentId, context, jsonPatch);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingController.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingController.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.delius.controller.secure;
 
+import com.github.fge.jsonpatch.JsonPatch;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.justice.digital.delius.controller.advice.ErrorResponse;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateResponse;
+import uk.gov.justice.digital.delius.data.api.AppointmentUpdateResponse;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateRequest;
 import uk.gov.justice.digital.delius.service.AppointmentService;
 
@@ -70,5 +72,26 @@ public class AppointmentBookingController {
 
         AppointmentCreateResponse response = appointmentService.createAppointment(crn, sentenceId, contextName, contextlessAppointmentCreateRequest);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @RequestMapping(value = "/offenders/crn/{crn}/appointments/{appointmentId}/context/{contextName}",
+        method = RequestMethod.PATCH,
+        consumes = "application/json")
+    @ApiResponses(
+        value = {
+            @ApiResponse(code = 200, message = "Updated", response = String.class),
+            @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
+            @ApiResponse(code = 403, message = "Requires role ROLE_COMMUNITY_INTERVENTIONS_UPDATE"),
+            @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
+        })
+
+    @ApiOperation(value = "Updates an Contact appointment")
+    public ResponseEntity<AppointmentUpdateResponse> patchAppointmentWithContext(final @PathVariable("crn") String crn,
+                                                                                 final @PathVariable("appointmentId") Long appointmentId,
+                                                                                 final @PathVariable("contextName") String context,
+                                                                                 final @RequestBody JsonPatch jsonPatch) {
+
+        AppointmentUpdateResponse response = appointmentService.patchAppointment(crn, appointmentId, context, jsonPatch);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingController.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingController.java
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateResponse;
 import uk.gov.justice.digital.delius.data.api.AppointmentUpdateResponse;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateRequest;
+import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentOutcomeRequest;
 import uk.gov.justice.digital.delius.service.AppointmentService;
 
 @RestController
@@ -74,8 +75,8 @@ public class AppointmentBookingController {
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
-    @RequestMapping(value = "/offenders/crn/{crn}/appointments/{appointmentId}/context/{contextName}",
-        method = RequestMethod.PATCH,
+    @RequestMapping(value = "/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}",
+        method = RequestMethod.POST,
         consumes = "application/json")
     @ApiResponses(
         value = {
@@ -85,12 +86,12 @@ public class AppointmentBookingController {
             @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
         })
 
-    @ApiOperation(value = "Updates an Contact appointment")
-    public AppointmentUpdateResponse patchAppointmentWithContext(final @PathVariable("crn") String crn,
-                                                                 final @PathVariable("appointmentId") Long appointmentId,
-                                                                 final @PathVariable("contextName") String context,
-                                                                 final @RequestBody JsonPatch jsonPatch) {
+    @ApiOperation(value = "Updates an Contact appointment outcome")
+    public AppointmentUpdateResponse updateAppointmentOutcomeWithContext(final @PathVariable("crn") String crn,
+                                                                         final @PathVariable("appointmentId") Long appointmentId,
+                                                                         final @PathVariable("contextName") String context,
+                                                                         final @RequestBody ContextlessAppointmentOutcomeRequest appointmentOutcomeRequest) {
 
-        return appointmentService.patchAppointment(crn, appointmentId, context, jsonPatch);
+        return appointmentService.updateAppointmentOutcome(crn, appointmentId, context, appointmentOutcomeRequest);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentUpdateResponse.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentUpdateResponse.java
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.delius.data.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppointmentUpdateResponse {
+
+    @NotNull
+    private Long appointmentId;
+}

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessAppointmentOutcomeRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessAppointmentOutcomeRequest.java
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.delius.data.api;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import java.time.OffsetDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContextlessAppointmentOutcomeRequest {
+
+    @NotNull
+    @ApiModelProperty(required = true)
+    private String notes;
+
+    @NotNull
+    @ApiModelProperty(required = true)
+    private String attended;
+
+    @NotNull
+    @ApiModelProperty(required = true)
+    private Boolean notifyPPOfAttendanceBehaviour;
+}

--- a/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateResponse;
 import uk.gov.justice.digital.delius.data.api.AppointmentUpdateResponse;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateRequest;
+import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentOutcomeRequest;
 import uk.gov.justice.digital.delius.data.api.deliusapi.ContactDto;
 import uk.gov.justice.digital.delius.data.api.deliusapi.NewContact;
 import uk.gov.justice.digital.delius.jpa.filters.AppointmentFilter;
@@ -27,6 +28,7 @@ import java.util.Optional;
 
 import static org.springframework.data.domain.Sort.Direction.DESC;
 import static uk.gov.justice.digital.delius.transformers.AppointmentCreateRequestTransformer.appointmentOf;
+import static uk.gov.justice.digital.delius.transformers.AppointmentPatchRequestTransformer.mapAttendanceFieldsToOutcomeOf;
 import static uk.gov.justice.digital.delius.utils.DateConverter.toLondonLocalDate;
 import static uk.gov.justice.digital.delius.utils.DateConverter.toLondonLocalTime;
 
@@ -39,7 +41,6 @@ public class AppointmentService {
     private final RequirementService requirementService;
     private final DeliusApiClient deliusApiClient;
     private final DeliusIntegrationContextConfig deliusIntegrationContextConfig;
-    private final AppointmentPatchRequestTransformer appointmentPatchRequestTransformer;
     private final JsonPatchSupport jsonPatchSupport;
 
     public List<Appointment> appointmentsFor(Long offenderId, AppointmentFilter filter) {
@@ -74,10 +75,10 @@ public class AppointmentService {
         return new AppointmentUpdateResponse(contactDto.getId());
     }
 
-    public AppointmentUpdateResponse patchAppointment(String crn, Long appointmentId, String contextName, JsonPatch jsonPatch) {
+    public AppointmentUpdateResponse updateAppointmentOutcome(String crn, Long appointmentId, String contextName, ContextlessAppointmentOutcomeRequest request) {
 
         final var context = getContext(contextName);
-        final var mappedJsonPatch = appointmentPatchRequestTransformer.mapAttendanceFieldsToOutcomeOf(jsonPatch, context);
+        final var mappedJsonPatch = mapAttendanceFieldsToOutcomeOf(request, context);
         return patchAppointment(crn, appointmentId, mappedJsonPatch);
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/service/DeliusApiClient.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/DeliusApiClient.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.delius.service;
 
+import com.github.fge.jsonpatch.JsonPatch;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -11,6 +12,8 @@ import uk.gov.justice.digital.delius.data.api.deliusapi.ContactDto;
 import uk.gov.justice.digital.delius.data.api.deliusapi.NewContact;
 import uk.gov.justice.digital.delius.data.api.deliusapi.NewNsi;
 import uk.gov.justice.digital.delius.data.api.deliusapi.NsiDto;
+
+import static org.springframework.web.util.UriComponentsBuilder.fromPath;
 
 @Service
 @Slf4j
@@ -33,7 +36,7 @@ public class DeliusApiClient {
             .block();
     }
 
-    public ContactDto createNewContract(NewContact newContact) {
+    public ContactDto createNewContact(NewContact newContact) {
         return webClient.post()
             .uri("/v1/contact")
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
@@ -43,4 +46,14 @@ public class DeliusApiClient {
             .bodyToMono(ContactDto.class)
             .block();
     }
-}
+
+    public ContactDto patchContact(Long contactId, JsonPatch jsonPatch) {
+        return webClient.patch()
+            .uri(fromPath("/v1/contact/{id}").buildAndExpand(contactId).toUriString())
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+            .bodyValue(jsonPatch)
+            .retrieve()
+            .bodyToMono(ContactDto.class)
+            .block();
+    }}

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformer.java
@@ -29,6 +29,7 @@ public class AppointmentPatchRequestTransformer {
     private static final String SOURCE_ATTENDED_FIELD_PATH = "/attended";
     private static final String SOURCE_NOTIFY_PP_FIELD_PATH = "/notifyPPOfAttendanceBehaviour";
     private static final String TARGET_OUTCOME_FIELD_NAME = "outcome";
+    private static final String TARGET_ENFORCEMENT_FIELD_NAME = "enforcement";
 
     private final JsonPatchSupport jsonPatchSupport;
 
@@ -76,6 +77,11 @@ public class AppointmentPatchRequestTransformer {
                     format("Mapping does not exist for attended: %s and notify PP of behaviour: %s", attendedType, notifyBehaviour)));
 
             replaceOperations.add(new ReplaceOperation(of(TARGET_OUTCOME_FIELD_NAME), valueOf(outcomeType)));
+
+            if ( notifyBehaviour ) {
+                replaceOperations.add(new ReplaceOperation(of(TARGET_ENFORCEMENT_FIELD_NAME),
+                    valueOf(context.getContactMapping().getEnforcementReferToOffenderManager())));
+            }
         }
 
         return replaceOperations;

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformer.java
@@ -1,0 +1,100 @@
+package uk.gov.justice.digital.delius.transformers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jsonpatch.JsonPatch;
+import com.github.fge.jsonpatch.JsonPatchOperation;
+import com.github.fge.jsonpatch.ReplaceOperation;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.IntegrationContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+import static com.fasterxml.jackson.databind.node.TextNode.valueOf;
+import static com.github.fge.jackson.jsonpointer.JsonPointer.of;
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toList;
+
+@Component
+@AllArgsConstructor
+public class AppointmentPatchRequestTransformer {
+
+    private static final String JSON_PATCH_PATH_FIELD = "path";
+    private static final String JSON_PATCH_VALUE_FIELD = "value";
+
+    private static final String SOURCE_ATTENDED_FIELD_PATH = "/attended";
+    private static final String SOURCE_NOTIFY_PP_FIELD_PATH = "/notifyPPOfAttendanceBehaviour";
+    private static final String TARGET_OUTCOME_FIELD_NAME = "outcome";
+
+    private final ObjectMapper objectMapper;
+
+    public JsonPatch mapAttendanceFieldsToOutcomeOf(final JsonPatch jsonPatch, final IntegrationContext context) {
+
+        var nodes = objectMapper.convertValue(jsonPatch, JsonNode.class);
+
+        var attendedNode = getAsText(SOURCE_ATTENDED_FIELD_PATH, nodes);
+        var notifyBehaviourNode = getAsBoolean(SOURCE_NOTIFY_PP_FIELD_PATH, nodes);
+
+        var otherReplaceOperations = StreamSupport
+            .stream(nodes.spliterator(), false)
+            .filter(node -> {
+                var fieldPath = node.path(JSON_PATCH_PATH_FIELD).asText();
+                return !SOURCE_ATTENDED_FIELD_PATH.equals(fieldPath) &&
+                    !SOURCE_NOTIFY_PP_FIELD_PATH.equals(fieldPath);
+            })
+            .map(node -> objectMapper.convertValue(node, JsonPatchOperation.class))
+            .collect(toList());
+
+        var replaceOperationsWithOutcome = addReplaceOperationForOutcomeIfAttended(
+            context, attendedNode, notifyBehaviourNode, otherReplaceOperations);
+
+        return new JsonPatch(replaceOperationsWithOutcome);
+    }
+
+    private List<JsonPatchOperation> addReplaceOperationForOutcomeIfAttended(final IntegrationContext context,
+                                                                             final Optional<String> attendedNode,
+                                                                             final Optional<Boolean> notifyBehaviourNode,
+                                                                             final List<JsonPatchOperation> originalReplaceOperations) {
+
+        var replaceOperations = new ArrayList<>(originalReplaceOperations);
+
+        if ( attendedNode.isPresent() ) {
+            var mappings = context.getContactMapping()
+                .getAttendanceAndBehaviourNotifiedMappingToOutcomeType();
+
+            var attendedType = attendedNode.orElseThrow(
+                () -> new IllegalStateException("Attended does not exist in json patch"));
+            var notifyBehaviour = notifyBehaviourNode.orElse(false);
+
+            var outcomeType = ofNullable(mappings.get(attendedType.toLowerCase()))
+                .map(mapping -> mapping.get(notifyBehaviour))
+                .orElseThrow(() -> new IllegalStateException(
+                    format("Mapping does not exist for attended: %s and notify PP of behaviour: %s", attendedType, notifyBehaviour)));
+
+            replaceOperations.add(new ReplaceOperation(of(TARGET_OUTCOME_FIELD_NAME), valueOf(outcomeType)));
+        }
+
+        return replaceOperations;
+    }
+
+    private Optional<Boolean> getAsBoolean(String path, JsonNode nodes) {
+        return getFieldValue(path, nodes).map(JsonNode::asBoolean);
+    }
+
+    private Optional<String> getAsText(String path, JsonNode nodes) {
+        return getFieldValue(path, nodes).map(JsonNode::asText);
+    }
+
+    private Optional<JsonNode> getFieldValue(String path, JsonNode nodes) {
+        return StreamSupport
+            .stream(nodes.spliterator(), false)
+            .filter(node -> node.path(JSON_PATCH_PATH_FIELD).asText().equals(path))
+            .map(node -> node.path(JSON_PATCH_VALUE_FIELD))
+            .findFirst();
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformer.java
@@ -1,90 +1,57 @@
 package uk.gov.justice.digital.delius.transformers;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jsonpatch.JsonPatch;
 import com.github.fge.jsonpatch.JsonPatchOperation;
 import com.github.fge.jsonpatch.ReplaceOperation;
 import lombok.AllArgsConstructor;
-import org.springframework.stereotype.Component;
 import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.IntegrationContext;
-import uk.gov.justice.digital.delius.utils.JsonPatchSupport;
+import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentOutcomeRequest;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.StreamSupport;
 
 import static com.fasterxml.jackson.databind.node.TextNode.valueOf;
 import static com.github.fge.jackson.jsonpointer.JsonPointer.of;
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.toList;
 
-@Component
 @AllArgsConstructor
 public class AppointmentPatchRequestTransformer {
 
-    private static final String JSON_PATCH_PATH_FIELD = "path";
-
-    private static final String SOURCE_ATTENDED_FIELD_PATH = "/attended";
-    private static final String SOURCE_NOTIFY_PP_FIELD_PATH = "/notifyPPOfAttendanceBehaviour";
+    private static final String TARGET_NOTES_FIELD_NAME = "notes";
     private static final String TARGET_OUTCOME_FIELD_NAME = "outcome";
     private static final String TARGET_ENFORCEMENT_FIELD_NAME = "enforcement";
 
-    private final JsonPatchSupport jsonPatchSupport;
+    public static JsonPatch mapAttendanceFieldsToOutcomeOf(final ContextlessAppointmentOutcomeRequest request, final IntegrationContext context) {
 
-    public JsonPatch mapAttendanceFieldsToOutcomeOf(final JsonPatch jsonPatch, final IntegrationContext context) {
+        final var patchOperations = new ArrayList<JsonPatchOperation>();
 
-        var nodes = jsonPatchSupport.convertValue(jsonPatch, JsonNode.class);
+        patchOperations.add(new ReplaceOperation(of(TARGET_NOTES_FIELD_NAME), valueOf(request.getNotes())));
 
-        var attendedNode = jsonPatchSupport.getAsText(SOURCE_ATTENDED_FIELD_PATH, nodes);
-        var notifyBehaviourNode = jsonPatchSupport.getAsBoolean(SOURCE_NOTIFY_PP_FIELD_PATH, nodes);
+        addReplaceOperationForOutcomeIfAttended(
+            context, request.getAttended(), request.getNotifyPPOfAttendanceBehaviour(), patchOperations);
 
-        var otherReplaceOperations = StreamSupport
-            .stream(nodes.spliterator(), false)
-            .filter(node -> {
-                var fieldPath = node.path(JSON_PATCH_PATH_FIELD).asText();
-                return !SOURCE_ATTENDED_FIELD_PATH.equals(fieldPath) &&
-                    !SOURCE_NOTIFY_PP_FIELD_PATH.equals(fieldPath);
-            })
-            .map(node -> jsonPatchSupport.convertValue(node, JsonPatchOperation.class))
-            .collect(toList());
-
-        var replaceOperationsWithOutcome = addReplaceOperationForOutcomeIfAttended(
-            context, attendedNode, notifyBehaviourNode, otherReplaceOperations);
-
-        return new JsonPatch(replaceOperationsWithOutcome);
+        return new JsonPatch(patchOperations);
     }
 
-    private List<JsonPatchOperation> addReplaceOperationForOutcomeIfAttended(final IntegrationContext context,
-                                                                             final Optional<String> attendedNode,
-                                                                             final Optional<Boolean> notifyBehaviourNode,
-                                                                             final List<JsonPatchOperation> originalReplaceOperations) {
+    private static void addReplaceOperationForOutcomeIfAttended(final IntegrationContext context,
+                                                         final String attended,
+                                                         final Boolean notifyBehaviour,
+                                                         final List<JsonPatchOperation> patchOperations) {
 
-        var replaceOperations = new ArrayList<>(originalReplaceOperations);
+        var mappings = context.getContactMapping()
+            .getAttendanceAndBehaviourNotifiedMappingToOutcomeType();
 
-        if ( attendedNode.isPresent() ) {
-            var mappings = context.getContactMapping()
-                .getAttendanceAndBehaviourNotifiedMappingToOutcomeType();
+        var outcomeType = ofNullable(mappings.get(attended.toLowerCase()))
+            .map(mapping -> mapping.get(notifyBehaviour))
+            .orElseThrow(() -> new IllegalStateException(
+                format("Mapping does not exist for attended: %s and notify PP of behaviour: %s", attended, notifyBehaviour)));
 
-            var attendedType = attendedNode.orElseThrow(
-                () -> new IllegalStateException("Attended does not exist in json patch"));
-            var notifyBehaviour = notifyBehaviourNode.orElse(false);
+        patchOperations.add(new ReplaceOperation(of(TARGET_OUTCOME_FIELD_NAME), valueOf(outcomeType)));
 
-            var outcomeType = ofNullable(mappings.get(attendedType.toLowerCase()))
-                .map(mapping -> mapping.get(notifyBehaviour))
-                .orElseThrow(() -> new IllegalStateException(
-                    format("Mapping does not exist for attended: %s and notify PP of behaviour: %s", attendedType, notifyBehaviour)));
-
-            replaceOperations.add(new ReplaceOperation(of(TARGET_OUTCOME_FIELD_NAME), valueOf(outcomeType)));
-
-            if ( notifyBehaviour ) {
-                replaceOperations.add(new ReplaceOperation(of(TARGET_ENFORCEMENT_FIELD_NAME),
-                    valueOf(context.getContactMapping().getEnforcementReferToOffenderManager())));
-            }
+        if ( notifyBehaviour ) {
+            patchOperations.add(new ReplaceOperation(of(TARGET_ENFORCEMENT_FIELD_NAME),
+                valueOf(context.getContactMapping().getEnforcementReferToOffenderManager())));
         }
-
-        return replaceOperations;
     }
-
 }

--- a/src/main/java/uk/gov/justice/digital/delius/utils/JsonPatchSupport.java
+++ b/src/main/java/uk/gov/justice/digital/delius/utils/JsonPatchSupport.java
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.delius.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jsonpatch.JsonPatch;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+@Component
+@AllArgsConstructor
+public class JsonPatchSupport {
+
+    private static final String JSON_PATCH_PATH_FIELD = "path";
+    private static final String JSON_PATCH_VALUE_FIELD = "value";
+
+    private final ObjectMapper objectMapper;
+
+    public Optional<Boolean> getAsBoolean(String path, JsonNode nodes) {
+        return getFieldValue(path, nodes).map(JsonNode::asBoolean);
+    }
+
+    public Optional<String> getAsText(String path, JsonNode nodes) {
+        return getFieldValue(path, nodes).map(JsonNode::asText);
+    }
+
+    public Optional<String> getAsText(String path, JsonPatch jsonPatch) {
+        var nodes = convertValue(jsonPatch, JsonNode.class);
+        return getFieldValue(path, nodes).map(JsonNode::asText);
+    }
+
+    public <T> T convertValue(Object fromValue, Class<T> clazz) {
+        return objectMapper.convertValue(fromValue, clazz);
+    }
+
+    private Optional<JsonNode> getFieldValue(String path, JsonNode nodes) {
+        return StreamSupport
+            .stream(nodes.spliterator(), false)
+            .filter(node -> node.path(JSON_PATCH_PATH_FIELD).asText().equals(path))
+            .map(node -> node.path(JSON_PATCH_VALUE_FIELD))
+            .findFirst();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -116,6 +116,16 @@ delius-integration-context:
           76bcdb97-1dea-41c1-a4f8-899d88e5d679: CRS04
       contact-mapping:
         appointment-contact-type: CRSAPT
+        attendance-and-behaviour-notified-mapping-to-outcome-type:
+          yes:
+            true: AFTC
+            false: ATTC
+          late:
+            true: AFTC
+            false: ATTC
+          no:
+            true: AFTA
+            false: AFTA
 
 smoke:
   test:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -116,6 +116,7 @@ delius-integration-context:
           76bcdb97-1dea-41c1-a4f8-899d88e5d679: CRS04
       contact-mapping:
         appointment-contact-type: CRSAPT
+        enforcement-refer-to-offender-manager: ROM
         attendance-and-behaviour-notified-mapping-to-outcome-type:
           yes:
             true: AFTC

--- a/src/test/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingControllerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingControllerTest.java
@@ -1,15 +1,21 @@
 package uk.gov.justice.digital.delius.controller.secure;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jsonpatch.JsonPatch;
+import com.github.fge.jsonpatch.ReplaceOperation;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateResponse;
+import uk.gov.justice.digital.delius.data.api.AppointmentUpdateResponse;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateRequest;
 import uk.gov.justice.digital.delius.jpa.filters.AppointmentFilter;
 import uk.gov.justice.digital.delius.service.AppointmentService;
@@ -19,9 +25,14 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.stream.StreamSupport;
 
+import static com.fasterxml.jackson.databind.node.TextNode.valueOf;
+import static com.github.fge.jackson.jsonpointer.JsonPointer.of;
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -103,5 +114,39 @@ public class AppointmentBookingControllerTest {
             .getAppointmentId();
 
         assertThat(appointmentIdResponse).isEqualTo(3L);
+    }
+
+    @Test
+    public void patchesAppointmentUsingContextlessClientEndpoint() {
+
+        JsonPatch jsonPatch = new JsonPatch(asList(new ReplaceOperation(of("attended"), valueOf("LATE"))));
+
+        when(appointmentService.patchAppointment(eq("1"), eq(2L), eq("commissioned-rehabilitation-services"),
+            ArgumentMatchers.argThat(patch -> getFieldValue("/attended", jsonPatch).equals("LATE"))))
+            .thenReturn(AppointmentUpdateResponse.builder().appointmentId(2L).build());
+
+        Long appointmentIdResponse = given()
+            .contentType(APPLICATION_JSON_VALUE)
+            .body(jsonPatch)
+            .when()
+            .patch("/secure/offenders/crn/1/appointments/2/context/commissioned-rehabilitation-services")
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .as(AppointmentUpdateResponse.class)
+            .getAppointmentId();
+
+        assertThat(appointmentIdResponse).isEqualTo(2L);
+    }
+
+    private String getFieldValue(String path, JsonPatch jsonPatch) {
+        final var objectMapper = new ObjectMapper();
+        return StreamSupport.stream(objectMapper.convertValue(jsonPatch, JsonNode.class).spliterator(), false)
+            .filter(node -> node.path("path").asText().equals(path))
+            .map(node -> node.path("value"))
+            .findFirst()
+            .map(JsonNode::asText)
+            .orElseThrow(() -> new IllegalStateException("Expected value"));
     }
 }

--- a/src/test/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingControllerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingControllerTest.java
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateResponse;
 import uk.gov.justice.digital.delius.data.api.AppointmentUpdateResponse;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateRequest;
+import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentOutcomeRequest;
 import uk.gov.justice.digital.delius.jpa.filters.AppointmentFilter;
 import uk.gov.justice.digital.delius.service.AppointmentService;
 import uk.gov.justice.digital.delius.service.OffenderService;
@@ -117,19 +118,23 @@ public class AppointmentBookingControllerTest {
     }
 
     @Test
-    public void patchesAppointmentUsingContextlessClientEndpoint() {
+    public void updatesAppointmentOutcomeUsingContextlessClientEndpoint() {
 
-        JsonPatch jsonPatch = new JsonPatch(asList(new ReplaceOperation(of("attended"), valueOf("LATE"))));
+        ContextlessAppointmentOutcomeRequest request = ContextlessAppointmentOutcomeRequest.builder()
+            .notes("notes")
+            .attended("LATE")
+            .notifyPPOfAttendanceBehaviour(true)
+            .build();
 
-        when(appointmentService.patchAppointment(eq("1"), eq(2L), eq("commissioned-rehabilitation-services"),
-            ArgumentMatchers.argThat(patch -> getFieldValue("/attended", jsonPatch).equals("LATE"))))
+        when(appointmentService.updateAppointmentOutcome(eq("1"), eq(2L), eq("commissioned-rehabilitation-services"),
+            eq(request)))
             .thenReturn(AppointmentUpdateResponse.builder().appointmentId(2L).build());
 
         Long appointmentIdResponse = given()
             .contentType(APPLICATION_JSON_VALUE)
-            .body(jsonPatch)
+            .body(request)
             .when()
-            .patch("/secure/offenders/crn/1/appointments/2/context/commissioned-rehabilitation-services")
+            .post("/secure/offenders/crn/1/appointments/2/outcome/context/commissioned-rehabilitation-services")
             .then()
             .statusCode(200)
             .extract()
@@ -138,15 +143,5 @@ public class AppointmentBookingControllerTest {
             .getAppointmentId();
 
         assertThat(appointmentIdResponse).isEqualTo(2L);
-    }
-
-    private String getFieldValue(String path, JsonPatch jsonPatch) {
-        final var objectMapper = new ObjectMapper();
-        return StreamSupport.stream(objectMapper.convertValue(jsonPatch, JsonNode.class).spliterator(), false)
-            .filter(node -> node.path("path").asText().equals(path))
-            .map(node -> node.path("value"))
-            .findFirst()
-            .map(JsonNode::asText)
-            .orElseThrow(() -> new IllegalStateException("Expected value"));
     }
 }

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformerTest.java
@@ -1,0 +1,110 @@
+package uk.gov.justice.digital.delius.transformers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jackson.jsonpointer.JsonPointer;
+import com.github.fge.jsonpatch.JsonPatch;
+import com.github.fge.jsonpatch.ReplaceOperation;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.IntegrationContext;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Optional;
+
+import static com.fasterxml.jackson.databind.node.BooleanNode.valueOf;
+import static com.fasterxml.jackson.databind.node.TextNode.valueOf;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppointmentPatchRequestTransformerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private AppointmentPatchRequestTransformer appointmentPatchRequestTransformer;
+
+    private IntegrationContext integrationContext;
+
+    @BeforeEach
+    public void before() {
+
+        integrationContext = new IntegrationContext();
+        integrationContext.getContactMapping().setAttendanceAndBehaviourNotifiedMappingToOutcomeType(
+            new HashMap<>() {{
+                this.put("no", new HashMap<>() {{
+                    this.put(true, "AFTA");
+                    this.put(false, "AFTA");
+                }});
+                this.put("late", new HashMap<>() {{
+                    this.put(true, "AFTC");
+                    this.put(false, "ATTC");
+                }});
+            }}
+        );
+        appointmentPatchRequestTransformer = new AppointmentPatchRequestTransformer(objectMapper);
+    }
+
+    @Test
+    public void transformsJsonPatchCollapsingAttendedAndNotifyFieldsToOutcome() throws JsonProcessingException {
+
+        final var attendedValue = "LATE";
+        final var notifyPPOfAttendanceBehaviourValue = true;
+        final var jsonPatch = buildPatch(of(attendedValue), of(notifyPPOfAttendanceBehaviourValue));
+
+        final var transformedPatch = appointmentPatchRequestTransformer.mapAttendanceFieldsToOutcomeOf(jsonPatch, integrationContext);
+
+        assertThat(objectMapper.writeValueAsString(transformedPatch))
+            .isEqualTo("[{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}," +
+                "{\"op\":\"replace\",\"path\":\"/outcome\",\"value\":\"AFTC\"}]");
+    }
+
+    @Test
+    public void doesNotTransformsJsonPatchWhenAttendedValueNotPresent() throws JsonProcessingException {
+
+        final var notifyPPOfAttendanceBehaviourValue = true;
+        final var jsonPatch = buildPatch(empty(), of(notifyPPOfAttendanceBehaviourValue));
+
+        final var transformedPatch = appointmentPatchRequestTransformer.mapAttendanceFieldsToOutcomeOf(jsonPatch, integrationContext);
+
+        assertThat(objectMapper.writeValueAsString(transformedPatch))
+            .isEqualTo("[{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}]");
+    }
+
+    @Test
+    public void defaultsNotifyBehaviourToFalseWhenAttendedSetToNo() throws JsonProcessingException {
+
+        final var attendedValue = "LATE";
+        final var jsonPatch = buildPatch(of(attendedValue), empty());
+
+        final var transformedPatch = appointmentPatchRequestTransformer.mapAttendanceFieldsToOutcomeOf(jsonPatch, integrationContext);
+
+        assertThat(objectMapper.writeValueAsString(transformedPatch))
+            .isEqualTo("[{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}," +
+                "{\"op\":\"replace\",\"path\":\"/outcome\",\"value\":\"ATTC\"}]");
+    }
+
+    @Test
+    public void throwsExceptionWhenNoMapping() {
+        final var attendedValue = "UnknownValue";
+        final var jsonPatch = buildPatch(of(attendedValue), empty());
+
+        IllegalStateException illegalStateException = Assertions.assertThrows(IllegalStateException.class,
+            () -> { appointmentPatchRequestTransformer.mapAttendanceFieldsToOutcomeOf(jsonPatch, integrationContext); });
+        assertThat(illegalStateException.getMessage())
+            .isEqualTo("Mapping does not exist for attended: UnknownValue and notify PP of behaviour: false");
+    }
+
+    private JsonPatch buildPatch(Optional<String> attendedValue, Optional<Boolean> notifyPPOfAttendanceBehaviourValue) {
+
+        return new JsonPatch(new ArrayList<>() {{
+            this.add(new ReplaceOperation(JsonPointer.of("notes"), valueOf("some notes")));
+            attendedValue.ifPresent(value ->
+                this.add(new ReplaceOperation(JsonPointer.of("attended"), valueOf(value))));
+            notifyPPOfAttendanceBehaviourValue.ifPresent(value ->
+                this.add(new ReplaceOperation(JsonPointer.of("notifyPPOfAttendanceBehaviour"), valueOf(value))));
+        }});
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformerTest.java
@@ -33,6 +33,7 @@ class AppointmentPatchRequestTransformerTest {
     public void before() {
 
         integrationContext = new IntegrationContext();
+        integrationContext.getContactMapping().setEnforcementReferToOffenderManager("ROM");
         integrationContext.getContactMapping().setAttendanceAndBehaviourNotifiedMappingToOutcomeType(
             new HashMap<>() {{
                 this.put("no", new HashMap<>() {{
@@ -52,6 +53,20 @@ class AppointmentPatchRequestTransformerTest {
     public void transformsJsonPatchCollapsingAttendedAndNotifyFieldsToOutcome() throws JsonProcessingException {
 
         final var attendedValue = "LATE";
+        final var notifyPPOfAttendanceBehaviourValue = false;
+        final var jsonPatch = buildPatch(of(attendedValue), of(notifyPPOfAttendanceBehaviourValue));
+
+        final var transformedPatch = appointmentPatchRequestTransformer.mapAttendanceFieldsToOutcomeOf(jsonPatch, integrationContext);
+
+        assertThat(objectMapper.writeValueAsString(transformedPatch))
+            .isEqualTo("[{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}," +
+                "{\"op\":\"replace\",\"path\":\"/outcome\",\"value\":\"ATTC\"}]");
+    }
+
+    @Test
+    public void transformsJsonPatchCollapsingAttendedAndNotifyFieldsToOutcomeWithEnforcement() throws JsonProcessingException {
+
+        final var attendedValue = "LATE";
         final var notifyPPOfAttendanceBehaviourValue = true;
         final var jsonPatch = buildPatch(of(attendedValue), of(notifyPPOfAttendanceBehaviourValue));
 
@@ -59,7 +74,8 @@ class AppointmentPatchRequestTransformerTest {
 
         assertThat(objectMapper.writeValueAsString(transformedPatch))
             .isEqualTo("[{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}," +
-                "{\"op\":\"replace\",\"path\":\"/outcome\",\"value\":\"AFTC\"}]");
+                "{\"op\":\"replace\",\"path\":\"/outcome\",\"value\":\"AFTC\"}," +
+                "{\"op\":\"replace\",\"path\":\"/enforcement\",\"value\":\"ROM\"}]");
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.IntegrationContext;
+import uk.gov.justice.digital.delius.utils.JsonPatchSupport;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -44,7 +45,7 @@ class AppointmentPatchRequestTransformerTest {
                 }});
             }}
         );
-        appointmentPatchRequestTransformer = new AppointmentPatchRequestTransformer(objectMapper);
+        appointmentPatchRequestTransformer = new AppointmentPatchRequestTransformer(new JsonPatchSupport(objectMapper));
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/digital/delius/utils/JsonPatchSupportTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/utils/JsonPatchSupportTest.java
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.delius.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.github.fge.jackson.jsonpointer.JsonPointer;
+import com.github.fge.jsonpatch.JsonPatch;
+import com.github.fge.jsonpatch.JsonPatchOperation;
+import com.github.fge.jsonpatch.ReplaceOperation;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JsonPatchSupportTest {
+
+    private static final List<JsonPatchOperation> REPLACE_OPERATIONS = asList(
+        new ReplaceOperation(JsonPointer.of("field1"), TextNode.valueOf("value1")),
+        new ReplaceOperation(JsonPointer.of("field2"), BooleanNode.valueOf(true)));
+
+    private static final JsonPatch JSON_PATCH = new JsonPatch(REPLACE_OPERATIONS);
+
+    private final JsonPatchSupport jsonPatchSupport = new JsonPatchSupport(new ObjectMapper());
+
+    @Test
+    public void getsStringValueUsingPath() {
+        assertThat(jsonPatchSupport.getAsText("/field1", JSON_PATCH)).isEqualTo(of("value1"));
+    }
+
+    @Test
+    public void getsStringValueUsingPathFromListOfNodes() {
+        final var nodes = jsonPatchSupport.convertValue(JSON_PATCH, JsonNode.class);
+        assertThat(jsonPatchSupport.getAsText("/field1", nodes)).isEqualTo(of("value1"));
+    }
+
+    @Test
+    public void getsBooleanValueUsingPathFromListOfNodes() {
+        final var nodes = jsonPatchSupport.convertValue(JSON_PATCH, JsonNode.class);
+        assertThat(jsonPatchSupport.getAsBoolean("/field2", nodes)).isEqualTo(of(true));
+    }
+
+    @Test
+    public void returnsOptionalEmptyWhenStringDoesNotExistUsingPath() {
+        assertThat(jsonPatchSupport.getAsText("/field3", JSON_PATCH)).isEqualTo(empty());
+    }
+
+    @Test
+    public void returnsOptionalEmptyWhenStringDoesNotExistUsingPathFromListOfNodes() {
+        final var nodes = jsonPatchSupport.convertValue(JSON_PATCH, JsonNode.class);
+        assertThat(jsonPatchSupport.getAsText("/field3", nodes)).isEqualTo(empty());
+    }
+
+    @Test
+    public void returnsOptionalEmptyWhenBooleanDoesNotExistUsingPathFromListOfNodes() {
+        final var nodes = jsonPatchSupport.convertValue(JSON_PATCH, JsonNode.class);
+        assertThat(jsonPatchSupport.getAsBoolean("/field3", nodes)).isEqualTo(empty());
+    }
+}

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingAPITest.java
@@ -135,6 +135,29 @@ public class AppointmentBookingAPITest extends IntegrationTestBase {
             .body("appointmentEnd", equalTo("2021-03-01T14:03:04Z"));
     }
 
+    @Test
+    public void shouldReturnOKAfterPatchingAContactUsingContextlessClientEndpoint() {
+
+        deliusApiMockServer.stubPatchContactToDeliusApi();
+
+        final var token = createJwt("bob", Collections.singletonList("ROLE_COMMUNITY_INTERVENTIONS_UPDATE"));
+
+        given()
+            .when()
+            .auth().oauth2(token)
+            .contentType(String.valueOf(ContentType.APPLICATION_JSON))
+            .body("[" +
+                "{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}," +
+                "{\"op\":\"replace\",\"path\":\"/attended\",\"value\":\"LATE\"}," +
+                "{\"op\":\"replace\",\"path\":\"/notifyPPOfAttendanceBehaviour\",\"value\":true}" +
+                "]")
+            .patch("offenders/crn/X320741/appointments/2500029015/context/commissioned-rehabilitation-services")
+            .then()
+            .assertThat()
+            .statusCode(HttpStatus.OK.value())
+            .body("appointmentId", equalTo(2500029015L));
+    }
+
     private String createJwt(final String user, final List<String> roles) {
         return jwtAuthenticationHelper.createJwt(JwtParameters.builder()
                 .username(user)

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingAPITest.java
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.delius.controller.wiremock.DeliusApiExtension;
 import uk.gov.justice.digital.delius.controller.wiremock.DeliusApiMockServer;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateRequest;
+import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentOutcomeRequest;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -136,7 +137,7 @@ public class AppointmentBookingAPITest extends IntegrationTestBase {
     }
 
     @Test
-    public void shouldReturnOKAfterPatchingAContactUsingContextlessClientEndpoint() {
+    public void shouldReturnOKAfterPatchingUpdatingAppointmentUsingContextlessClientEndpoint() {
 
         deliusApiMockServer.stubPatchContactToDeliusApi();
 
@@ -146,12 +147,12 @@ public class AppointmentBookingAPITest extends IntegrationTestBase {
             .when()
             .auth().oauth2(token)
             .contentType(String.valueOf(ContentType.APPLICATION_JSON))
-            .body("[" +
-                "{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}," +
-                "{\"op\":\"replace\",\"path\":\"/attended\",\"value\":\"LATE\"}," +
-                "{\"op\":\"replace\",\"path\":\"/notifyPPOfAttendanceBehaviour\",\"value\":true}" +
-                "]")
-            .patch("offenders/crn/X320741/appointments/2500029015/context/commissioned-rehabilitation-services")
+            .body(ContextlessAppointmentOutcomeRequest.builder()
+                .notes("some notes")
+                .attended("LATE")
+                .notifyPPOfAttendanceBehaviour(true)
+                .build())
+            .post("offenders/crn/X320741/appointments/2500029015/outcome/context/commissioned-rehabilitation-services")
             .then()
             .assertThat()
             .statusCode(HttpStatus.OK.value())

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/wiremock/DeliusApiMockServer.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/wiremock/DeliusApiMockServer.java
@@ -72,4 +72,27 @@ public class DeliusApiMockServer extends WireMockServer {
                 "}")
         ));
     }
+
+    public void stubPatchContactToDeliusApi() {
+        stubFor(patch(urlPathMatching("/v1/contact/2500029015")).willReturn(aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
+            .withBody("{\n" +
+                "    \"id\": 2500029015,\n" +
+                "    \"offenderCrn\": \"X320741\",\n" +
+                "    \"type\": \"CRSAPT\",\n" +
+                "    \"provider\": \"CRS\",\n" +
+                "    \"team\": \"CRSUAT\",\n" +
+                "    \"staff\": \"CRSUATU\",\n" +
+                "    \"officeLocation\": \"CRSSHEF\",\n" +
+                "    \"date\": \"2021-03-01\",\n" +
+                "    \"startTime\": \"13:01:02\",\n" +
+                "    \"endTime\": \"14:03:04\",\n" +
+                "    \"notes\": \"http://url\",\n" +
+                "    \"eventId\": 2500295343,\n" +
+                "    \"requirementId\": 2500428188\n" +
+                "    }\n" +
+                "}")
+        ));
+    }
 }

--- a/src/testIntegration/resources/application.properties
+++ b/src/testIntegration/resources/application.properties
@@ -33,3 +33,9 @@ delius-integration-context.integration-contexts[commissioned-rehabilitation-serv
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.service-category-to-nsi-type[96a63c39-4371-4f17-a6ec-265755f0cf7b]=CRS03
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.service-category-to-nsi-type[76bcdb97-1dea-41c1-a4f8-899d88e5d679]=CRS04
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.appointment-contact-type=CRSAPT
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.attendance-and-behaviour-notified-mapping-to-outcome-type[yes].[true]=AFTC
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.attendance-and-behaviour-notified-mapping-to-outcome-type[yes].[false]=ATTC
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.attendance-and-behaviour-notified-mapping-to-outcome-type[late].[true]=AFTC
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.attendance-and-behaviour-notified-mapping-to-outcome-type[late].[false]=ATTC
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.attendance-and-behaviour-notified-mapping-to-outcome-type[no].[true]=AFTA
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.attendance-and-behaviour-notified-mapping-to-outcome-type[no].[false]=AFTA

--- a/src/testIntegration/resources/application.properties
+++ b/src/testIntegration/resources/application.properties
@@ -33,6 +33,7 @@ delius-integration-context.integration-contexts[commissioned-rehabilitation-serv
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.service-category-to-nsi-type[96a63c39-4371-4f17-a6ec-265755f0cf7b]=CRS03
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.service-category-to-nsi-type[76bcdb97-1dea-41c1-a4f8-899d88e5d679]=CRS04
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.appointment-contact-type=CRSAPT
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.enforcement_refer-to-offender-manager=ROM
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.attendance-and-behaviour-notified-mapping-to-outcome-type[yes].[true]=AFTC
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.attendance-and-behaviour-notified-mapping-to-outcome-type[yes].[false]=ATTC
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.attendance-and-behaviour-notified-mapping-to-outcome-type[late].[true]=AFTC


### PR DESCRIPTION
**What does this pull request do?**
Introduced a new endpoint to carry out an appointment with an outcome type - for a specified context, e.g. commissioned rehabilitation services. Context specific PATCH hasn't been used after further technical and requirements discussions.

@RequestMapping(value = "/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}",
        method = RequestMethod.POST, consumes = "application/json")

To make the update compatible with Delius the following transformation is done:
1) attended (Yes/No/Late) and notifyPPOfAttendanceBehaviour (true/false) are mapped to a single replace operation on outcome (e.g. AFTC)

**What is the intent behind these changes?**
This enables consumers of community-api to update Delius with the outcome of an appointment.

**Is this a breaking change?**
No.