### PR TITLE
DAPI-99 Referral End request

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/config/DeliusIntegrationContextConfig.java
+++ b/src/main/java/uk/gov/justice/digital/delius/config/DeliusIntegrationContextConfig.java
@@ -7,8 +7,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 @Configuration
 @ConfigurationProperties(prefix = "delius-integration-context")
@@ -39,7 +39,12 @@ public class DeliusIntegrationContextConfig {
         private String appointmentRarContactType;
         private String appointmentNonRarContactType;
         private String enforcementReferToOffenderManager;
+        private Map<String, String> endTypeToOutcomeType;
         private Map<String, Map<Boolean, String>> attendanceAndBehaviourNotifiedMappingToOutcomeType;
+
+        public List<String> getAllAppointmentContactTypes() {
+            return List.of(appointmentRarContactType, appointmentNonRarContactType);
+        }
     }
 
     private Map<String, IntegrationContext> integrationContexts = new HashMap<>();

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/ReferralController.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/ReferralController.java
@@ -14,7 +14,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.justice.digital.delius.controller.advice.ErrorResponse;
+import uk.gov.justice.digital.delius.data.api.ContextlessReferralEndRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessReferralStartRequest;
+import uk.gov.justice.digital.delius.data.api.ReferralEndResponse;
 import uk.gov.justice.digital.delius.data.api.ReferralStartResponse;
 import uk.gov.justice.digital.delius.service.ReferralService;
 
@@ -34,7 +36,7 @@ public class ReferralController {
         consumes = "application/json")
     @ApiResponses(
         value = {
-            @ApiResponse(code = 201, message = "Created", response = String.class),
+            @ApiResponse(code = 200, message = "Created", response = String.class),
             @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
             @ApiResponse(code = 403, message = "Requires role ROLE_COMMUNITY_INTERVENTIONS_UPDATE"),
             @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
@@ -46,5 +48,24 @@ public class ReferralController {
                                                                 @PathVariable("context") String context,
                                                           final @RequestBody @Valid ContextlessReferralStartRequest referralStartRequest) {
         return referralService.startNsiReferral(crn, context, referralStartRequest);
+    }
+
+    @RequestMapping(value = "/offenders/crn/{crn}/referral/end/context/{context}",
+        method = RequestMethod.POST,
+        consumes = "application/json")
+    @ApiResponses(
+        value = {
+            @ApiResponse(code = 200, message = "Updated", response = String.class),
+            @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
+            @ApiResponse(code = 403, message = "Requires role ROLE_COMMUNITY_INTERVENTIONS_UPDATE"),
+            @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
+        })
+
+    @ApiOperation(value = "Ends a NSI referral")
+    public ReferralEndResponse endReferralContextLess(final @PathVariable("crn") String crn,
+                                                      final @ApiParam(value = "Name identifying preprocessing applied to the request", example = "commissioned-rehabilitation-services")
+                                                            @PathVariable("context") String context,
+                                                      final @RequestBody @Valid ContextlessReferralEndRequest referralEndRequest) {
+        return referralService.endNsiReferral(crn, context, referralEndRequest);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessReferralEndRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessReferralEndRequest.java
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.delius.data.api;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.With;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import java.time.OffsetDateTime;
+
+@Data
+@With
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContextlessReferralEndRequest {
+
+    // Fields used to identify associated Referral/Nsi
+    @NotNull
+    @ApiModelProperty(required = true, value = "Denotes a group of services delivered through a referral to a service user, e.g. Personal Well Being", example = "PWB")
+    private String contractType;
+
+    @NotNull
+    @ApiModelProperty(required = true)
+    private OffsetDateTime startedAt;
+
+    // Fields used for ending the referral
+    @NotNull
+    @ApiModelProperty(required = true)
+    private OffsetDateTime endedAt;
+
+    @Positive
+    @NotNull
+    @ApiModelProperty(required = true)
+    private Long sentenceId;
+
+    @NotNull
+    @ApiModelProperty(required = true)
+    private String endType;
+
+    @NotNull
+    private String notes;
+}

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ReferralEndResponse.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ReferralEndResponse.java
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.delius.data.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReferralEndResponse {
+    private Long nsiId;
+}

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/ContactRepository.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/ContactRepository.java
@@ -32,4 +32,11 @@ public interface ContactRepository extends JpaRepository<Contact, Long>, JpaSpec
                                             @Param("eventId") Long eventId,
                                             @Param("contactDate") LocalDate contactDate);
 
+
+    @Query("SELECT contact FROM Contact contact "
+        + "WHERE contact.offenderId = :offenderId "
+        + "AND contact.nsi.nsiId = :nsiId "
+    )
+    List<Contact> findByOffenderAndNsiId(@Param("offenderId") Long offenderId,
+                                         @Param("nsiId") Long nsiId);
 }

--- a/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig;
 import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.IntegrationContext;
 import uk.gov.justice.digital.delius.controller.BadRequestException;
@@ -57,6 +58,7 @@ public class AppointmentService {
                         Sort.by(DESC, "contactDate")));
     }
 
