### PR TITLE
DAPI-172 DAPI-173 Changes to Referral Start endpoint for interventions

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/config/DeliusIntegrationContextConfig.java
+++ b/src/main/java/uk/gov/justice/digital/delius/config/DeliusIntegrationContextConfig.java
@@ -31,7 +31,7 @@ public class DeliusIntegrationContextConfig {
     @Data
     public static class NsiMapping {
         private String nsiStatus;
-        private Map<UUID, String> serviceCategoryToNsiType;
+        private Map<String, String> contractTypeToNsiType;
     }
 
     @Data

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingController.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingController.java
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.delius.controller.secure;
 
-import com.github.fge.jsonpatch.JsonPatch;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.AllArgsConstructor;
@@ -68,7 +68,8 @@ public class AppointmentBookingController {
     @ApiOperation(value = "Creates an Contact appointment for a specified context")
     public ResponseEntity<AppointmentCreateResponse> createAppointmentWithContextName(final @PathVariable("crn") String crn,
                                                                                       final @PathVariable("sentenceId") Long sentenceId,
-                                                                                      final @PathVariable("contextName") String contextName,
+                                                                                      final @ApiParam(value = "Name identifying preprocessing applied to a referral start request", example = "commissioned-rehabilitation-services")
+                                                                                          @PathVariable("contextName") String contextName,
                                                                                       final @RequestBody ContextlessAppointmentCreateRequest contextlessAppointmentCreateRequest) {
 
         AppointmentCreateResponse response = appointmentService.createAppointment(crn, sentenceId, contextName, contextlessAppointmentCreateRequest);

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingController.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingController.java
@@ -68,7 +68,7 @@ public class AppointmentBookingController {
     @ApiOperation(value = "Creates an Contact appointment for a specified context")
     public ResponseEntity<AppointmentCreateResponse> createAppointmentWithContextName(final @PathVariable("crn") String crn,
                                                                                       final @PathVariable("sentenceId") Long sentenceId,
-                                                                                      final @ApiParam(value = "Name identifying preprocessing applied to a referral start request", example = "commissioned-rehabilitation-services")
+                                                                                      final @ApiParam(value = "Name identifying preprocessing applied to the request", example = "commissioned-rehabilitation-services")
                                                                                           @PathVariable("contextName") String contextName,
                                                                                       final @RequestBody ContextlessAppointmentCreateRequest contextlessAppointmentCreateRequest) {
 
@@ -90,7 +90,8 @@ public class AppointmentBookingController {
     @ApiOperation(value = "Updates an Contact appointment outcome")
     public AppointmentUpdateResponse updateAppointmentOutcomeWithContext(final @PathVariable("crn") String crn,
                                                                          final @PathVariable("appointmentId") Long appointmentId,
-                                                                         final @PathVariable("contextName") String context,
+                                                                         final @ApiParam(value = "Name identifying preprocessing applied to the request", example = "commissioned-rehabilitation-services")
+                                                                             @PathVariable("contextName") String context,
                                                                          final @RequestBody ContextlessAppointmentOutcomeRequest appointmentOutcomeRequest) {
 
         return appointmentService.updateAppointmentOutcome(crn, appointmentId, context, appointmentOutcomeRequest);

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/ReferralController.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/ReferralController.java
@@ -13,8 +13,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.justice.digital.delius.controller.advice.ErrorResponse;
-import uk.gov.justice.digital.delius.data.api.ReferralSentRequest;
-import uk.gov.justice.digital.delius.data.api.ReferralSentResponse;
+import uk.gov.justice.digital.delius.data.api.ContextlessReferralStartRequest;
+import uk.gov.justice.digital.delius.data.api.ReferralStartResponse;
 import uk.gov.justice.digital.delius.service.ReferralService;
 
 import javax.validation.Valid;
@@ -28,20 +28,21 @@ public class ReferralController {
 
     private final ReferralService referralService;
 
-    @RequestMapping(value = "/offenders/crn/{crn}/referral/sent",
-                    method = RequestMethod.POST,
-                    consumes = "application/json")
+    @RequestMapping(value = "/offenders/crn/{crn}/referral/start/context/{context}",
+        method = RequestMethod.POST,
+        consumes = "application/json")
     @ApiResponses(
-            value = {
-                @ApiResponse(code = 201, message = "Created", response = String.class),
-                @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
-                @ApiResponse(code = 403, message = "Requires role ROLE_COMMUNITY_INTERVENTIONS_UPDATE"),
-                @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
-            })
+        value = {
+            @ApiResponse(code = 201, message = "Created", response = String.class),
+            @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
+            @ApiResponse(code = 403, message = "Requires role ROLE_COMMUNITY_INTERVENTIONS_UPDATE"),
+            @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
+        })
 
-    @ApiOperation(value = "Creates an NSI referral")
-    public ReferralSentResponse createReferralSent(final @PathVariable("crn") String crn,
-                                                                   final @RequestBody @Valid ReferralSentRequest referralSentRequest) {
-        return referralService.createNsiReferral(crn, referralSentRequest);
+    @ApiOperation(value = "Starts an NSI referral")
+    public ReferralStartResponse startReferralContextLess(final @PathVariable("crn") String crn,
+                                                          final @PathVariable("context") String context,
+                                                          final @RequestBody @Valid ContextlessReferralStartRequest referralStartRequest) {
+        return referralService.startNsiReferral(crn, context, referralStartRequest);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/ReferralController.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/ReferralController.java
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.delius.controller.secure;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.AllArgsConstructor;
@@ -41,7 +42,8 @@ public class ReferralController {
 
     @ApiOperation(value = "Starts an NSI referral")
     public ReferralStartResponse startReferralContextLess(final @PathVariable("crn") String crn,
-                                                          final @PathVariable("context") String context,
+                                                          final @ApiParam(value = "Name identifying preprocessing applied to the request", example = "commissioned-rehabilitation-services")
+                                                                @PathVariable("context") String context,
                                                           final @RequestBody @Valid ContextlessReferralStartRequest referralStartRequest) {
         return referralService.startNsiReferral(crn, context, referralStartRequest);
     }

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessReferralStartRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessReferralStartRequest.java
@@ -17,15 +17,15 @@ import java.util.UUID;
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
-public class ReferralSentRequest {
+public class ContextlessReferralStartRequest {
 
     @NotNull
     @ApiModelProperty(required = true)
-    private OffsetDateTime sentAt;
+    private OffsetDateTime startedAt;
 
     @NotNull
     @ApiModelProperty(required = true)
-    private UUID serviceCategoryId;
+    private String contractType;
 
     @Positive
     @NotNull
@@ -34,7 +34,4 @@ public class ReferralSentRequest {
 
     @NotNull
     private String notes;
-
-    @NotNull
-    private String context;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessReferralStartRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessReferralStartRequest.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.delius.data.api;
 
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.annotations.ApiParam;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -24,7 +25,7 @@ public class ContextlessReferralStartRequest {
     private OffsetDateTime startedAt;
 
     @NotNull
-    @ApiModelProperty(required = true)
+    @ApiModelProperty(required = true, value = "Denotes a group of services delivered through a referral to a service user, e.g. Personal Well Being", example = "PWB")
     private String contractType;
 
     @Positive

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ReferralStartResponse.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ReferralStartResponse.java
@@ -9,6 +9,6 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ReferralSentResponse {
+public class ReferralStartResponse {
     private Long nsiId;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
@@ -68,7 +68,7 @@ public class AppointmentService {
 
         final var context = getContext(contextName);
         final var requirement = requirementService.getRequirement(crn, sentenceId, context.getRequirementRehabilitationActivityType());
-        final var request = appointmentOf(contextualRequest, requirement.getRequirementId(), context);
+        final var request = appointmentOf(contextualRequest, requirement, context);
 
         return createAppointment(crn, sentenceId, request);
     }

--- a/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
@@ -7,15 +7,14 @@ import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.Integ
 import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.NsiMapping;
 import uk.gov.justice.digital.delius.controller.BadRequestException;
 import uk.gov.justice.digital.delius.controller.ConflictingRequestException;
+import uk.gov.justice.digital.delius.data.api.ContextlessReferralStartRequest;
 import uk.gov.justice.digital.delius.data.api.Nsi;
-import uk.gov.justice.digital.delius.data.api.ReferralSentRequest;
-import uk.gov.justice.digital.delius.data.api.ReferralSentResponse;
+import uk.gov.justice.digital.delius.data.api.ReferralStartResponse;
 import uk.gov.justice.digital.delius.data.api.deliusapi.NewNsi;
 import uk.gov.justice.digital.delius.data.api.deliusapi.NewNsiManager;
 
 import java.util.Collections;
 import java.util.Optional;
-import java.util.UUID;
 
 import static java.util.stream.Collectors.toList;
 import static uk.gov.justice.digital.delius.utils.DateConverter.toLondonLocalDate;
@@ -48,25 +47,26 @@ public class ReferralService {
     }
 
     @Transactional
-    public ReferralSentResponse createNsiReferral(final String crn,
-                                                  final ReferralSentRequest referralSent) {
+    public ReferralStartResponse startNsiReferral(final String crn,
+                                                  final String contextName,
+                                                  final ContextlessReferralStartRequest referralStart) {
 
-        var context = getContext(referralSent.getContext());
+        var context = getContext(contextName);
         var nsiMapping = context.getNsiMapping();
 
-        Long requirementId = getRequirement(crn, referralSent.getSentenceId(), context);
-        var existingNsi = getExistingMatchingNsi(crn, referralSent, requirementId);
+        Long requirementId = getRequirement(crn, referralStart.getSentenceId(), context);
+        var existingNsi = getExistingMatchingNsi(crn, contextName, referralStart, requirementId);
 
-        return ReferralSentResponse.builder().nsiId(existingNsi.map(Nsi::getNsiId).orElseGet(() -> {
+        return ReferralStartResponse.builder().nsiId(existingNsi.map(Nsi::getNsiId).orElseGet(() -> {
             var newNsiRequest = NewNsi.builder()
-                .type(getNsiType(nsiMapping, referralSent.getServiceCategoryId()))
+                .type(getNsiType(nsiMapping, referralStart.getContractType()))
                 .offenderCrn(crn)
-                .eventId(referralSent.getSentenceId())
+                .eventId(referralStart.getSentenceId())
                 .requirementId(requirementId)
-                .referralDate(toLondonLocalDate(referralSent.getSentAt()))
+                .referralDate(toLondonLocalDate(referralStart.getStartedAt()))
                 .status(nsiMapping.getNsiStatus())
-                .statusDate(toLondonLocalDateTime(referralSent.getSentAt()))
-                .notes(referralSent.getNotes())
+                .statusDate(toLondonLocalDateTime(referralStart.getStartedAt()))
+                .notes(referralStart.getNotes())
                 .intendedProvider(context.getProviderCode())
                 .manager(NewNsiManager.builder()
                     .staff(context.getStaffCode())
@@ -78,17 +78,17 @@ public class ReferralService {
         })).build();
     }
 
-    public Optional<Nsi> getExistingMatchingNsi(String crn, ReferralSentRequest referralSent, Long requirementId) {
+    public Optional<Nsi> getExistingMatchingNsi(String crn, String contextName, ContextlessReferralStartRequest referralStart, Long requirementId) {
         // determine if there is an existing suitable NSI
         var offenderId = offenderService.offenderIdOfCrn(crn).orElseThrow(() -> new BadRequestException("Offender CRN not found"));
 
-        var context = getContext(referralSent.getContext());
+        var context = getContext(contextName);
         var nsiMapping = context.getNsiMapping();
 
-        var existingNsis = nsiService.getNsiByCodes(offenderId, referralSent.getSentenceId(), Collections.singletonList(getNsiType(nsiMapping, referralSent.getServiceCategoryId())))
+        var existingNsis = nsiService.getNsiByCodes(offenderId, referralStart.getSentenceId(), Collections.singletonList(getNsiType(nsiMapping, referralStart.getContractType())))
             .map(wrapper -> wrapper.getNsis().stream()
                 // eventID, offenderID, nsiID, and callerID are handled in the NSI service
-                .filter(nsi -> Optional.ofNullable(nsi.getReferralDate()).map(n -> n.equals(toLondonLocalDate(referralSent.getSentAt()))).orElse(false))
+                .filter(nsi -> Optional.ofNullable(nsi.getReferralDate()).map(n -> n.equals(toLondonLocalDate(referralStart.getStartedAt()))).orElse(false))
                 .filter(nsi -> Optional.ofNullable(nsi.getNsiStatus()).map(n -> n.getCode().equals(nsiMapping.getNsiStatus())).orElse(false))
                 .filter(nsi -> Optional.ofNullable(nsi.getRequirement()).map(n -> nsi.getRequirement().getRequirementId().equals(requirementId)).orElse(false))
                 .filter(nsi -> Optional.ofNullable(nsi.getIntendedProvider()).map(n -> n.getCode().equals(context.getProviderCode())).orElse(false))
@@ -111,9 +111,9 @@ public class ReferralService {
         return requirementService.getRequirement(crn, sentenceId, context.getRequirementRehabilitationActivityType()).getRequirementId();
     }
 
-    String getNsiType(final NsiMapping nsiMapping, final UUID serviceCategoryId) {
-        return Optional.ofNullable(nsiMapping.getServiceCategoryToNsiType().get(serviceCategoryId)).orElseThrow(
-            () -> new IllegalArgumentException("Nsi Type mapping from referralType does not exist for: " + serviceCategoryId)
+    String getNsiType(final NsiMapping nsiMapping, final String contactType) {
+        return Optional.ofNullable(nsiMapping.getContractTypeToNsiType().get(contactType)).orElseThrow(
+            () -> new IllegalArgumentException("Nsi Type mapping from contractType does not exist for: " + contactType)
         );
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.delius.controller.ConflictingRequestException;
 import uk.gov.justice.digital.delius.data.api.ContextlessReferralStartRequest;
 import uk.gov.justice.digital.delius.data.api.Nsi;
 import uk.gov.justice.digital.delius.data.api.ReferralStartResponse;
+import uk.gov.justice.digital.delius.data.api.Requirement;
 import uk.gov.justice.digital.delius.data.api.deliusapi.NewNsi;
 import uk.gov.justice.digital.delius.data.api.deliusapi.NewNsiManager;
 
@@ -54,15 +55,15 @@ public class ReferralService {
         var context = getContext(contextName);
         var nsiMapping = context.getNsiMapping();
 
-        Long requirementId = getRequirement(crn, referralStart.getSentenceId(), context);
-        var existingNsi = getExistingMatchingNsi(crn, contextName, referralStart, requirementId);
+        Optional<Long> requirementId = getRequirement(crn, referralStart.getSentenceId(), context);
+        var existingNsi = getExistingMatchingNsi(crn, contextName, referralStart);
 
         return ReferralStartResponse.builder().nsiId(existingNsi.map(Nsi::getNsiId).orElseGet(() -> {
             var newNsiRequest = NewNsi.builder()
                 .type(getNsiType(nsiMapping, referralStart.getContractType()))
                 .offenderCrn(crn)
                 .eventId(referralStart.getSentenceId())
-                .requirementId(requirementId)
+                .requirementId(requirementId.orElse(null))
                 .referralDate(toLondonLocalDate(referralStart.getStartedAt()))
                 .status(nsiMapping.getNsiStatus())
                 .statusDate(toLondonLocalDateTime(referralStart.getStartedAt()))
@@ -78,7 +79,7 @@ public class ReferralService {
         })).build();
     }
 
-    public Optional<Nsi> getExistingMatchingNsi(String crn, String contextName, ContextlessReferralStartRequest referralStart, Long requirementId) {
+    public Optional<Nsi> getExistingMatchingNsi(String crn, String contextName, ContextlessReferralStartRequest referralStart) {
         // determine if there is an existing suitable NSI
         var offenderId = offenderService.offenderIdOfCrn(crn).orElseThrow(() -> new BadRequestException("Offender CRN not found"));
 
@@ -87,10 +88,9 @@ public class ReferralService {
 
         var existingNsis = nsiService.getNsiByCodes(offenderId, referralStart.getSentenceId(), Collections.singletonList(getNsiType(nsiMapping, referralStart.getContractType())))
             .map(wrapper -> wrapper.getNsis().stream()
-                // eventID, offenderID, nsiID, and callerID are handled in the NSI service
+                // eventID, offenderID, nsi type are handled in the NSI service
                 .filter(nsi -> Optional.ofNullable(nsi.getReferralDate()).map(n -> n.equals(toLondonLocalDate(referralStart.getStartedAt()))).orElse(false))
                 .filter(nsi -> Optional.ofNullable(nsi.getNsiStatus()).map(n -> n.getCode().equals(nsiMapping.getNsiStatus())).orElse(false))
-                .filter(nsi -> Optional.ofNullable(nsi.getRequirement()).map(n -> nsi.getRequirement().getRequirementId().equals(requirementId)).orElse(false))
                 .filter(nsi -> Optional.ofNullable(nsi.getIntendedProvider()).map(n -> n.getCode().equals(context.getProviderCode())).orElse(false))
                 .filter(nsi -> Optional.ofNullable(nsi.getNsiManagers()).map(n -> n.stream().anyMatch(
                     nsiManager -> nsiManager.getStaff().getStaffCode().equals(context.getStaffCode())
@@ -107,8 +107,9 @@ public class ReferralService {
         return existingNsis.stream().findFirst();
     }
 
-    Long getRequirement(String crn, Long sentenceId, IntegrationContext context) {
-        return requirementService.getRequirement(crn, sentenceId, context.getRequirementRehabilitationActivityType()).getRequirementId();
+    Optional<Long> getRequirement(String crn, Long sentenceId, IntegrationContext context) {
+        return requirementService.getRequirement(crn, sentenceId, context.getRequirementRehabilitationActivityType())
+            .map(Requirement::getRequirementId);
     }
 
     String getNsiType(final NsiMapping nsiMapping, final String contactType) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
@@ -109,7 +109,7 @@ public class RequirementService {
     // that has a main category of F - rehab activity requirement. It is invalid for multiple to exist.
     // NB. The called method getRequirementsByConvictionId accepts an event id (conviction or sentence)
     // and perhaps should have been named getRequirementsByEventId
-    public Requirement getRequirement(String crn, Long eventId, String requirementTypeCode) {
+    public Optional<Requirement> getRequirement(String crn, Long eventId, String requirementTypeCode) {
 
         var requirements = getRequirementsByConvictionId(crn, eventId)
             .getRequirements().stream()
@@ -123,8 +123,7 @@ public class RequirementService {
             throw new IllegalStateException(format("CRN: %s EventId: %d has multiple referral requirements", crn, eventId));
         }
 
-        return requirements.stream().findFirst().orElseThrow(() ->
-            new IllegalStateException(format("CRN: %s EventId: %d has no referral requirement", crn, eventId)));
+        return requirements.stream().findFirst();
     }
 
 

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformer.java
@@ -3,14 +3,17 @@ package uk.gov.justice.digital.delius.transformers;
 import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.IntegrationContext;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateRequest;
+import uk.gov.justice.digital.delius.data.api.Requirement;
+
+import java.util.Optional;
 
 public class AppointmentCreateRequestTransformer {
 
     public static AppointmentCreateRequest appointmentOf(ContextlessAppointmentCreateRequest request,
-                                                         Long requirementId,
+                                                         Optional<Requirement> requirement,
                                                          IntegrationContext context) {
         return AppointmentCreateRequest.builder()
-                .requirementId(requirementId)
+                .requirementId(requirement.map(Requirement::getRequirementId).orElse(null))
                 .contactType(context.getContactMapping().getAppointmentContactType())
                 .appointmentStart(request.getAppointmentStart())
                 .appointmentEnd(request.getAppointmentEnd())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -109,11 +109,8 @@ delius-integration-context:
       requirement-rehabilitation-activity-type: F
       nsi-mapping:
         nsi-status: INPROG
-        service-category-to-nsi-type:
-          428ee70f-3001-4399-95a6-ad25eaaede16: CRS01
-          ca374ac3-84eb-4b91-bea7-9005398f426f: CRS02
-          96a63c39-4371-4f17-a6ec-265755f0cf7b: CRS03
-          76bcdb97-1dea-41c1-a4f8-899d88e5d679: CRS04
+        contract-type-to-nsi-type:
+          ACC: CRS01
       contact-mapping:
         appointment-contact-type: CRSAPT
         enforcement-refer-to-offender-manager: ROM

--- a/src/test/java/uk/gov/justice/digital/delius/controller/secure/ReferralControllerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/controller/secure/ReferralControllerTest.java
@@ -1,16 +1,14 @@
 
 package uk.gov.justice.digital.delius.controller.secure;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.digital.delius.controller.advice.SecureControllerAdvice;
-import uk.gov.justice.digital.delius.data.api.ReferralSentRequest;
+import uk.gov.justice.digital.delius.data.api.ContextlessReferralStartRequest;
 import uk.gov.justice.digital.delius.service.ReferralService;
 
 import java.time.OffsetDateTime;
-import java.util.UUID;
 
 import static io.restassured.config.EncoderConfig.encoderConfig;
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
@@ -23,7 +21,6 @@ public class ReferralControllerTest {
 
     private ReferralService referralService = mock(ReferralService.class);
     private static final String SOME_OFFENDER_CRN = "X0OOM";
-    private static final String INTEGRATION_CONTEXT = "commissioned-rehabilitation-services";
 
     @BeforeEach
     public void setup() {
@@ -35,31 +32,30 @@ public class ReferralControllerTest {
     }
 
     @Test
-    public void createReferral_returnsBadRequestWhenNoBodySupplied() throws JsonProcessingException {
+    public void createReferral_returnsBadRequestWhenNoBodySupplied() {
         given()
             .contentType(APPLICATION_JSON_VALUE)
             .body("")
             .when()
-            .post(String.format("/secure/offenders/crn/%s/referral/sent", SOME_OFFENDER_CRN))
+            .post(String.format("/secure/offenders/crn/%s/referral/start/context/commissioned-rehabilitation-services", SOME_OFFENDER_CRN))
             .then()
             .log().all()
             .statusCode(400);
     }
 
     @Test
-    public void updateReferral_callsServiceAndReturnsOKWhenValidationSucceeds() throws JsonProcessingException {
+    public void updateReferral_callsServiceAndReturnsOKWhenValidationSucceeds() {
         given()
             .contentType(APPLICATION_JSON_VALUE)
-            .body(ReferralSentRequest.builder()
-                .sentAt(OffsetDateTime.now())
-                .serviceCategoryId(UUID.fromString("76bcdb97-1dea-41c1-a4f8-899d88e5d679"))
+            .body(ContextlessReferralStartRequest.builder()
+                .startedAt(OffsetDateTime.now())
+                .contractType("ACC")
                 .sentenceId(12354L)
                 .notes("comes notes")
-                .context(INTEGRATION_CONTEXT)
                 .build()
             )
             .when()
-            .post(String.format("/secure/offenders/crn/%s/referral/sent", SOME_OFFENDER_CRN))
+            .post(String.format("/secure/offenders/crn/%s/referral/start/context/commissioned-rehabilitation-services", SOME_OFFENDER_CRN))
             .then()
             .statusCode(200);
     }

--- a/src/test/java/uk/gov/justice/digital/delius/service/AppointmentServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/AppointmentServiceTest.java
@@ -47,6 +47,7 @@ import java.util.function.UnaryOperator;
 import static com.fasterxml.jackson.databind.node.TextNode.valueOf;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -65,6 +66,7 @@ public class AppointmentServiceTest {
     private static final String RAR_TYPE_CODE = "F";
     private static final String CRSAPT_CONTACT_TYPE = "CRSAPT";
     private static final String CONTEXT = "commissioned-rehabilitation-services";
+    private static final Long REQUIREMENT_ID = 99L;
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -128,7 +130,7 @@ public class AppointmentServiceTest {
 
         havingContactType(true, builder -> builder.attendanceContact("Y"));
 
-        final var deliusNewContactRequest = aDeliusNewContactRequest(startTime, endTime);
+        final var deliusNewContactRequest = aDeliusNewContactRequest(startTime, endTime, REQUIREMENT_ID);
         final var createdContact = ContactDto.builder().id(3L).typeDescription("Office Visit")
             .date(LocalDate.of(2021, 1, 31))
             .startTime(LocalTime.of(10, 0))
@@ -137,7 +139,7 @@ public class AppointmentServiceTest {
         when(deliusApiClient.createNewContact(deliusNewContactRequest)).thenReturn(createdContact);
 
         // When
-        final var appointmentCreateRequest = aAppointmentCreateRequest(startTime, endTime);
+        final var appointmentCreateRequest = aAppointmentCreateRequest(startTime, endTime, REQUIREMENT_ID);
         final var response = service.createAppointment("X007", 1L, appointmentCreateRequest);
 
         // Then
@@ -154,7 +156,7 @@ public class AppointmentServiceTest {
         havingContactType(false, builder -> builder);
 
         // When
-        final var appointmentCreateRequest = aAppointmentCreateRequest(startTime, endTime);
+        final var appointmentCreateRequest = aAppointmentCreateRequest(startTime, endTime, REQUIREMENT_ID);
         assertThrows(BadRequestException.class,
             () -> service.createAppointment("X007", 1L, appointmentCreateRequest),
             "contact type 'X007' does not exist");
@@ -169,7 +171,7 @@ public class AppointmentServiceTest {
         havingContactType(true, builder -> builder.attendanceContact("N"));
 
         // When
-        final var appointmentCreateRequest = aAppointmentCreateRequest(startTime, endTime);
+        final var appointmentCreateRequest = aAppointmentCreateRequest(startTime, endTime, REQUIREMENT_ID);
         assertThrows(BadRequestException.class,
             () -> service.createAppointment("X007", 1L, appointmentCreateRequest),
             "contact type 'X007' is not an appointment type");
@@ -179,14 +181,40 @@ public class AppointmentServiceTest {
     public void createsAppointmentUsingContextlessClientRequest() {
         // Given
         final var requirement = Requirement.builder().requirementId(99L).build();
-        when(requirementService.getRequirement("X007", 1L, RAR_TYPE_CODE)).thenReturn(requirement);
+        when(requirementService.getRequirement("X007", 1L, RAR_TYPE_CODE)).thenReturn(of(requirement));
 
         final var startTime = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
         final var endTime = startTime.plusHours(1);
 
         havingContactType(true, builder -> builder.attendanceContact("Y"));
 
-        final var deliusNewContactRequest = aDeliusNewContactRequest(startTime, endTime);
+        final var deliusNewContactRequest = aDeliusNewContactRequest(startTime, endTime, REQUIREMENT_ID);
+        final var createdContact = ContactDto.builder().id(3L)
+            .date(LocalDate.of(2021, 1, 31))
+            .startTime(LocalTime.of(10, 0))
+            .endTime(LocalTime.of(11, 0))
+            .build();
+        when(deliusApiClient.createNewContact(deliusNewContactRequest)).thenReturn(createdContact);
+
+        // When
+        final var appointmentCreateRequest = aContextlessAppointmentCreateRequest(startTime, endTime);
+        final var response = service.createAppointment("X007", 1L, CONTEXT, appointmentCreateRequest);
+
+        // Then
+        assertThat(response.getAppointmentId()).isEqualTo(3L);
+    }
+
+    @Test
+    public void createsAppointmentUsingContextlessClientRequest_withNoRequirement() {
+        // Given
+        when(requirementService.getRequirement("X007", 1L, RAR_TYPE_CODE)).thenReturn(empty());
+
+        final var startTime = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+        final var endTime = startTime.plusHours(1);
+
+        havingContactType(true, builder -> builder.attendanceContact("Y"));
+
+        final var deliusNewContactRequest = aDeliusNewContactRequest(startTime, endTime, null);
         final var createdContact = ContactDto.builder().id(3L)
             .date(LocalDate.of(2021, 1, 31))
             .startTime(LocalTime.of(10, 0))
@@ -341,7 +369,7 @@ public class AppointmentServiceTest {
         }
     }
 
-    private NewContact aDeliusNewContactRequest(OffsetDateTime startTime, OffsetDateTime endTime) {
+    private NewContact aDeliusNewContactRequest(OffsetDateTime startTime, OffsetDateTime endTime, Long requirementId) {
         return NewContact.builder()
             .offenderCrn("X007")
             .type(CRSAPT_CONTACT_TYPE)
@@ -358,13 +386,13 @@ public class AppointmentServiceTest {
             .notes("/url")
             .description(null)
             .eventId(1L)
-            .requirementId(99L)
+            .requirementId(requirementId)
             .build();
     }
 
-    private AppointmentCreateRequest aAppointmentCreateRequest(OffsetDateTime startTime, OffsetDateTime endTime) {
+    private AppointmentCreateRequest aAppointmentCreateRequest(OffsetDateTime startTime, OffsetDateTime endTime, Long requirementId) {
         return AppointmentCreateRequest.builder()
-            .requirementId(99L)
+            .requirementId(requirementId)
             .contactType(CRSAPT_CONTACT_TYPE)
             .appointmentStart(startTime)
             .appointmentEnd(endTime)

--- a/src/test/java/uk/gov/justice/digital/delius/service/ReferralServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ReferralServiceTest.java
@@ -35,6 +35,8 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -112,15 +114,15 @@ public class ReferralServiceTest {
 
         referralService = new ReferralService(deliusApiClient, nsiService, offenderService, requirementService, integrationContextConfig);
 
-        when(offenderService.offenderIdOfCrn(OFFENDER_CRN)).thenReturn(Optional.of(OFFENDER_ID));
+        when(offenderService.offenderIdOfCrn(OFFENDER_CRN)).thenReturn(of(OFFENDER_ID));
     }
 
     @Test
     public void creatingNewNsiWhenMatchingOneExistsReturnsExistingNsi() {
 
         Requirement requirement = Requirement.builder().requirementId(REQUIREMENT_ID).build();
-        when(requirementService.getRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(requirement);
-        when(nsiService.getNsiByCodes(any(), any(), any())).thenReturn(Optional.of(NsiWrapper.builder().nsis(singletonList(MATCHING_NSI)).build()));
+        when(requirementService.getRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(of(requirement));
+        when(nsiService.getNsiByCodes(any(), any(), any())).thenReturn(of(NsiWrapper.builder().nsis(singletonList(MATCHING_NSI)).build()));
 
         var response = referralService.startNsiReferral("X123456", INTEGRATION_CONTEXT, NSI_REQUEST);
 
@@ -134,8 +136,8 @@ public class ReferralServiceTest {
     public void creatingNewNsiWhenMultipleMatchingExistReturnsConflict() {
 
         Requirement requirement = Requirement.builder().requirementId(REQUIREMENT_ID).build();
-        when(requirementService.getRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(requirement);
-        when(nsiService.getNsiByCodes(any(), any(), any())).thenReturn(Optional.of(NsiWrapper.builder().nsis(Collections.nCopies(2, MATCHING_NSI)).build()));
+        when(requirementService.getRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(of(requirement));
+        when(nsiService.getNsiByCodes(any(), any(), any())).thenReturn(of(NsiWrapper.builder().nsis(Collections.nCopies(2, MATCHING_NSI)).build()));
 
         assertThrows(ConflictingRequestException.class, () -> referralService.startNsiReferral("X123456", INTEGRATION_CONTEXT, NSI_REQUEST));
 
@@ -147,10 +149,10 @@ public class ReferralServiceTest {
     public void creatingNewNsiCallsDeliusApiWhenNonExisting() {
 
         Requirement requirement = Requirement.builder().requirementId(REQUIREMENT_ID).build();
-        when(requirementService.getRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(requirement);
+        when(requirementService.getRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(of(requirement));
         var deliusApiResponse = NsiDto.builder().id(66853L).build();
 
-        when(nsiService.getNsiByCodes(any(), any(), any())).thenReturn(Optional.of(NsiWrapper.builder().nsis(Collections.emptyList()).build()));
+        when(nsiService.getNsiByCodes(any(), any(), any())).thenReturn(of(NsiWrapper.builder().nsis(Collections.emptyList()).build()));
         when(deliusApiClient.createNewNsi(any())).thenReturn(deliusApiResponse);
 
         var response = referralService.startNsiReferral("X123456", INTEGRATION_CONTEXT, NSI_REQUEST);
@@ -179,13 +181,48 @@ public class ReferralServiceTest {
         assertThat(response.getNsiId()).isEqualTo(deliusApiResponse.getId());
     }
 
+    @Test
+    public void creatingNewNsiCallsDeliusApiWhenNonExisting_withNoRequirement() {
+
+        when(requirementService.getRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(empty());
+        var deliusApiResponse = NsiDto.builder().id(66853L).build();
+
+        when(nsiService.getNsiByCodes(any(), any(), any())).thenReturn(of(NsiWrapper.builder().nsis(Collections.emptyList()).build()));
+        when(deliusApiClient.createNewNsi(any())).thenReturn(deliusApiResponse);
+
+        var response = referralService.startNsiReferral("X123456", INTEGRATION_CONTEXT, NSI_REQUEST);
+
+        verify(nsiService).getNsiByCodes(OFFENDER_ID, SENTENCE_ID, singletonList(NSI_TYPE));
+
+        verify(deliusApiClient).createNewNsi(eq(NewNsi.builder()
+            .type(NSI_TYPE)
+            .offenderCrn(OFFENDER_CRN)
+            .eventId(SENTENCE_ID)
+            .requirementId(null)
+            .referralDate(LocalDate.of(2021, 1, 20))
+            .expectedStartDate(null)
+            .expectedEndDate(null)
+            .startDate(null)
+            .endDate(null)
+            .length(null)
+            .status(NSI_STATUS)
+            .statusDate(LocalDateTime.of(2021, 1, 20, 12, 0))
+            .outcome(null)
+            .notes("A test note")
+            .intendedProvider(PROVIDER_CODE)
+            .manager(NewNsiManager.builder().staff(STAFF_CODE).team(TEAM_CODE).provider(PROVIDER_CODE).build())
+            .build()));
+
+        assertThat(response.getNsiId()).isEqualTo(deliusApiResponse.getId());
+    }
+
     @ParameterizedTest
     @MethodSource("nsis")
     public void noNsisAreReturnedWhenNotExactMatch(final ContextlessReferralStartRequest nsiRequest, final Nsi existingNsi, final boolean exists) {
 
-        when(nsiService.getNsiByCodes(any(), any(), any())).thenReturn(Optional.of(NsiWrapper.builder().nsis(singletonList(existingNsi)).build()));
+        when(nsiService.getNsiByCodes(any(), any(), any())).thenReturn(of(NsiWrapper.builder().nsis(singletonList(existingNsi)).build()));
 
-        var response = referralService.getExistingMatchingNsi(OFFENDER_CRN, INTEGRATION_CONTEXT, nsiRequest, REQUIREMENT_ID);
+        var response = referralService.getExistingMatchingNsi(OFFENDER_CRN, INTEGRATION_CONTEXT, nsiRequest);
 
         assertThat(response.isPresent()).isEqualTo(exists);
     }
@@ -194,7 +231,7 @@ public class ReferralServiceTest {
     public void throwsExceptionIfNsiTypeMappingNotFound() {
 
         Requirement requirement = Requirement.builder().requirementId(REQUIREMENT_ID).build();
-        when(requirementService.getRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(requirement);
+        when(requirementService.getRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(of(requirement));
 
         var nsiRequest = NSI_REQUEST
             .toBuilder()
@@ -207,9 +244,7 @@ public class ReferralServiceTest {
     private static Stream<Arguments> nsis() {
         return Stream.of(
             Arguments.of(NSI_REQUEST, MATCHING_NSI, true),
-            Arguments.of(NSI_REQUEST.withStartedAt(OffsetDateTime.of(2017, 1, 1, 12, 0, 0, 0, ZoneOffset.UTC)), MATCHING_NSI, false),
-            Arguments.of(NSI_REQUEST, MATCHING_NSI.withRequirement(Requirement.builder().requirementId(999L).build()), false),
-            Arguments.of(NSI_REQUEST, MATCHING_NSI.withRequirement(null), false)
+            Arguments.of(NSI_REQUEST.withStartedAt(OffsetDateTime.of(2017, 1, 1, 12, 0, 0, 0, ZoneOffset.UTC)), MATCHING_NSI, false)
         );
     }
 }

--- a/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
@@ -231,7 +231,7 @@ public class RequirementServiceTest {
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build())
                 .build()));
             var requirement = requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE);
-            assertThat(requirement.getRequirementId()).isEqualTo(99L);
+            assertThat(requirement.get().getRequirementId()).isEqualTo(99L);
         }
 
         @Test
@@ -242,13 +242,11 @@ public class RequirementServiceTest {
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("X").build())
                 .build()));
 
-            assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(() -> requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE))
-                .withMessage("CRN: CRN EventId: 987654321 has no referral requirement");
+            assertThat(requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE)).isEmpty();
         }
 
         @Test
-        public void whenGetReferralRequirementByConvictionId_AndNoRequirementsExist_thenThrowException() {
+        public void whenGetReferralRequirementByConvictionId_AndMultipleRequirementsExist_thenThrowException() {
             when(disposal.getRequirements()).thenReturn(Arrays.asList(
                 Requirement.builder().requirementId(99L)
                     .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build()).build(),
@@ -262,12 +260,10 @@ public class RequirementServiceTest {
         }
 
         @Test
-        public void whenGetReferralRequirementByConvictionId_AndMultipleRequirementsExist_thenThrowException() {
+        public void whenGetReferralRequirementByConvictionId_AndNoRequirementsExist_thenReturnEmptyOptional() {
             when(disposal.getRequirements()).thenReturn(Collections.emptyList());
 
-            assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(() -> requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE))
-                .withMessage("CRN: CRN EventId: 987654321 has no referral requirement");
+            assertThat(requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE)).isEmpty();
         }
 
         @Test

--- a/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
@@ -231,7 +231,7 @@ public class RequirementServiceTest {
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build())
                 .build()));
             var requirement = requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE);
-            assertThat(requirement.get().getRequirementId()).isEqualTo(99L);
+            assertThat(requirement.orElse(null).getRequirementId()).isEqualTo(99L);
         }
 
         @Test

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformerTest.java
@@ -7,10 +7,9 @@ import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateReques
 import uk.gov.justice.digital.delius.data.api.Requirement;
 
 import java.time.OffsetDateTime;
+import java.util.Optional;
 
 import static java.time.OffsetDateTime.now;
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AppointmentCreateRequestTransformerTest {
@@ -27,7 +26,7 @@ class AppointmentCreateRequestTransformerTest {
                 .officeLocationCode("CRSHEFF")
                 .notes("some notes")
                 .build(),
-            of(Requirement.builder().requirementId(123456L).build()),
+            Optional.of(Requirement.builder().requirementId(123456L).build()),
             anIntegrationContext())).isEqualTo(
                     AppointmentCreateRequest.builder()
                         .requirementId(123456L)
@@ -55,7 +54,7 @@ class AppointmentCreateRequestTransformerTest {
                 .officeLocationCode("CRSHEFF")
                 .notes("some notes")
                 .build(),
-            empty(),
+            Optional.empty(),
             anIntegrationContext())).isEqualTo(
             AppointmentCreateRequest.builder()
                 .requirementId(null)

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformerTest.java
@@ -4,10 +4,13 @@ import org.junit.jupiter.api.Test;
 import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.IntegrationContext;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateRequest;
+import uk.gov.justice.digital.delius.data.api.Requirement;
 
 import java.time.OffsetDateTime;
 
 import static java.time.OffsetDateTime.now;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AppointmentCreateRequestTransformerTest {
@@ -24,7 +27,7 @@ class AppointmentCreateRequestTransformerTest {
                 .officeLocationCode("CRSHEFF")
                 .notes("some notes")
                 .build(),
-            123456L,
+            of(Requirement.builder().requirementId(123456L).build()),
             anIntegrationContext())).isEqualTo(
                     AppointmentCreateRequest.builder()
                         .requirementId(123456L)
@@ -37,6 +40,34 @@ class AppointmentCreateRequestTransformerTest {
                         .staffCode("CRSUATU")
                         .teamCode("CRSUAT")
                         .build()
+        );
+    }
+
+    @Test
+    public void appointmentCreateRequestFromContextlessClientRequest_withNoRequirement() {
+        OffsetDateTime start = now();
+        OffsetDateTime end = start.plusHours(1);
+
+        assertThat(AppointmentCreateRequestTransformer.appointmentOf(
+            ContextlessAppointmentCreateRequest.builder()
+                .appointmentStart(start)
+                .appointmentEnd(end)
+                .officeLocationCode("CRSHEFF")
+                .notes("some notes")
+                .build(),
+            empty(),
+            anIntegrationContext())).isEqualTo(
+            AppointmentCreateRequest.builder()
+                .requirementId(null)
+                .contactType("CRSAPT")
+                .appointmentStart(start)
+                .appointmentEnd(end)
+                .officeLocationCode("CRSHEFF")
+                .notes("some notes")
+                .providerCode("CRS")
+                .staffCode("CRSUATU")
+                .teamCode("CRSUAT")
+                .build()
         );
     }
 

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/ReferralAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/ReferralAPITest.java
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.delius.JwtAuthenticationHelper;
 import uk.gov.justice.digital.delius.JwtParameters;
 import uk.gov.justice.digital.delius.controller.wiremock.DeliusApiExtension;
 import uk.gov.justice.digital.delius.controller.wiremock.DeliusApiMockServer;
-import uk.gov.justice.digital.delius.data.api.ReferralSentRequest;
+import uk.gov.justice.digital.delius.data.api.ContextlessReferralStartRequest;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -23,7 +23,6 @@ import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
@@ -31,9 +30,6 @@ import static org.hamcrest.Matchers.equalTo;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ExtendWith(SpringExtension.class)
 public class ReferralAPITest extends IntegrationTestBase {
-
-    private static final String INTEGRATION_CONTEXT = "commissioned-rehabilitation-services";
-    private static final UUID SERVICE_CATEGORY_ID = UUID.fromString("428ee70f-3001-4399-95a6-ad25eaaede16");
 
     private static final DeliusApiMockServer deliusApiMockServer = new DeliusApiMockServer(7999);
 
@@ -63,15 +59,14 @@ public class ReferralAPITest extends IntegrationTestBase {
                 .when()
                 .auth().oauth2(token)
                 .contentType(String.valueOf(ContentType.APPLICATION_JSON))
-                .body(writeValueAsString(ReferralSentRequest
+                .body(writeValueAsString(ContextlessReferralStartRequest
                     .builder()
-                    .sentAt(OffsetDateTime.now())
-                    .serviceCategoryId(SERVICE_CATEGORY_ID)
+                    .startedAt(OffsetDateTime.now())
+                    .contractType("ACC")
                     .sentenceId(2500295343L)
                     .notes("A test note")
-                    .context(INTEGRATION_CONTEXT)
                     .build()))
-                .post("offenders/crn/X320741/referral/sent")
+                .post("offenders/crn/X320741/referral/start/context/commissioned-rehabilitation-services")
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.OK.value())
@@ -89,15 +84,14 @@ public class ReferralAPITest extends IntegrationTestBase {
             .when()
             .auth().oauth2(token)
             .contentType(String.valueOf(ContentType.APPLICATION_JSON))
-            .body(writeValueAsString(ReferralSentRequest
+            .body(writeValueAsString(ContextlessReferralStartRequest
                 .builder()
-                .sentAt(OffsetDateTime.of(2019,9,2, 12, 0, 1, 2, ZoneOffset.UTC))
-                .serviceCategoryId(SERVICE_CATEGORY_ID)
+                .startedAt(OffsetDateTime.of(2019,9,2, 12, 0, 1, 2, ZoneOffset.UTC))
+                .contractType("ACC")
                 .sentenceId(2500295345L)
                 .notes("A test note")
-                .context(INTEGRATION_CONTEXT)
                 .build()))
-            .post("offenders/crn/X320741/referral/sent")
+            .post("offenders/crn/X320741/referral/start/context/commissioned-rehabilitation-services")
             .then()
             .assertThat()
             .statusCode(HttpStatus.OK.value())

--- a/src/testIntegration/resources/application.properties
+++ b/src/testIntegration/resources/application.properties
@@ -28,10 +28,7 @@ delius-integration-context.integration-contexts[commissioned-rehabilitation-serv
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].team-code=CRSUAT
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].requirement-rehabilitation-activity-type=F
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.nsi-status=INPROG
-delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi_mapping.service-category-to-nsi-type[428ee70f-3001-4399-95a6-ad25eaaede16]=CRS01
-delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.service-category-to-nsi-type[ca374ac3-84eb-4b91-bea7-9005398f426f]=CRS02
-delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.service-category-to-nsi-type[96a63c39-4371-4f17-a6ec-265755f0cf7b]=CRS03
-delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi-mapping.service-category-to-nsi-type[76bcdb97-1dea-41c1-a4f8-899d88e5d679]=CRS04
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].nsi_mapping.contract-type-to-nsi-type[ACC]=CRS01
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.appointment-contact-type=CRSAPT
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.enforcement_refer-to-offender-manager=ROM
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.attendance-and-behaviour-notified-mapping-to-outcome-type[yes].[true]=AFTC


### PR DESCRIPTION
**What does this pull request do?**
After a review of the interaction with Interventions, a number of changes where identified for the referral sent end point:

1) A more generic name for the endpoint is ReferralStart
2) Referrals are not limited to Sentences with RAR requirements, and thus, exception not raised if requirement not found
2) ContractType is to be used to map to NsiType instead of ServiceCategory
3) SentAt is renamed to StartedAt
4) Context name is to be specified in URL as apposed to in the body - in line with appointment creation

**What is the intent behind these changes?**
This change means that the initial release of interventions can be supported.

**Breaking Changes?**
Yes and limited to interventions referralSent endpoint.