### PR TITLE
DAPI-175 Create appointment with correct contact type

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/config/DeliusIntegrationContextConfig.java
+++ b/src/main/java/uk/gov/justice/digital/delius/config/DeliusIntegrationContextConfig.java
@@ -36,7 +36,8 @@ public class DeliusIntegrationContextConfig {
 
     @Data
     public static class ContactMapping {
-        private String appointmentContactType;
+        private String appointmentRarContactType;
+        private String appointmentNonRarContactType;
         private String enforcementReferToOffenderManager;
         private Map<String, Map<Boolean, String>> attendanceAndBehaviourNotifiedMappingToOutcomeType;
     }

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessAppointmentCreateRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessAppointmentCreateRequest.java
@@ -23,6 +23,9 @@ public class ContextlessAppointmentCreateRequest {
     @ApiModelProperty(required = true)
     private OffsetDateTime appointmentEnd;
 
+    @ApiModelProperty
+    private Boolean nonRar;
+
     @NotNull
     @ApiModelProperty(required = true)
     private String officeLocationCode;

--- a/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
@@ -18,7 +18,6 @@ import uk.gov.justice.digital.delius.data.api.deliusapi.NewContact;
 import uk.gov.justice.digital.delius.jpa.filters.AppointmentFilter;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactTypeRepository;
-import uk.gov.justice.digital.delius.transformers.AppointmentPatchRequestTransformer;
 import uk.gov.justice.digital.delius.transformers.AppointmentTransformer;
 import uk.gov.justice.digital.delius.utils.DateConverter;
 import uk.gov.justice.digital.delius.utils.JsonPatchSupport;
@@ -63,7 +62,7 @@ public class AppointmentService {
 
         final var context = getContext(contextName);
         final var requirement = requirementService.getRequirement(crn, sentenceId, context.getRequirementRehabilitationActivityType());
-        final var request = appointmentOf(contextualRequest, requirement.getRequirementId(), context);
+        final var request = appointmentOf(contextualRequest, requirement, context);
 
         return createAppointment(crn, sentenceId, request);
     }

--- a/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
@@ -109,7 +109,7 @@ public class RequirementService {
     // that has a main category of F - rehab activity requirement. It is invalid for multiple to exist.
     // NB. The called method getRequirementsByConvictionId accepts an event id (conviction or sentence)
     // and perhaps should have been named getRequirementsByEventId
-    public Requirement getRequirement(String crn, Long eventId, String requirementTypeCode) {
+    public Optional<Requirement> getRequirement(String crn, Long eventId, String requirementTypeCode) {
 
         var requirements = getRequirementsByConvictionId(crn, eventId)
             .getRequirements().stream()
@@ -123,8 +123,7 @@ public class RequirementService {
             throw new IllegalStateException(format("CRN: %s EventId: %d has multiple referral requirements", crn, eventId));
         }
 
-        return requirements.stream().findFirst().orElseThrow(() ->
-            new IllegalStateException(format("CRN: %s EventId: %d has no referral requirement", crn, eventId)));
+        return requirements.stream().findFirst();
     }
 
 

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformer.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.delius.transformers;
 
+import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.ContactMapping;
 import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.IntegrationContext;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateRequest;
@@ -7,14 +8,20 @@ import uk.gov.justice.digital.delius.data.api.Requirement;
 
 import java.util.Optional;
 
+import static java.util.Optional.ofNullable;
+
 public class AppointmentCreateRequestTransformer {
 
     public static AppointmentCreateRequest appointmentOf(ContextlessAppointmentCreateRequest request,
                                                          Optional<Requirement> requirement,
                                                          IntegrationContext context) {
+        ContactMapping contactMapping = context.getContactMapping();
+
         return AppointmentCreateRequest.builder()
                 .requirementId(requirement.map(Requirement::getRequirementId).orElse(null))
-                .contactType(context.getContactMapping().getAppointmentContactType())
+                .contactType(ofNullable(request.getNonRar()).orElse(false) ?
+                    contactMapping.getAppointmentNonRarContactType() :
+                    contactMapping.getAppointmentRarContactType())
                 .appointmentStart(request.getAppointmentStart())
                 .appointmentEnd(request.getAppointmentEnd())
                 .officeLocationCode(request.getOfficeLocationCode())

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformer.java
@@ -3,14 +3,17 @@ package uk.gov.justice.digital.delius.transformers;
 import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.IntegrationContext;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateRequest;
+import uk.gov.justice.digital.delius.data.api.Requirement;
+
+import java.util.Optional;
 
 public class AppointmentCreateRequestTransformer {
 
     public static AppointmentCreateRequest appointmentOf(ContextlessAppointmentCreateRequest request,
-                                                         Long requirementId,
+                                                         Optional<Requirement> requirement,
                                                          IntegrationContext context) {
         return AppointmentCreateRequest.builder()
-                .requirementId(requirementId)
+                .requirementId(requirement.map(Requirement::getRequirementId).orElse(null))
                 .contactType(context.getContactMapping().getAppointmentContactType())
                 .appointmentStart(request.getAppointmentStart())
                 .appointmentEnd(request.getAppointmentEnd())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -115,7 +115,8 @@ delius-integration-context:
           96a63c39-4371-4f17-a6ec-265755f0cf7b: CRS03
           76bcdb97-1dea-41c1-a4f8-899d88e5d679: CRS04
       contact-mapping:
-        appointment-contact-type: CRSAPT
+        appointment-rar-contact-type: CRSAPT
+        appointment-non-rar-contact-type: CRSSAA
         enforcement-refer-to-offender-manager: ROM
         attendance-and-behaviour-notified-mapping-to-outcome-type:
           yes:

--- a/src/test/java/uk/gov/justice/digital/delius/service/AppointmentServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/AppointmentServiceTest.java
@@ -97,7 +97,7 @@ public class AppointmentServiceTest {
         integrationContext.setStaffCode(STAFF_CODE);
         integrationContext.setTeamCode(TEAM_CODE);
         integrationContext.setRequirementRehabilitationActivityType(RAR_TYPE_CODE);
-        integrationContext.getContactMapping().setAppointmentContactType(CRSAPT_CONTACT_TYPE);
+        integrationContext.getContactMapping().setAppointmentRarContactType(CRSAPT_CONTACT_TYPE);
         integrationContext.getContactMapping().setAttendanceAndBehaviourNotifiedMappingToOutcomeType(
             new HashMap<>() {{
                 this.put("late", new HashMap<>() {{

--- a/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
@@ -231,7 +231,7 @@ public class RequirementServiceTest {
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build())
                 .build()));
             var requirement = requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE);
-            assertThat(requirement.getRequirementId()).isEqualTo(99L);
+            assertThat(requirement.get().getRequirementId()).isEqualTo(99L);
         }
 
         @Test
@@ -242,13 +242,11 @@ public class RequirementServiceTest {
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("X").build())
                 .build()));
 
-            assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(() -> requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE))
-                .withMessage("CRN: CRN EventId: 987654321 has no referral requirement");
+            assertThat(requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE)).isEmpty();
         }
 
         @Test
-        public void whenGetReferralRequirementByConvictionId_AndNoRequirementsExist_thenThrowException() {
+        public void whenGetReferralRequirementByConvictionId_AndMultipleRequirementsExist_thenThrowException() {
             when(disposal.getRequirements()).thenReturn(Arrays.asList(
                 Requirement.builder().requirementId(99L)
                     .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build()).build(),
@@ -262,12 +260,10 @@ public class RequirementServiceTest {
         }
 
         @Test
-        public void whenGetReferralRequirementByConvictionId_AndMultipleRequirementsExist_thenThrowException() {
+        public void whenGetReferralRequirementByConvictionId_AndNoRequirementsExist_thenReturnEmptyOptional() {
             when(disposal.getRequirements()).thenReturn(Collections.emptyList());
 
-            assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(() -> requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE))
-                .withMessage("CRN: CRN EventId: 987654321 has no referral requirement");
+            assertThat(requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE)).isEmpty();
         }
 
         @Test

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformerTest.java
@@ -4,10 +4,13 @@ import org.junit.jupiter.api.Test;
 import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.IntegrationContext;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateRequest;
+import uk.gov.justice.digital.delius.data.api.Requirement;
 
 import java.time.OffsetDateTime;
 
 import static java.time.OffsetDateTime.now;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AppointmentCreateRequestTransformerTest {
@@ -24,7 +27,7 @@ class AppointmentCreateRequestTransformerTest {
                 .officeLocationCode("CRSHEFF")
                 .notes("some notes")
                 .build(),
-            123456L,
+            of(Requirement.builder().requirementId(123456L).build()),
             anIntegrationContext())).isEqualTo(
                     AppointmentCreateRequest.builder()
                         .requirementId(123456L)
@@ -37,6 +40,34 @@ class AppointmentCreateRequestTransformerTest {
                         .staffCode("CRSUATU")
                         .teamCode("CRSUAT")
                         .build()
+        );
+    }
+
+    @Test
+    public void appointmentCreateRequestFromContextlessClientRequest_withNoRequirement() {
+        OffsetDateTime start = now();
+        OffsetDateTime end = start.plusHours(1);
+
+        assertThat(AppointmentCreateRequestTransformer.appointmentOf(
+            ContextlessAppointmentCreateRequest.builder()
+                .appointmentStart(start)
+                .appointmentEnd(end)
+                .officeLocationCode("CRSHEFF")
+                .notes("some notes")
+                .build(),
+            empty(),
+            anIntegrationContext())).isEqualTo(
+            AppointmentCreateRequest.builder()
+                .requirementId(null)
+                .contactType("CRSAPT")
+                .appointmentStart(start)
+                .appointmentEnd(end)
+                .officeLocationCode("CRSHEFF")
+                .notes("some notes")
+                .providerCode("CRS")
+                .staffCode("CRSUATU")
+                .teamCode("CRSUAT")
+                .build()
         );
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformerTest.java
@@ -15,31 +15,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class AppointmentCreateRequestTransformerTest {
 
+    private static final Long REQUIREMENT_ID = 1234567L;
+    private static final String RAR_CONTACT_TYPE = "CRSAPT";
+    private static final String NON_RAR_CONTACT_TYPE = "CRSSAA";
+
     @Test
     public void appointmentCreateRequestFromContextlessClientRequest() {
         OffsetDateTime start = now();
         OffsetDateTime end = start.plusHours(1);
 
-        assertThat(AppointmentCreateRequestTransformer.appointmentOf(
-            ContextlessAppointmentCreateRequest.builder()
-                .appointmentStart(start)
-                .appointmentEnd(end)
-                .officeLocationCode("CRSHEFF")
-                .notes("some notes")
-                .build(),
-            of(Requirement.builder().requirementId(123456L).build()),
-            anIntegrationContext())).isEqualTo(
-                    AppointmentCreateRequest.builder()
-                        .requirementId(123456L)
-                        .contactType("CRSAPT")
-                        .appointmentStart(start)
-                        .appointmentEnd(end)
-                        .officeLocationCode("CRSHEFF")
-                        .notes("some notes")
-                        .providerCode("CRS")
-                        .staffCode("CRSUATU")
-                        .teamCode("CRSUAT")
-                        .build()
+        assertThat(
+            AppointmentCreateRequestTransformer.appointmentOf(
+                buildContextlessRequest(start, end, null),
+                of(Requirement.builder().requirementId(REQUIREMENT_ID).build()),
+                anIntegrationContext()
+            )
+        ).isEqualTo(
+            buildExpectedTransformedRequest(start, end, REQUIREMENT_ID, RAR_CONTACT_TYPE)
         );
     }
 
@@ -48,27 +40,69 @@ class AppointmentCreateRequestTransformerTest {
         OffsetDateTime start = now();
         OffsetDateTime end = start.plusHours(1);
 
-        assertThat(AppointmentCreateRequestTransformer.appointmentOf(
-            ContextlessAppointmentCreateRequest.builder()
-                .appointmentStart(start)
-                .appointmentEnd(end)
-                .officeLocationCode("CRSHEFF")
-                .notes("some notes")
-                .build(),
-            empty(),
-            anIntegrationContext())).isEqualTo(
-            AppointmentCreateRequest.builder()
-                .requirementId(null)
-                .contactType("CRSAPT")
-                .appointmentStart(start)
-                .appointmentEnd(end)
-                .officeLocationCode("CRSHEFF")
-                .notes("some notes")
-                .providerCode("CRS")
-                .staffCode("CRSUATU")
-                .teamCode("CRSUAT")
-                .build()
+        assertThat(
+            AppointmentCreateRequestTransformer.appointmentOf(
+                buildContextlessRequest(start, end, null),
+                empty(),
+                anIntegrationContext()
+            )
+        ).isEqualTo(
+            buildExpectedTransformedRequest(start, end, null, RAR_CONTACT_TYPE)
         );
+    }
+
+    @Test
+    public void appointmentCreateRequestFromContextlessClientRequest_withNonRarFalse() {
+        OffsetDateTime start = now();
+        OffsetDateTime end = start.plusHours(1);
+
+        assertThat(
+            AppointmentCreateRequestTransformer.appointmentOf(
+                buildContextlessRequest(start, end, false),
+                of(Requirement.builder().requirementId(REQUIREMENT_ID).build()),
+                anIntegrationContext())
+        ).isEqualTo(
+            buildExpectedTransformedRequest(start, end, REQUIREMENT_ID, RAR_CONTACT_TYPE)
+        );
+    }
+
+    @Test
+    public void appointmentCreateRequestFromContextlessClientRequest_withNonRarTrue() {
+        OffsetDateTime start = now();
+        OffsetDateTime end = start.plusHours(1);
+
+        assertThat(
+            AppointmentCreateRequestTransformer.appointmentOf(
+                buildContextlessRequest(start, end, true),
+                of(Requirement.builder().requirementId(REQUIREMENT_ID).build()),
+                anIntegrationContext())
+        ).isEqualTo(
+            buildExpectedTransformedRequest(start, end, REQUIREMENT_ID, NON_RAR_CONTACT_TYPE)
+        );
+    }
+
+    private ContextlessAppointmentCreateRequest buildContextlessRequest(OffsetDateTime start, OffsetDateTime end, Boolean nonRar) {
+        return ContextlessAppointmentCreateRequest.builder()
+            .appointmentStart(start)
+            .appointmentEnd(end)
+            .nonRar(nonRar)
+            .officeLocationCode("CRSHEFF")
+            .notes("some notes")
+            .build();
+    }
+
+    private AppointmentCreateRequest buildExpectedTransformedRequest(OffsetDateTime start, OffsetDateTime end, Long requirementId, String contactType) {
+        return AppointmentCreateRequest.builder()
+            .requirementId(requirementId)
+            .contactType(contactType)
+            .appointmentStart(start)
+            .appointmentEnd(end)
+            .officeLocationCode("CRSHEFF")
+            .notes("some notes")
+            .providerCode("CRS")
+            .staffCode("CRSUATU")
+            .teamCode("CRSUAT")
+            .build();
     }
 
     private IntegrationContext anIntegrationContext() {
@@ -76,7 +110,8 @@ class AppointmentCreateRequestTransformerTest {
         integrationContext.setProviderCode("CRS");
         integrationContext.setStaffCode("CRSUATU");
         integrationContext.setTeamCode("CRSUAT");
-        integrationContext.getContactMapping().setAppointmentContactType("CRSAPT");
+        integrationContext.getContactMapping().setAppointmentRarContactType(RAR_CONTACT_TYPE);
+        integrationContext.getContactMapping().setAppointmentNonRarContactType(NON_RAR_CONTACT_TYPE);
         return integrationContext;
     }
 }

--- a/src/testIntegration/resources/application.properties
+++ b/src/testIntegration/resources/application.properties
@@ -32,7 +32,8 @@ delius-integration-context.integration-contexts[commissioned-rehabilitation-serv
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.service-category-to-nsi-type[ca374ac3-84eb-4b91-bea7-9005398f426f]=CRS02
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.service-category-to-nsi-type[96a63c39-4371-4f17-a6ec-265755f0cf7b]=CRS03
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.service-category-to-nsi-type[76bcdb97-1dea-41c1-a4f8-899d88e5d679]=CRS04
-delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.appointment-contact-type=CRSAPT
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.appointment-rar-contact-type=CRSAPT
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.appointment-non-rar-contact-type=CRSSAA
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.enforcement_refer-to-offender-manager=ROM
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.attendance-and-behaviour-notified-mapping-to-outcome-type[yes].[true]=AFTC
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.attendance-and-behaviour-notified-mapping-to-outcome-type[yes].[false]=ATTC


### PR DESCRIPTION
What does this pull request do?
When an appointment is created the correct attended contact type should be applied for a contextless request.

For appointments that count towards RAR days, this is CRSAPT, otherwise it's CRSSAA.

What is the intent behind these changes?
This change allows appointments created in Delius to be accounted for correctly.

Breaking Changes?
None