+    @Transactional
     public AppointmentCreateResponse createAppointment(String crn, Long sentenceId, AppointmentCreateRequest request) {
         this.assertAppointmentType(request.getContactType());
 
@@ -66,6 +68,7 @@ public class AppointmentService {
         return makeResponse(contactDto);
     }
 
+    @Transactional
     public AppointmentCreateResponse createAppointment(String crn, Long sentenceId, String contextName, ContextlessAppointmentCreateRequest contextlessRequest) {
 
         final var context = getContext(contextName);
@@ -76,6 +79,7 @@ public class AppointmentService {
         return createAppointment(crn, sentenceId, request);
     }
 
+    @Transactional
     public AppointmentUpdateResponse patchAppointment(String crn, Long appointmentId, JsonPatch jsonPatch) {
 
         this.assertAppointmentTypeIfExists(jsonPatch);
@@ -83,6 +87,7 @@ public class AppointmentService {
         return new AppointmentUpdateResponse(contactDto.getId());
     }
 
+    @Transactional
     public AppointmentUpdateResponse updateAppointmentOutcome(String crn, Long appointmentId, String contextName, ContextlessAppointmentOutcomeRequest request) {
 
         final var context = getContext(contextName);

--- a/src/main/java/uk/gov/justice/digital/delius/service/DeliusApiClient.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/DeliusApiClient.java
@@ -36,6 +36,17 @@ public class DeliusApiClient {
             .block();
     }
 
+    public NsiDto patchNsi(Long nsiId, JsonPatch jsonPatch) {
+        return webClient.patch()
+            .uri(fromPath("/v1/nsi/{id}").buildAndExpand(nsiId).toUriString())
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+            .bodyValue(jsonPatch)
+            .retrieve()
+            .bodyToMono(NsiDto.class)
+            .block();
+    }
+
     public ContactDto createNewContact(NewContact newContact) {
         return webClient.post()
             .uri("/v1/contact")
@@ -56,4 +67,13 @@ public class DeliusApiClient {
             .retrieve()
             .bodyToMono(ContactDto.class)
             .block();
-    }}
+    }
+
+    public Void deleteContact(Long contactId) {
+        return webClient.delete()
+            .uri(fromPath("/v1/contact/{id}").buildAndExpand(contactId).toUriString())
+            .retrieve()
+            .bodyToMono(Void.class)
+            .block();
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/NsiPatchRequestTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/NsiPatchRequestTransformer.java
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.delius.transformers;
+
+import com.github.fge.jsonpatch.JsonPatch;
+import com.github.fge.jsonpatch.JsonPatchOperation;
+import com.github.fge.jsonpatch.ReplaceOperation;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.IntegrationContext;
+import uk.gov.justice.digital.delius.data.api.ContextlessReferralEndRequest;
+
+import java.util.ArrayList;
+
+import static com.fasterxml.jackson.databind.node.TextNode.valueOf;
+import static com.github.fge.jackson.jsonpointer.JsonPointer.of;
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static uk.gov.justice.digital.delius.utils.DateConverter.toLondonLocalDateTime;
+
+@Component
+@AllArgsConstructor
+public class NsiPatchRequestTransformer {
+
+    private static final String TARGET_NSI_OUTCOME_FIELD_NAME = "outcome";
+    private static final String TARGET_END_DATE_TIME_FIELD_NAME = "endDate";
+    private static final String TARGET_NOTES_FIELD_NAME = "notes";
+
+    public JsonPatch mapEndTypeToOutcomeOf(final ContextlessReferralEndRequest request, final IntegrationContext context) {
+
+        final var endTypeToOutcomeTypeMapping = context.getContactMapping().getEndTypeToOutcomeType();
+        final var outcomeType = ofNullable(endTypeToOutcomeTypeMapping.get(request.getEndType()))
+            .orElseThrow(() -> new IllegalStateException(format("Mapping does not exist for referral end type: %s", request.getEndType())));
+
+        final var patchOperations = new ArrayList<JsonPatchOperation>();
+        patchOperations.add(new ReplaceOperation(of(TARGET_NSI_OUTCOME_FIELD_NAME), valueOf(outcomeType)));
+        patchOperations.add(new ReplaceOperation(of(TARGET_END_DATE_TIME_FIELD_NAME), valueOf(toLondonLocalDateTime(request.getEndedAt()).toString()))); // ISO-8601 format
+        patchOperations.add(new ReplaceOperation(of(TARGET_NOTES_FIELD_NAME), valueOf(request.getNotes())));
+
+        return new JsonPatch(patchOperations);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -117,6 +117,10 @@ delius-integration-context:
         appointment-rar-contact-type: CRSAPT
         appointment-non-rar-contact-type: CRS01
         enforcement-refer-to-offender-manager: ROM
+        end-type-to-outcome-type:
+          CANCELLED: CRS01
+          PREMATURELY_ENDED: CRS02
+          COMPLETED: CRS03
         attendance-and-behaviour-notified-mapping-to-outcome-type:
           # Key values must be quoted otherwise they will get converted to true/false
           "yes":

--- a/src/test/java/uk/gov/justice/digital/delius/controller/secure/ReferralControllerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/controller/secure/ReferralControllerTest.java
@@ -5,6 +5,7 @@ import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.digital.delius.controller.advice.SecureControllerAdvice;
+import uk.gov.justice.digital.delius.data.api.ContextlessReferralEndRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessReferralStartRequest;
 import uk.gov.justice.digital.delius.service.ReferralService;
 
@@ -44,13 +45,32 @@ public class ReferralControllerTest {
     }
 
     @Test
-    public void updateReferral_callsServiceAndReturnsOKWhenValidationSucceeds() {
+    public void startReferral_callsServiceAndReturnsOKWhenValidationSucceeds() {
         given()
             .contentType(APPLICATION_JSON_VALUE)
             .body(ContextlessReferralStartRequest.builder()
                 .startedAt(OffsetDateTime.now())
                 .contractType("ACC")
                 .sentenceId(12354L)
+                .notes("comes notes")
+                .build()
+            )
+            .when()
+            .post(String.format("/secure/offenders/crn/%s/referral/start/context/commissioned-rehabilitation-services", SOME_OFFENDER_CRN))
+            .then()
+            .statusCode(200);
+    }
+
+    @Test
+    public void endReferral_callsServiceAndReturnsOKWhenValidationSucceeds() {
+        given()
+            .contentType(APPLICATION_JSON_VALUE)
+            .body(ContextlessReferralEndRequest.builder()
+                .startedAt(OffsetDateTime.now())
+                .endedAt(OffsetDateTime.now())
+                .contractType("ACC")
+                .sentenceId(12354L)
+                .endType("COMPLETED")
                 .notes("comes notes")
                 .build()
             )

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/NsiPatchRequestTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/NsiPatchRequestTransformerTest.java
@@ -1,0 +1,85 @@
+package uk.gov.justice.digital.delius.transformers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.IntegrationContext;
+import uk.gov.justice.digital.delius.data.api.ContextlessReferralEndRequest;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NsiPatchRequestTransformerTest {
+
+    private static final OffsetDateTime END_DATE = OffsetDateTime.of(2021,6,1,0,0,0,1, ZoneOffset.UTC);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private IntegrationContext integrationContext;
+
+    private NsiPatchRequestTransformer transformer = new NsiPatchRequestTransformer();
+
+    @BeforeEach
+    public void before() {
+
+        integrationContext = new IntegrationContext();
+        integrationContext.getContactMapping().setEndTypeToOutcomeType(
+            new HashMap<>() {{
+                this.put("CANCELLED", "CRS01");
+                this.put("PREMATURELY_ENDED", "CRS02");
+                this.put("COMPLETED", "CRS03");
+            }}
+        );
+    }
+
+    @Test
+    public void transformsToJsonPatchMappingCorrectOutcome() throws JsonProcessingException {
+
+        assertThat(
+            objectMapper.writeValueAsString(
+                transformer.mapEndTypeToOutcomeOf(buildRequest("CANCELLED"), integrationContext)
+            )
+        ).isEqualTo("[{\"op\":\"replace\",\"path\":\"/outcome\",\"value\":\"CRS01\"}," +
+            "{\"op\":\"replace\",\"path\":\"/endDate\",\"value\":\"2021-06-01T01:00:00.000000001\"}," +
+            "{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}]");
+
+        assertThat(
+            objectMapper.writeValueAsString(
+                transformer.mapEndTypeToOutcomeOf(buildRequest("PREMATURELY_ENDED"), integrationContext)
+            )
+        ).isEqualTo("[{\"op\":\"replace\",\"path\":\"/outcome\",\"value\":\"CRS02\"}," +
+            "{\"op\":\"replace\",\"path\":\"/endDate\",\"value\":\"2021-06-01T01:00:00.000000001\"}," +
+            "{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}]");
+
+        assertThat(
+            objectMapper.writeValueAsString(
+                transformer.mapEndTypeToOutcomeOf(buildRequest("COMPLETED"), integrationContext)
+            )
+        ).isEqualTo("[{\"op\":\"replace\",\"path\":\"/outcome\",\"value\":\"CRS03\"}," +
+            "{\"op\":\"replace\",\"path\":\"/endDate\",\"value\":\"2021-06-01T01:00:00.000000001\"}," +
+            "{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}]");
+    }
+
+    @Test
+    public void throwsExceptionWhenNoMapping() {
+        final var request = buildRequest("UnknownValue");
+
+        IllegalStateException illegalStateException = Assertions.assertThrows(IllegalStateException.class,
+            () -> transformer.mapEndTypeToOutcomeOf(request, integrationContext) );
+        assertThat(illegalStateException.getMessage())
+            .isEqualTo("Mapping does not exist for referral end type: UnknownValue");
+    }
+
+    private ContextlessReferralEndRequest buildRequest(final String endType) {
+        return ContextlessReferralEndRequest.builder()
+            .endType(endType)
+            .endedAt(END_DATE)
+            .notes("some notes")
+            .build();
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/NsiPatchRequestTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/NsiPatchRequestTransformerTest.java
@@ -44,25 +44,31 @@ class NsiPatchRequestTransformerTest {
             objectMapper.writeValueAsString(
                 transformer.mapEndTypeToOutcomeOf(buildRequest("CANCELLED"), integrationContext)
             )
-        ).isEqualTo("[{\"op\":\"replace\",\"path\":\"/outcome\",\"value\":\"CRS01\"}," +
-            "{\"op\":\"replace\",\"path\":\"/endDate\",\"value\":\"2021-06-01T01:00:00.000000001\"}," +
-            "{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}]");
+        ).isEqualTo("""
+            [{"op":"replace","path":"/outcome","value":"CRS01"},\
+            {"op":"replace","path":"/endDate","value":"2021-06-01T01:00:00.000000001"},\
+            {"op":"replace","path":"/notes","value":"some notes"}]\
+            """);
 
         assertThat(
             objectMapper.writeValueAsString(
                 transformer.mapEndTypeToOutcomeOf(buildRequest("PREMATURELY_ENDED"), integrationContext)
             )
-        ).isEqualTo("[{\"op\":\"replace\",\"path\":\"/outcome\",\"value\":\"CRS02\"}," +
-            "{\"op\":\"replace\",\"path\":\"/endDate\",\"value\":\"2021-06-01T01:00:00.000000001\"}," +
-            "{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}]");
+        ).isEqualTo("""
+            [{"op":"replace","path":"/outcome","value":"CRS02"},\
+            {"op":"replace","path":"/endDate","value":"2021-06-01T01:00:00.000000001"},\
+            {"op":"replace","path":"/notes","value":"some notes"}]\
+            """);
 
         assertThat(
             objectMapper.writeValueAsString(
                 transformer.mapEndTypeToOutcomeOf(buildRequest("COMPLETED"), integrationContext)
             )
-        ).isEqualTo("[{\"op\":\"replace\",\"path\":\"/outcome\",\"value\":\"CRS03\"}," +
-            "{\"op\":\"replace\",\"path\":\"/endDate\",\"value\":\"2021-06-01T01:00:00.000000001\"}," +
-            "{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}]");
+        ).isEqualTo("""
+            [{"op":"replace","path":"/outcome","value":"CRS03"},\
+            {"op":"replace","path":"/endDate","value":"2021-06-01T01:00:00.000000001"},\
+            {"op":"replace","path":"/notes","value":"some notes"}]\
+            """);
     }
 
     @Test

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/wiremock/DeliusApiMockServer.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/wiremock/DeliusApiMockServer.java
@@ -49,6 +49,39 @@ public class DeliusApiMockServer extends WireMockServer {
         ));
     }
 
+
+    public void stubPatchNsiToDeliusApi() {
+        stubFor(patch(urlPathMatching("/v1/nsi/2500018596")).willReturn(aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
+            .withBody("{\n" +
+                "    \"id\": 2500295345,\n" +
+                "    \"type\": \"KSS021\",\n" +
+                "    \"subType\": \"KSS026\",\n" +
+                "    \"offenderCrn\": \"X371505\",\n" +
+                "    \"eventId\": 2500428188,\n" +
+                "    \"requirementId\": 2500185175,\n" +
+                "    \"referralDate\": \"2021-03-01\",\n" +
+                "    \"expectedStartDate\": \"2021-03-01\",\n" +
+                "    \"expectedEndDate\": \"2021-03-01\",\n" +
+                "    \"startDate\": \"2021-03-01\",\n" +
+                "    \"endDate\": \"2021-03-01\",\n" +
+                "    \"length\": 1,\n" +
+                "    \"status\": \"SLI01\",\n" +
+                "    \"statusDate\": \"2021-03-03T00:01:00\",\n" +
+                "    \"outcome\": \"COMP\",\n" +
+                "    \"notes\": \"fugi\",\n" +
+                "    \"intendedProvider\": \"C21\",\n" +
+                "    \"manager\": {\n" +
+                "        \"id\": 2500039895,\n" +
+                "        \"provider\": \"C00\",\n" +
+                "        \"team\": \"C00T02\",\n" +
+                "        \"staff\": \"C00P017\"\n" +
+                "    }\n" +
+                "}")
+        ));
+    }
+
     public void stubPostContactToDeliusApi() {
         stubFor(post(urlPathMatching("/v1/contact")).willReturn(aResponse()
             .withHeader("Content-Type", "application/json")
@@ -93,6 +126,13 @@ public class DeliusApiMockServer extends WireMockServer {
                 "    \"requirementId\": 2500428188\n" +
                 "    }\n" +
                 "}")
+        ));
+    }
+
+    public void stubDeleteContactToDeliusApi() {
+        stubFor(delete(urlPathMatching("/v1/contact/2502709999")).willReturn(aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
         ));
     }
 }

--- a/src/testIntegration/resources/application.properties
+++ b/src/testIntegration/resources/application.properties
@@ -33,6 +33,9 @@ delius-integration-context.integration-contexts[commissioned-rehabilitation-serv
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.appointment-rar-contact-type=CRSAPT
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.appointment-non-rar-contact-type=CRS01
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.enforcement_refer-to-offender-manager=ROM
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.end-type-to-outcome-type.CANCELLED=CRS01
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.end-type-to-outcome-type.PREMATURELY_ENDED=CRS02
+delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.end-type-to-outcome-type.COMPLETED=CRS03
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.attendance-and-behaviour-notified-mapping-to-outcome-type[yes].[true]=AFTC
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.attendance-and-behaviour-notified-mapping-to-outcome-type[yes].[false]=ATTC
 delius-integration-context.integration-contexts[commissioned-rehabilitation-services].contact-mapping.attendance-and-behaviour-notified-mapping-to-outcome-type[late].[true]=AFTC


### PR DESCRIPTION
**What does this pull request do?**
Referrals in Interventions can end in one of three ways. They can be cancelled, prematurely ended or completed in their entirety. As a result, delius must be updated with the appropriate outcome and where there are any outstanding appointments, they must be deleted from delius. This PR provides this functionality.

**What is the intent behind these changes?**
These changes allow interventions to end referrals with the knowledge that delius has been kept up to date.

**Breaking Changes?**
None