### PR TITLE
E2E-520: Get offender appointments

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/AppointmentControllerSecure.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/AppointmentControllerSecure.java
@@ -45,9 +45,9 @@ public class AppointmentControllerSecure {
     @ApiOperation(value = "Gets all appointments for a specific offender by CRN")
     public List<AppointmentDetail> getOffenderAppointmentsByCrn(
         final @PathVariable("crn") String crn,
-        final @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @RequestParam("from") @ApiParam(value = "date of the earliest appointment") Optional<LocalDate> from,
-        final @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @RequestParam("to") @ApiParam(value = "date of the latest appointment") Optional<LocalDate> to,
-        final @RequestParam("attended") Optional<Attended> attended) {
+        final @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @RequestParam(value = "from", required = false) @ApiParam(value = "date of the earliest appointment") Optional<LocalDate> from,
+        final @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @RequestParam(value = "to", required = false) @ApiParam(value = "date of the latest appointment") Optional<LocalDate> to,
+        final @RequestParam(value = "attended", required = false) Optional<Attended> attended) {
 
         final var filter = AppointmentFilter.builder()
             .from(from).to(to)

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/AppointmentControllerSecure.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/AppointmentControllerSecure.java
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.delius.controller.secure;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.AllArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.justice.digital.delius.controller.NotFoundException;
+import uk.gov.justice.digital.delius.controller.advice.ErrorResponse;
+import uk.gov.justice.digital.delius.data.api.Appointment.Attended;
+import uk.gov.justice.digital.delius.data.api.AppointmentDetail;
+import uk.gov.justice.digital.delius.jpa.filters.AppointmentFilter;
+import uk.gov.justice.digital.delius.service.AppointmentService;
+import uk.gov.justice.digital.delius.service.OffenderService;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@Api(tags = {"Appointments"})
+@PreAuthorize("hasRole('ROLE_COMMUNITY')")
+@RequestMapping(value = "secure", produces = MediaType.APPLICATION_JSON_VALUE)
+@AllArgsConstructor
+public class AppointmentControllerSecure {
+    private final AppointmentService appointmentService;
+    private final OffenderService offenderService;
+
+    @RequestMapping(value = "/offenders/crn/{crn}/appointments", method = RequestMethod.GET)
+    @ApiResponses(
+        value = {
+            @ApiResponse(code = 200, message = "All offender appointments", response = AppointmentDetail.class, responseContainer = "List"),
+            @ApiResponse(code = 403, message = "Requires role ROLE_COMMUNITY"),
+            @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
+        })
+    @ApiOperation(value = "Gets all appointments for a specific offender by CRN")
+    public List<AppointmentDetail> getOffenderAppointmentsByCrn(
+        final @PathVariable("crn") String crn,
+        final @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @RequestParam("from") @ApiParam(value = "date of the earliest appointment") Optional<LocalDate> from,
+        final @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @RequestParam("to") @ApiParam(value = "date of the latest appointment") Optional<LocalDate> to,
+        final @RequestParam("attended") Optional<Attended> attended) {
+
+        final var filter = AppointmentFilter.builder()
+            .from(from).to(to)
+            .attended(attended)
+            .build();
+        final var id = offenderService.offenderIdOfCrn(crn)
+            .orElseThrow(() -> new NotFoundException(String.format("Offender with crn %s does not exist", crn)));
+        return appointmentService.appointmentDetailsFor(id, filter);
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentDetail.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentDetail.java
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.delius.data.api;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import java.time.OffsetDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppointmentDetail {
+    @NotNull
+    @ApiModelProperty(name = "Appointment id", example = "1")
+    private Long appointmentId;
+
+    @NotNull
+    @ApiModelProperty(name = "Appointment start date & time", example = "2021-05-25T10:00:00+01:00")
+    private OffsetDateTime appointmentStart;
+
+    @NotNull
+    @ApiModelProperty(name = "Appointment end date & time", example = "2021-05-25T11:00:00+01:00")
+    private OffsetDateTime appointmentEnd;
+
+    @NotNull
+    private AppointmentType type;
+
+    @NotNull
+    private OfficeLocation officeLocation;
+
+    @NotNull
+    @ApiModelProperty(name = "Appointment notes", example = "Some interesting notes about the appointment.")
+    private String notes;
+
+    @NotNull
+    @ApiModelProperty(name = "Provider")
+    private KeyValue provider;
+
+    @NotNull
+    @ApiModelProperty(name = "Team")
+    private KeyValue team;
+
+    @NotNull
+    @ApiModelProperty(name = "Staff")
+    private StaffHuman staff;
+
+    @ApiModelProperty(name = "Sensitive appointment flag", example = "true")
+    private Boolean sensitive;
+
+    @ApiModelProperty(name = "Outcome")
+    private AppointmentOutcome outcome;
+}

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentOutcome.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentOutcome.java
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.delius.data.api;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppointmentOutcome {
+    @NotNull
+    @ApiModelProperty(name = "Code", example = "ABC123")
+    private String code;
+
+    @NotNull
+    @ApiModelProperty(name = "Description", example = "Some appointment outcome")
+    private String description;
+
+    @ApiModelProperty(name = "Attended", example = "true")
+    private Boolean attended;
+
+    @ApiModelProperty(name = "Complied", example = "true")
+    private Boolean complied;
+
+    @ApiModelProperty(name = "Hours credited", example = "1.5")
+    private Double hoursCredited;
+}

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/KeyValue.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/KeyValue.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.delius.data.api;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,6 +11,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class KeyValue {
+    @ApiModelProperty(name = "Code", example = "ABC123", position = 1)
     private String code;
+
+    @ApiModelProperty(name = "Description", example = "Some description", position = 2)
     private String description;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/StaffHuman.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/StaffHuman.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.delius.data.api;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,6 +22,7 @@ public class StaffHuman {
     @ApiModelProperty(value = "Family name", example = "Hancock")
     private String surname;
 
+    @JsonProperty(access = Access.READ_ONLY)
     public boolean isUnallocated() {
         return Optional.ofNullable(code).map(c -> c.endsWith("U")).orElse(false);
     }

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Contact.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Contact.java
@@ -175,6 +175,6 @@ public class Contact {
     @LastModifiedDate
     private LocalDateTime lastUpdatedDateTime;
 
-
-
+    @Column(name = "SENSITIVE")
+    private String sensitive;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/service/TeamService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/TeamService.java
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.delius.jpa.standard.repository.LocalDeliveryUnitRe
 import uk.gov.justice.digital.delius.jpa.standard.repository.ProbationAreaRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.StaffTeamRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.TeamRepository;
+import uk.gov.justice.digital.delius.transformers.OfficeLocationTransformer;
 import uk.gov.justice.digital.delius.transformers.StaffTransformer;
 import uk.gov.justice.digital.delius.transformers.TeamTransformer;
 
@@ -61,16 +62,7 @@ public class TeamService {
 
         return team.getOfficeLocations()
             .stream()
-            .map(x -> OfficeLocation.builder()
-                .code(x.getCode())
-                .description(x.getDescription())
-                .buildingName(x.getBuildingName())
-                .buildingNumber(x.getBuildingNumber())
-                .streetName(x.getStreetName())
-                .townCity(x.getTownCity())
-                .county(x.getCounty())
-                .postcode(x.getPostcode())
-                .build())
+            .map(OfficeLocationTransformer::officeLocationOf)
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentTransformer.java
@@ -1,14 +1,26 @@
 package uk.gov.justice.digital.delius.transformers;
 
+import org.apache.commons.lang3.tuple.Pair;
 import uk.gov.justice.digital.delius.data.api.Appointment;
+import uk.gov.justice.digital.delius.data.api.AppointmentDetail;
+import uk.gov.justice.digital.delius.data.api.AppointmentOutcome;
+import uk.gov.justice.digital.delius.data.api.AppointmentType;
+import uk.gov.justice.digital.delius.data.api.AppointmentType.OrderType;
+import uk.gov.justice.digital.delius.data.api.AppointmentType.RequiredOptional;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Contact;
 import uk.gov.justice.digital.delius.jpa.standard.entity.ContactOutcomeType;
 import uk.gov.justice.digital.delius.jpa.standard.entity.ContactType;
 import uk.gov.justice.digital.delius.jpa.standard.entity.OfficeLocation;
+import uk.gov.justice.digital.delius.utils.DateConverter;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static uk.gov.justice.digital.delius.data.api.Appointment.Attended.ATTENDED;
 import static uk.gov.justice.digital.delius.data.api.Appointment.Attended.NOT_RECORDED;
@@ -17,69 +29,129 @@ import static uk.gov.justice.digital.delius.transformers.TypesTransformer.ynToBo
 
 public class AppointmentTransformer {
 
-    public static List<Appointment> appointmentsOf(List<uk.gov.justice.digital.delius.jpa.standard.entity.Contact> contacts) {
+    public static List<Appointment> appointmentsOf(List<Contact> contacts) {
         return contacts.stream()
                 .map(AppointmentTransformer::appointmentOf)
                 .collect(Collectors.toList());
     }
 
-    private static Appointment appointmentOf(uk.gov.justice.digital.delius.jpa.standard.entity.Contact contact) {
-        return Appointment.builder()
-                .eventId(ContactTransformer.eventIdOf(contact.getEvent()))
-                .alertActive(ynToBoolean(contact.getAlertActive()))
-                .appointmentDate(contact.getContactDate())
-                .appointmentStartTime(contact.getContactStartTime())
-                .appointmentEndTime(contact.getContactEndTime())
-                .appointmentId(contact.getContactId())
-                .appointmentOutcomeType(appointmentOutcomeTypeOf(contact.getContactOutcomeType()))
-                .appointmentType(appointmentTypeOf(contact.getContactType()))
-                .createdDateTime(contact.getCreatedDateTime())
-                .explanation(ContactTransformer.explanationOf(contact.getExplanation()))
-                .lastUpdatedDateTime(contact.getLastUpdatedDateTime())
-                .licenceCondition(ContactTransformer.licenceConditionOf(contact.getLicenceCondition()))
-                .linkedContactId(contact.getLinkedContactId())
-                .notes(contact.getNotes())
-                .nsi(ContactTransformer.nsiOf(contact.getNsi()))
-                .requirement(RequirementTransformer.requirementOf(contact.getRequirement()))
-                .probationArea(ContactTransformer.probationAreaOf(contact.getProbationArea()))
-                .providerEmployee(ContactTransformer.providerEmployeeOf(contact.getProviderEmployee()))
-                .officeLocation(officeLocationOf(contact.getOfficeLocation()))
-                .providerLocation(ContactTransformer.providerLocationOf(contact.getProviderLocation()))
-                .team(ContactTransformer.teamOf(contact.getTeam()))
-                .providerTeam(ContactTransformer.providerTeamOf(contact.getProviderTeam()))
-                .staff(ContactTransformer.staffOf(contact.getStaff()))
-                .hoursCredited(contact.getHoursCredited())
-                .visorContact(ynToBoolean(contact.getVisorContact()))
-                .attended(attendedOf(contact.getAttended()))
-                .complied(ynToBoolean(contact.getComplied()))
-                .uploadLinked(ynToBoolean(contact.getUploadLinked()))
-                .documentLinked(ynToBoolean(contact.getDocumentLinked()))
-                .build();
+    private static OffsetDateTime offsetDateTimeOf(LocalDate date, LocalTime time) {
+        return DateConverter.toOffsetDateTime(date.atTime(Optional.ofNullable(time).orElse(LocalTime.MIDNIGHT)));
     }
 
-    private static KeyValue appointmentOutcomeTypeOf(ContactOutcomeType contactOutcomeType) {
+    public static AppointmentDetail appointmentDetailOf(Contact contact) {
+        return AppointmentDetail.builder()
+            .appointmentId(contact.getContactId())
+            .appointmentStart(offsetDateTimeOf(contact.getContactDate(), contact.getContactStartTime()))
+            .appointmentEnd(offsetDateTimeOf(contact.getContactDate(), contact.getContactEndTime()))
+            .type(appointmentTypeOf(contact.getContactType()))
+            .officeLocation(Optional.ofNullable(contact.getOfficeLocation())
+                .map(OfficeLocationTransformer::officeLocationOf)
+                .orElse(null))
+            .notes(contact.getNotes())
+            .provider(ContactTransformer.probationAreaOf(contact.getProbationArea()))
+            .team(ContactTransformer.teamOf(contact.getTeam()))
+            .staff(ContactTransformer.staffOf(contact.getStaff()))
+            .sensitive(booleanOfYesNo(contact.getSensitive()))
+            .outcome(Optional.of(contact.getContactOutcomeType())
+                .map(type -> AppointmentOutcome.builder()
+                    .code(type.getCode())
+                    .description(type.getDescription())
+
+                    // the following fields are taken from the contact as they are de-normalised there during contact creation.
+                    // these copies seem to be the canonical source.
+                    .attended(booleanOfYesNo(contact.getAttended()))
+                    .complied(booleanOfYesNo(contact.getComplied()))
+                    .hoursCredited(contact.getHoursCredited())
+                    .build())
+                .orElse(null))
+            .build();
+    }
+
+    private static Boolean booleanOfYesNo(String flag) {
+        return Optional.ofNullable(flag).map(s -> s.equals("Y")).orElse(null);
+    }
+
+    public static AppointmentType appointmentTypeOf(ContactType type) {
+        return AppointmentType.builder()
+            .contactType(type.getCode())
+            .description(type.getDescription())
+            .requiresLocation(locationFlagToRequiredOptional(type.getLocationFlag()))
+            .orderTypes(Stream.of(
+                Pair.of(OrderType.CJA, type.getCjaOrderLevel()),
+                Pair.of(OrderType.LEGACY, type.getLegacyOrderLevel())
+            ).filter(x -> x.getValue().equals("Y")).map(Pair::getKey).collect(Collectors.toList()))
+            .build();
+    }
+
+    private static Appointment appointmentOf(Contact contact) {
+        return Appointment.builder()
+            .eventId(ContactTransformer.eventIdOf(contact.getEvent()))
+            .alertActive(ynToBoolean(contact.getAlertActive()))
+            .appointmentDate(contact.getContactDate())
+            .appointmentStartTime(contact.getContactStartTime())
+            .appointmentEndTime(contact.getContactEndTime())
+            .appointmentId(contact.getContactId())
+            .appointmentOutcomeType(keyValueOf(contact.getContactOutcomeType()))
+            .appointmentType(keyValueOf(contact.getContactType()))
+            .createdDateTime(contact.getCreatedDateTime())
+            .explanation(ContactTransformer.explanationOf(contact.getExplanation()))
+            .lastUpdatedDateTime(contact.getLastUpdatedDateTime())
+            .licenceCondition(ContactTransformer.licenceConditionOf(contact.getLicenceCondition()))
+            .linkedContactId(contact.getLinkedContactId())
+            .notes(contact.getNotes())
+            .nsi(ContactTransformer.nsiOf(contact.getNsi()))
+            .requirement(RequirementTransformer.requirementOf(contact.getRequirement()))
+            .probationArea(ContactTransformer.probationAreaOf(contact.getProbationArea()))
+            .providerEmployee(ContactTransformer.providerEmployeeOf(contact.getProviderEmployee()))
+            .officeLocation(keyValueOf(contact.getOfficeLocation()))
+            .providerLocation(ContactTransformer.providerLocationOf(contact.getProviderLocation()))
+            .team(ContactTransformer.teamOf(contact.getTeam()))
+            .providerTeam(ContactTransformer.providerTeamOf(contact.getProviderTeam()))
+            .staff(ContactTransformer.staffOf(contact.getStaff()))
+            .hoursCredited(contact.getHoursCredited())
+            .visorContact(ynToBoolean(contact.getVisorContact()))
+            .attended(attendedOf(contact.getAttended()))
+            .complied(ynToBoolean(contact.getComplied()))
+            .uploadLinked(ynToBoolean(contact.getUploadLinked()))
+            .documentLinked(ynToBoolean(contact.getDocumentLinked()))
+            .build();
+    }
+
+    private static KeyValue keyValueOf(ContactOutcomeType contactOutcomeType) {
         return Optional.ofNullable(contactOutcomeType).map(cot ->
-                KeyValue.builder()
-                        .code(cot.getCode())
-                        .description(cot.getDescription())
-                        .build()).orElse(null);
+            KeyValue.builder()
+                .code(cot.getCode())
+                .description(cot.getDescription())
+                .build()).orElse(null);
     }
 
     private static Appointment.Attended attendedOf(String yn) {
-       return Optional.ofNullable(ynToBoolean(yn)).map(flag -> flag ? ATTENDED : UNATTENDED).orElse(NOT_RECORDED);
+        return Optional.ofNullable(ynToBoolean(yn)).map(flag -> flag ? ATTENDED : UNATTENDED).orElse(NOT_RECORDED);
     }
 
-    private static KeyValue appointmentTypeOf(ContactType contactType) {
+    private static KeyValue keyValueOf(ContactType contactType) {
         return KeyValue.builder()
-                .code(contactType.getCode())
-                .description(contactType.getDescription())
-                .build();
+            .code(contactType.getCode())
+            .description(contactType.getDescription())
+            .build();
     }
 
-    private static KeyValue officeLocationOf(OfficeLocation officeLocation) {
+    private static KeyValue keyValueOf(OfficeLocation officeLocation) {
         return Optional.ofNullable(officeLocation).map(
-                pl -> KeyValue.builder().code(officeLocation.getCode()).description(officeLocation.getDescription()).build()
+            pl -> KeyValue.builder().code(officeLocation.getCode()).description(officeLocation.getDescription()).build()
         ).orElse(null);
     }
 
+    private static RequiredOptional locationFlagToRequiredOptional(String value) {
+        if (value == null) {
+            return null;
+        }
+        return switch (value) {
+            case "Y" -> RequiredOptional.REQUIRED;
+            case "B" -> RequiredOptional.OPTIONAL;
+            case "N" -> RequiredOptional.NOT_REQUIRED;
+            default -> throw new RuntimeException(String.format("Invalid location flag '%s'", value));
+        };
+    }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/OfficeLocationTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/OfficeLocationTransformer.java
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.delius.transformers;
+
+import uk.gov.justice.digital.delius.data.api.OfficeLocation;
+
+public class OfficeLocationTransformer {
+    public static OfficeLocation officeLocationOf(uk.gov.justice.digital.delius.jpa.standard.entity.OfficeLocation location) {
+        return OfficeLocation.builder()
+            .code(location.getCode())
+            .description(location.getDescription())
+            .buildingName(location.getBuildingName())
+            .buildingNumber(location.getBuildingNumber())
+            .streetName(location.getStreetName())
+            .townCity(location.getTownCity())
+            .county(location.getCounty())
+            .postcode(location.getPostcode())
+            .build();
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/delius/controller/secure/AppointmentControllerSecureTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/controller/secure/AppointmentControllerSecureTest.java
@@ -1,0 +1,118 @@
+package uk.gov.justice.digital.delius.controller.secure;
+
+import com.google.common.collect.ImmutableList;
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.delius.data.api.Appointment.Attended;
+import uk.gov.justice.digital.delius.data.api.AppointmentDetail;
+import uk.gov.justice.digital.delius.data.api.AppointmentOutcome;
+import uk.gov.justice.digital.delius.data.api.AppointmentType;
+import uk.gov.justice.digital.delius.data.api.AppointmentType.OrderType;
+import uk.gov.justice.digital.delius.data.api.AppointmentType.RequiredOptional;
+import uk.gov.justice.digital.delius.data.api.KeyValue;
+import uk.gov.justice.digital.delius.data.api.OfficeLocation;
+import uk.gov.justice.digital.delius.data.api.StaffHuman;
+import uk.gov.justice.digital.delius.jpa.filters.AppointmentFilter;
+import uk.gov.justice.digital.delius.service.AppointmentService;
+import uk.gov.justice.digital.delius.service.OffenderService;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AppointmentControllerSecureTest {
+    @Mock
+    private AppointmentService appointmentService;
+
+    @Mock
+    private OffenderService offenderService;
+
+    @Captor
+    private ArgumentCaptor<AppointmentFilter> filterCaptor;
+
+    @InjectMocks
+    private AppointmentControllerSecure subject;
+
+    @BeforeEach
+    public void setUp() {
+        RestAssuredMockMvc.standaloneSetup(subject);
+    }
+
+    @Test
+    public void gettingOffenderAppointmentsByCrn() {
+        when(offenderService.offenderIdOfCrn("CRN1")).thenReturn(Optional.of(1L));
+        when(appointmentService.appointmentDetailsFor(eq(1L), filterCaptor.capture()))
+            .thenReturn(ImmutableList.of(anAppointmentDetail(1L), anAppointmentDetail(2L)));
+
+        final var observed = given()
+            .when()
+            .get("/secure/offenders/crn/CRN1/appointments?from=2021-05-26&to=2021-06-02&attended=ATTENDED")
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .as(AppointmentDetail[].class);
+
+        assertThat(observed)
+            .hasSize(2)
+            .extracting("appointmentId", Long.class)
+            .containsExactly(1L, 2L);
+
+        assertThat(filterCaptor.getValue())
+            .isEqualTo(AppointmentFilter.builder()
+                .from(Optional.of(LocalDate.of(2021, 5, 26)))
+                .to(Optional.of(LocalDate.of(2021, 6, 2)))
+                .attended(Optional.of(Attended.ATTENDED))
+                .build());
+    }
+
+    private static AppointmentDetail anAppointmentDetail(Long id) {
+        return AppointmentDetail.builder()
+            .appointmentId(id)
+            .appointmentStart(OffsetDateTime.now())
+            .appointmentEnd(OffsetDateTime.now().plus(1, ChronoUnit.HOURS))
+            .type(AppointmentType.builder()
+                .contactType("ABC123")
+                .description("Some appointment type")
+                .requiresLocation(RequiredOptional.REQUIRED)
+                .orderTypes(List.of(OrderType.CJA))
+                .build())
+            .officeLocation(OfficeLocation.builder()
+                .code("ASP_ASH")
+                .description("Ashley House Approved Premises")
+                .buildingName("Ashley House")
+                .buildingNumber("14")
+                .streetName("Somerset Street")
+                .townCity("Bristol")
+                .county("Somerset")
+                .postcode("BS2 8NB")
+                .build())
+            .notes("Some important notes about this appointment.")
+            .provider(new KeyValue("P123", "Some provider"))
+            .team(new KeyValue("T123", "Some team"))
+            .staff(StaffHuman.builder().code("S123").forenames("Alex").surname("Haslehurst").build())
+            .sensitive(true)
+            .outcome(AppointmentOutcome.builder()
+                .code("ABC123")
+                .attended(true)
+                .complied(true)
+                .hoursCredited(1.5)
+                .build())
+            .build();
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
+++ b/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.CircumstanceSubType;
 import uk.gov.justice.digital.delius.jpa.standard.entity.CircumstanceType;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Contact;
 import uk.gov.justice.digital.delius.jpa.standard.entity.ContactDocument;
+import uk.gov.justice.digital.delius.jpa.standard.entity.ContactOutcomeType;
 import uk.gov.justice.digital.delius.jpa.standard.entity.ContactType;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Court;
 import uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance;
@@ -26,9 +27,11 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.District;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Document;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
 import uk.gov.justice.digital.delius.jpa.standard.entity.EventDocument;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Explanation;
 import uk.gov.justice.digital.delius.jpa.standard.entity.InstitutionalReport;
 import uk.gov.justice.digital.delius.jpa.standard.entity.InstitutionalReportDocument;
 import uk.gov.justice.digital.delius.jpa.standard.entity.KeyDate;
+import uk.gov.justice.digital.delius.jpa.standard.entity.LicenceCondition;
 import uk.gov.justice.digital.delius.jpa.standard.entity.LocalDeliveryUnit;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Nsi;
 import uk.gov.justice.digital.delius.jpa.standard.entity.NsiDocument;
@@ -56,6 +59,7 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.RecallReason;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Referral;
 import uk.gov.justice.digital.delius.jpa.standard.entity.ReferralDocument;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Release;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Requirement;
 import uk.gov.justice.digital.delius.jpa.standard.entity.ResponsibleOfficer;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Staff;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
@@ -531,7 +535,7 @@ public class EntityHelper {
         return document;
     }
 
-    private static Contact aContact(final Long eventId) {
+    public static Contact aContact(final Long eventId) {
         return Contact
                 .builder()
                 .event(anEvent(eventId))
@@ -544,15 +548,18 @@ public class EntityHelper {
                 .build();
     }
 
-    private static Contact aContact() {
+    public static Contact aContact() {
         return Contact
                 .builder()
+                .contactId(1L)
                 .contactDate(LocalDate.now())
                 .contactStartTime(LocalTime.now())
-                .contactType(ContactType
-                        .builder()
-                        .description("Offered Female OM - Accepted")
-                        .build())
+                .contactOutcomeType(aContactOutcomeType())
+                .contactType(aContactType())
+                .explanation(anExplanation())
+                .probationArea(aProbationArea())
+                .team(aTeam())
+                .staff(aStaff())
                 .build();
 
     }
@@ -829,6 +836,8 @@ public class EntityHelper {
                 .code("EPOMEX")
                 .description("Prison Offender Manager - External Transfer")
                 .alertFlag("N")
+                .cjaOrderLevel("Y")
+                .legacyOrderLevel("Y")
                 .build();
     }
 
@@ -875,5 +884,22 @@ public class EntityHelper {
                 .team(aTeam())
                 .nsiManagerId(99L)
                 .build();
+    }
+
+    public static ContactOutcomeType aContactOutcomeType() {
+        return ContactOutcomeType.builder()
+            .contactOutcomeTypeId(100L)
+            .code("CO1")
+            .description("Some contact outcome type")
+            .build();
+    }
+
+    private static Explanation anExplanation() {
+        return Explanation
+            .builder()
+            .explanationId(101L)
+            .code("E1")
+            .description("Some explanation")
+            .build();
     }
 }

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AppointmentAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AppointmentAPITest.java
@@ -1,0 +1,84 @@
+package uk.gov.justice.digital.delius.controller.secure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.justice.digital.delius.data.api.AppointmentDetail;
+import uk.gov.justice.digital.delius.data.api.AppointmentType.OrderType;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(SpringExtension.class)
+public class AppointmentAPITest extends IntegrationTestBase {
+
+    @Test
+    public void gettingOffenderAppointmentsByCrn() {
+
+        final var appointments = given()
+            .auth().oauth2(tokenWithRoleCommunity())
+            .when()
+            .get("/offenders/crn/X320741/appointments")
+            .then()
+            .assertThat()
+            .statusCode(HttpStatus.OK.value())
+            .body("size()", greaterThan(0))
+            .root("find { it.appointmentId == 2502719240 }")
+            .body("appointmentStart", equalTo("2020-09-04T00:00:00+01:00"))
+            .body("appointmentEnd", equalTo("2020-09-04T00:00:00+01:00"))
+            .body("type.contactType", equalTo("C084"))
+            .body("type.description", equalTo("3 Way Meeting (NS)"))
+            .body("type.requiresLocation", equalTo("REQUIRED"))
+            .body("type.orderTypes", equalTo(List.of("CJA", "LEGACY")))
+            .body("officeLocation", equalTo(null))
+            .body("notes", equalTo("The notes field"))
+            .body("provider.code", equalTo("N02"))
+            .body("provider.description", equalTo("NPS North East"))
+            .body("team.code", equalTo("N02SP5"))
+            .body("team.description", equalTo("BRADFORD\\BULLS SP"))
+            .body("staff.code", equalTo("N02SP5U"))
+            .body("staff.forenames", equalTo("Unallocated"))
+            .body("staff.surname", equalTo("Staff"))
+            .body("staff.unallocated", equalTo(true))
+            .body("sensitive", equalTo(null))
+            .body("outcome.code", equalTo("APPK"))
+            .body("outcome.description", equalTo("Appointment Kept"))
+            .body("outcome.attended", equalTo(true))
+            .body("outcome.complied", equalTo(null))
+            .body("outcome.hoursCredited", equalTo(null))
+            .extract()
+            .body()
+            .as(AppointmentDetail[].class);
+
+        assertThat(appointments).hasSize(1);
+    }
+
+    @Test
+    public void attemptingToGetOffenderAppointmentsByCrnButForbidden() {
+        given()
+            .auth().oauth2(createJwt("SOME_OTHER_ROLE"))
+            .when()
+            .get("/offenders/crn/X320741/appointments")
+            .then()
+            .assertThat()
+            .statusCode(HttpStatus.FORBIDDEN.value());
+    }
+
+    @Test
+    public void attemptingToGetOffenderAppointmentsByCrnButMissing() {
+        given()
+            .auth().oauth2(tokenWithRoleCommunity())
+            .when()
+            .get("/offenders/crn/A999999/appointments")
+            .then()
+            .assertThat()
+            .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+}


### PR DESCRIPTION
New API for getting offender appointments by CRN. Uses same URL structure as existing, /api endpoint.

![image](https://user-images.githubusercontent.com/4509102/119650985-5fc46400-be1c-11eb-8de5-19d4729ea57b.png)
