### PR TITLE
DAPI-173 Create NSI Using Either RAR Requirement ID or Event ID

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
@@ -18,7 +18,6 @@ import uk.gov.justice.digital.delius.data.api.deliusapi.NewContact;
 import uk.gov.justice.digital.delius.jpa.filters.AppointmentFilter;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactTypeRepository;
-import uk.gov.justice.digital.delius.transformers.AppointmentPatchRequestTransformer;
 import uk.gov.justice.digital.delius.transformers.AppointmentTransformer;
 import uk.gov.justice.digital.delius.utils.DateConverter;
 import uk.gov.justice.digital.delius.utils.JsonPatchSupport;
@@ -63,7 +62,7 @@ public class AppointmentService {
 
         final var context = getContext(contextName);
         final var requirement = requirementService.getRequirement(crn, sentenceId, context.getRequirementRehabilitationActivityType());
-        final var request = appointmentOf(contextualRequest, requirement.getRequirementId(), context);
+        final var request = appointmentOf(contextualRequest, requirement, context);
 
         return createAppointment(crn, sentenceId, request);
     }

--- a/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
@@ -109,7 +109,7 @@ public class RequirementService {
     // that has a main category of F - rehab activity requirement. It is invalid for multiple to exist.
     // NB. The called method getRequirementsByConvictionId accepts an event id (conviction or sentence)
     // and perhaps should have been named getRequirementsByEventId
-    public Requirement getRequirement(String crn, Long eventId, String requirementTypeCode) {
+    public Optional<Requirement> getRequirement(String crn, Long eventId, String requirementTypeCode) {
 
         var requirements = getRequirementsByConvictionId(crn, eventId)
             .getRequirements().stream()
@@ -123,8 +123,7 @@ public class RequirementService {
             throw new IllegalStateException(format("CRN: %s EventId: %d has multiple referral requirements", crn, eventId));
         }
 
-        return requirements.stream().findFirst().orElseThrow(() ->
-            new IllegalStateException(format("CRN: %s EventId: %d has no referral requirement", crn, eventId)));
+        return requirements.stream().findFirst();
     }
 
 

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformer.java
@@ -3,14 +3,17 @@ package uk.gov.justice.digital.delius.transformers;
 import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.IntegrationContext;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateRequest;
+import uk.gov.justice.digital.delius.data.api.Requirement;
+
+import java.util.Optional;
 
 public class AppointmentCreateRequestTransformer {
 
     public static AppointmentCreateRequest appointmentOf(ContextlessAppointmentCreateRequest request,
-                                                         Long requirementId,
+                                                         Optional<Requirement> requirement,
                                                          IntegrationContext context) {
         return AppointmentCreateRequest.builder()
-                .requirementId(requirementId)
+                .requirementId(requirement.map(Requirement::getRequirementId).orElse(null))
                 .contactType(context.getContactMapping().getAppointmentContactType())
                 .appointmentStart(request.getAppointmentStart())
                 .appointmentEnd(request.getAppointmentEnd())

--- a/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
@@ -231,7 +231,7 @@ public class RequirementServiceTest {
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build())
                 .build()));
             var requirement = requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE);
-            assertThat(requirement.getRequirementId()).isEqualTo(99L);
+            assertThat(requirement.get().getRequirementId()).isEqualTo(99L);
         }
 
         @Test
@@ -242,13 +242,11 @@ public class RequirementServiceTest {
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("X").build())
                 .build()));
 
-            assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(() -> requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE))
-                .withMessage("CRN: CRN EventId: 987654321 has no referral requirement");
+            assertThat(requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE)).isEmpty();
         }
 
         @Test
-        public void whenGetReferralRequirementByConvictionId_AndNoRequirementsExist_thenThrowException() {
+        public void whenGetReferralRequirementByConvictionId_AndMultipleRequirementsExist_thenThrowException() {
             when(disposal.getRequirements()).thenReturn(Arrays.asList(
                 Requirement.builder().requirementId(99L)
                     .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build()).build(),
@@ -262,12 +260,10 @@ public class RequirementServiceTest {
         }
 
         @Test
-        public void whenGetReferralRequirementByConvictionId_AndMultipleRequirementsExist_thenThrowException() {
+        public void whenGetReferralRequirementByConvictionId_AndNoRequirementsExist_thenReturnEmptyOptional() {
             when(disposal.getRequirements()).thenReturn(Collections.emptyList());
 
-            assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(() -> requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE))
-                .withMessage("CRN: CRN EventId: 987654321 has no referral requirement");
+            assertThat(requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE)).isEmpty();
         }
 
         @Test

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformerTest.java
@@ -4,10 +4,13 @@ import org.junit.jupiter.api.Test;
 import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.IntegrationContext;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateRequest;
+import uk.gov.justice.digital.delius.data.api.Requirement;
 
 import java.time.OffsetDateTime;
 
 import static java.time.OffsetDateTime.now;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AppointmentCreateRequestTransformerTest {
@@ -24,7 +27,7 @@ class AppointmentCreateRequestTransformerTest {
                 .officeLocationCode("CRSHEFF")
                 .notes("some notes")
                 .build(),
-            123456L,
+            of(Requirement.builder().requirementId(123456L).build()),
             anIntegrationContext())).isEqualTo(
                     AppointmentCreateRequest.builder()
                         .requirementId(123456L)
@@ -37,6 +40,34 @@ class AppointmentCreateRequestTransformerTest {
                         .staffCode("CRSUATU")
                         .teamCode("CRSUAT")
                         .build()
+        );
+    }
+
+    @Test
+    public void appointmentCreateRequestFromContextlessClientRequest_withNoRequirement() {
+        OffsetDateTime start = now();
+        OffsetDateTime end = start.plusHours(1);
+
+        assertThat(AppointmentCreateRequestTransformer.appointmentOf(
+            ContextlessAppointmentCreateRequest.builder()
+                .appointmentStart(start)
+                .appointmentEnd(end)
+                .officeLocationCode("CRSHEFF")
+                .notes("some notes")
+                .build(),
+            empty(),
+            anIntegrationContext())).isEqualTo(
+            AppointmentCreateRequest.builder()
+                .requirementId(null)
+                .contactType("CRSAPT")
+                .appointmentStart(start)
+                .appointmentEnd(end)
+                .officeLocationCode("CRSHEFF")
+                .notes("some notes")
+                .providerCode("CRS")
+                .staffCode("CRSUATU")
+                .teamCode("CRSUAT")
+                .build()
         );
     }
 


### PR DESCRIPTION
**What does this pull request do?**
When a referral is initiated, prior to this change, the referral was associated to a RAR requirement for the supplied sentence after looking it up. If one didn't exist, an exception was thrown. After this change, should a requirement not exist the referral is associated to the supplied sentence (event) only and the exception not thrown.

**What is the intent behind these changes?**
This change allows Referral NSI's to created for sentences with no RAR requirement.

**Breaking Changes?**
None