### PR TITLE
DAPI-177 When searching for a matching NSI using existing criteria, and if multiple are found, then use ReferralId (URN) to find a unique one.

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessAppointmentCreateRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessAppointmentCreateRequest.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 @Data
 @Builder
@@ -23,6 +24,9 @@ public class ContextlessAppointmentCreateRequest {
     @NotNull
     @ApiModelProperty(required = true)
     private OffsetDateTime referralStart;
+
+    @ApiModelProperty
+    private UUID referralId;
 
     // Fields used for creating the appointment
     @NotNull

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessNotificationCreateRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessNotificationCreateRequest.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 @Data
 @Builder
@@ -23,6 +24,9 @@ public class ContextlessNotificationCreateRequest {
     @NotNull
     @ApiModelProperty(required = true)
     private OffsetDateTime referralStart;
+
+    @ApiModelProperty
+    private UUID referralId;
 
     // Fields used for creating the contact
     @NotNull

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessReferralEndRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessReferralEndRequest.java
@@ -10,6 +10,7 @@ import lombok.With;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 @Data
 @With
@@ -26,6 +27,9 @@ public class ContextlessReferralEndRequest {
     @NotNull
     @ApiModelProperty(required = true)
     private OffsetDateTime startedAt;
+
+    @ApiModelProperty
+    private UUID referralId;
 
     // Fields used for ending the referral
     @NotNull

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessReferralStartRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessReferralStartRequest.java
@@ -10,6 +10,7 @@ import lombok.With;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 @Data
 @With
@@ -30,6 +31,9 @@ public class ContextlessReferralStartRequest {
     @NotNull
     @ApiModelProperty(required = true)
     private Long sentenceId;
+
+    @ApiModelProperty
+    private UUID referralId;
 
     @NotNull
     private String notes;

--- a/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
@@ -76,7 +76,7 @@ public class AppointmentService {
     public AppointmentCreateResponse createAppointment(String crn, Long sentenceId, String contextName, ContextlessAppointmentCreateRequest contextlessRequest) {
 
         final var context = getContext(contextName);
-        final var request = referralService.getExistingMatchingNsi(crn, contextName, sentenceId, contextlessRequest.getContractType(), contextlessRequest.getReferralStart())
+        final var request = referralService.getExistingMatchingNsi(crn, contextName, sentenceId, contextlessRequest.getContractType(), contextlessRequest.getReferralStart(), contextlessRequest.getReferralId())
             .map(existingNsi -> appointmentOf(contextlessRequest, existingNsi, context))
             .orElseThrow(() -> new BadRequestException(format("Cannot find NSI for CRN: %s Sentence: %d and ContractType %s", crn, sentenceId, contextlessRequest.getContractType())));
 

--- a/src/main/java/uk/gov/justice/digital/delius/service/NotificationService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/NotificationService.java
@@ -43,7 +43,7 @@ public class NotificationService {
     public NotificationResponse notifyContact(final String crn, final Long sentenceId, final String contextName, final ContextlessNotificationCreateRequest contextlessRequest) {
 
         final var context = getContext(contextName);
-        final var request = referralService.getExistingMatchingNsi(crn, contextName, sentenceId, contextlessRequest.getContractType(), contextlessRequest.getReferralStart())
+        final var request = referralService.getExistingMatchingNsi(crn, contextName, sentenceId, contextlessRequest.getContractType(), contextlessRequest.getReferralStart(), contextlessRequest.getReferralId())
             .map(nsi -> notificationOf(contextlessRequest, nsi, context))
             .orElseThrow(() -> new BadRequestException(format("Cannot find NSI for CRN: %s Sentence: %d and ContractType %s", crn, sentenceId, contextlessRequest.getContractType())));
 

--- a/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
@@ -18,15 +18,21 @@ import uk.gov.justice.digital.delius.data.api.deliusapi.NewNsi;
 import uk.gov.justice.digital.delius.data.api.deliusapi.NewNsiManager;
 import uk.gov.justice.digital.delius.jpa.standard.repository.ContactRepository;
 import uk.gov.justice.digital.delius.transformers.NsiPatchRequestTransformer;
+import uk.gov.justice.digital.delius.transformers.ReferralTransformer;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
+import javax.validation.constraints.NotNull;
 
 import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
+import static uk.gov.justice.digital.delius.transformers.ReferralTransformer.transformReferralIdToUrn;
 import static uk.gov.justice.digital.delius.utils.DateConverter.toLondonLocalDate;
 import static uk.gov.justice.digital.delius.utils.DateConverter.toLondonLocalDateTime;
 
@@ -57,35 +63,32 @@ public class ReferralService {
         var nsiMapping = context.getNsiMapping();
 
         Optional<Long> requirementId = getRequirement(crn, referralStart.getSentenceId(), context);
-        var existingNsi = getExistingMatchingNsi(crn, contextName, referralStart.getSentenceId(),
-            referralStart.getContractType(), referralStart.getStartedAt());
 
-        return ReferralStartResponse.builder().nsiId(existingNsi.map(Nsi::getNsiId).orElseGet(() -> {
-            var newNsiRequest = NewNsi.builder()
-                .type(getNsiType(nsiMapping, referralStart.getContractType()))
-                .offenderCrn(crn)
-                .eventId(referralStart.getSentenceId())
-                .requirementId(requirementId.orElse(null))
-                .referralDate(toLondonLocalDate(referralStart.getStartedAt()))
-                .startDate(toLondonLocalDate(referralStart.getStartedAt()))
-                .status(nsiMapping.getNsiStatus())
-                .statusDate(toLondonLocalDateTime(referralStart.getStartedAt()))
-                .notes(referralStart.getNotes())
-                .intendedProvider(context.getProviderCode())
-                .manager(NewNsiManager.builder()
-                    .staff(context.getStaffCode())
-                    .team(context.getTeamCode())
-                    .provider(context.getProviderCode())
-                    .build()).build();
+        final var newNsiRequest = NewNsi.builder()
+            .type(getNsiType(nsiMapping, referralStart.getContractType()))
+            .offenderCrn(crn)
+            .eventId(referralStart.getSentenceId())
+            .requirementId(requirementId.orElse(null))
+            .referralDate(toLondonLocalDate(referralStart.getStartedAt()))
+            .startDate(toLondonLocalDate(referralStart.getStartedAt()))
+            .status(nsiMapping.getNsiStatus())
+            .statusDate(toLondonLocalDateTime(referralStart.getStartedAt()))
+            .notes(ReferralTransformer.prefixReferralStartNotesWithUrn(referralStart.getNotes(), referralStart.getReferralId()))
+            .intendedProvider(context.getProviderCode())
+            .manager(NewNsiManager.builder()
+                .staff(context.getStaffCode())
+                .team(context.getTeamCode())
+                .provider(context.getProviderCode())
+                .build()).build();
 
-            return deliusApiClient.createNewNsi(newNsiRequest).getId();
-        })).build();
+        final var newNsi = deliusApiClient.createNewNsi(newNsiRequest);
+        return ReferralStartResponse.builder().nsiId(newNsi.getId()).build();
     }
 
     @Transactional
     public ReferralEndResponse endNsiReferral(final String crn, final String contextName, final ContextlessReferralEndRequest request) {
 
-        final var nsi = getExistingMatchingNsi(crn, contextName, request.getSentenceId(), request.getContractType(), request.getStartedAt())
+        final var nsi = getExistingMatchingNsi(crn, contextName, request.getSentenceId(), request.getContractType(), request.getStartedAt(), request.getReferralId())
             .orElseThrow(() -> new BadRequestException(format("Cannot find NSI for CRN: %s Sentence: %d and ContractType %s", crn, request.getSentenceId(), request.getContractType())));
 
         final var offenderId = offenderService.offenderIdOfCrn(crn)
@@ -98,11 +101,12 @@ public class ReferralService {
         return new ReferralEndResponse(nsi.getNsiId());
     }
 
-    public Optional<Nsi> getExistingMatchingNsi(final String crn,
-                                                final String contextName,
-                                                final Long sentenceId,
-                                                final String contractType,
-                                                final OffsetDateTime startedAt) {
+    public Optional<Nsi> getExistingMatchingNsi(@NotNull final String crn,
+                                                @NotNull final String contextName,
+                                                @NotNull final Long sentenceId,
+                                                @NotNull final String contractType,
+                                                @NotNull final OffsetDateTime startedAt,
+                                                @NotNull final UUID referralId) {
         // determine if there is an existing suitable NSI
         var offenderId = offenderService.offenderIdOfCrn(crn).orElseThrow(() -> new BadRequestException("Offender CRN not found"));
 
@@ -112,11 +116,11 @@ public class ReferralService {
         var existingNsis = nsiService.getNsiByCodes(offenderId, sentenceId, Collections.singletonList(getNsiType(nsiMapping, contractType)))
             .map(wrapper -> wrapper.getNsis().stream()
                 // eventID, offenderID, nsi type are handled in the NSI service
-                .filter(nsi -> Optional.ofNullable(nsi.getReferralDate()).map(n -> n.equals(toLondonLocalDate(startedAt))).orElse(false))
-                .filter(nsi -> Optional.ofNullable(nsi.getNsiStatus()).map(n -> n.getCode().equals(nsiMapping.getNsiStatus())).orElse(false))
+                .filter(nsi -> ofNullable(nsi.getReferralDate()).map(n -> n.equals(toLondonLocalDate(startedAt))).orElse(false))
+                .filter(nsi -> ofNullable(nsi.getNsiStatus()).map(n -> n.getCode().equals(nsiMapping.getNsiStatus())).orElse(false))
                 .filter(nsi -> Objects.isNull(nsi.getNsiOutcome()))
-                .filter(nsi -> Optional.ofNullable(nsi.getIntendedProvider()).map(n -> n.getCode().equals(context.getProviderCode())).orElse(false))
-                .filter(nsi -> Optional.ofNullable(nsi.getNsiManagers()).map(n -> n.stream().anyMatch(
+                .filter(nsi -> ofNullable(nsi.getIntendedProvider()).map(n -> n.getCode().equals(context.getProviderCode())).orElse(false))
+                .filter(nsi -> ofNullable(nsi.getNsiManagers()).map(n -> n.stream().anyMatch(
                     nsiManager -> nsiManager.getStaff().getStaffCode().equals(context.getStaffCode())
                         && nsiManager.getTeam().getCode().equals(context.getTeamCode())
                         && nsiManager.getProbationArea().getCode().equals(context.getProviderCode())
@@ -126,10 +130,30 @@ public class ReferralService {
             ).orElse(Collections.emptyList());
 
         if (existingNsis.size() > 1) {
-            throw new ConflictingRequestException("Multiple existing matching NSIs found");
+            existingNsis = findExistingNsiByReferralUrnIfSupplied(existingNsis, referralId);
         }
         return existingNsis.stream().findFirst();
     }
+
+    @NotNull
+    List<Nsi> findExistingNsiByReferralUrnIfSupplied(@NotNull final List<Nsi> existingNsis, final UUID referralId) {
+        final var filteredNsis = ofNullable(referralId)
+            .map(id -> filterExistingNsisByReferralUrn(existingNsis, id))
+            .orElse(existingNsis);
+
+        if (filteredNsis.size() > 1) {
+            throw new ConflictingRequestException("Multiple existing matching NSIs found");
+        }
+        return filteredNsis;
+    }
+
+    @NotNull
+    List<Nsi> filterExistingNsisByReferralUrn(@NotNull final List<Nsi> existingNsis, @NotNull final UUID referralId) {
+        final var referralUrn = transformReferralIdToUrn(referralId).toLowerCase();
+        return existingNsis.stream()
+            .filter(nsi -> nsi.getNotes().toLowerCase().startsWith(referralUrn))
+            .toList();
+   }
 
     void deleteFutureAppointments(Long offenderId, String contextName, Nsi nsi) {
 
@@ -150,14 +174,14 @@ public class ReferralService {
     }
 
     String getNsiType(final NsiMapping nsiMapping, final String contactType) {
-        return Optional.ofNullable(nsiMapping.getContractTypeToNsiType().get(contactType)).orElseThrow(
+        return ofNullable(nsiMapping.getContractTypeToNsiType().get(contactType)).orElseThrow(
             () -> new IllegalArgumentException("Nsi Type mapping from contractType does not exist for: " + contactType)
         );
     }
 
     IntegrationContext getContext(String contextName) {
         var context = deliusIntegrationContextConfig.getIntegrationContexts().get(contextName);
-        return Optional.ofNullable(context).orElseThrow(
+        return ofNullable(context).orElseThrow(
             () -> new IllegalArgumentException("IntegrationContext does not exist for: " + contextName)
         );
     }

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/ReferralTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/ReferralTransformer.java
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.delius.transformers;
+
+import java.util.UUID;
+
+public class ReferralTransformer {
+    private ReferralTransformer() {
+        // static helpers only
+    }
+
+    public static String prefixReferralStartNotesWithUrn(final String notes, final UUID referralId) {
+        if (referralId == null) {
+            return notes;
+        }
+        return transformReferralIdToUrn(referralId) + "\n" + notes;
+    }
+
+    public static String transformReferralIdToUrn(final UUID referralId) {
+        return "urn:hmpps:interventions-referral:" + referralId.toString();
+    }
+}

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/ReferralTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/ReferralTransformerTest.java
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.delius.transformers;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static uk.gov.justice.digital.delius.transformers.ReferralTransformer.prefixReferralStartNotesWithUrn;
+import static uk.gov.justice.digital.delius.transformers.ReferralTransformer.transformReferralIdToUrn;
+
+class ReferralTransformerTest {
+
+    @Test
+    public void generatesAUrnFromAReferralId() {
+
+        final var referralId = UUID.randomUUID();
+        assertThat(transformReferralIdToUrn(referralId))
+            .isEqualTo("urn:hmpps:interventions-referral:" + referralId.toString());
+    }
+
+    @Test
+    public void prefixesNotesWithReferralIdUrn() {
+
+        final var referralId = UUID.randomUUID();
+        assertThat(prefixReferralStartNotesWithUrn("some notes", referralId))
+            .isEqualTo("urn:hmpps:interventions-referral:" + referralId.toString() + "\nsome notes");
+    }
+
+    @Test
+    public void doesNotPrefixesNotesWithUrn_WhenReferralIdNotSupport() {
+
+        final var referralId = UUID.randomUUID();
+        assertThat(prefixReferralStartNotesWithUrn("some notes", null))
+            .isEqualTo("some notes");
+    }
+}

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/ReferralAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/ReferralAPITest.java
@@ -75,32 +75,6 @@ public class ReferralAPITest extends IntegrationTestBase {
     }
 
     @Test
-    public void shouldReturnOKWhenStartingAReferralWithAnExistingNsi() {
-
-        deliusApiMockServer.stubPostNsiToDeliusApi();
-        deliusApiMockServer.stubDeleteContactToDeliusApi();
-
-        final var token = createJwt("bob", Collections.singletonList("ROLE_COMMUNITY_INTERVENTIONS_UPDATE"));
-
-        final var response = given()
-            .when()
-            .auth().oauth2(token)
-            .contentType(String.valueOf(ContentType.APPLICATION_JSON))
-            .body(writeValueAsString(ContextlessReferralStartRequest
-                .builder()
-                .startedAt(OffsetDateTime.of(2019,9,2, 12, 0, 1, 2, ZoneOffset.UTC))
-                .contractType("ACC")
-                .sentenceId(2500295345L)
-                .notes("A test note")
-                .build()))
-            .post("offenders/crn/X320741/referral/start/context/commissioned-rehabilitation-services")
-            .then()
-            .assertThat()
-            .statusCode(HttpStatus.OK.value())
-            .body("nsiId", equalTo(2500018596L));
-    }
-
-    @Test
     public void shouldReturnOKWhenEndingAReferral() {
 
         deliusApiMockServer.stubPatchNsiToDeliusApi();


### PR DESCRIPTION
**What does this pull request do?**
There is an edge case  when more that one Referral may be created in R&M that appear to cover the same Intervention, i.e. are for the same CRN and Sentence, cover the same Contract Type (e.g. Personal Wellbeing) and start on the same date. Prior to this change they would both be tied to the same NSI in Delius. After this change, each one results in its own NSI using the ReferralId (in the form of an URN) to distinguish them ... should an initial search return multiple. The belief is this case is rare and so the additional filtering by URN will not come into play most of the time. There is no designated field for the URN to reside in so it is held in the Notes as an initial entry. The Notes field is never replaced, only appended too. 

Specifically the following changes:
1. The Interventions ReferralId is stored as a URN against each NSI created
2. The URN is used as a last resort when finding the corresponding NSI in Delius, when multiple NIS's exist for the same CRN and Sentence, Contract Type and on the same Referral Sent Date.

**What is the intent behind these changes?**
To ensure that should multiple referrals be created which appear to be the same, they can be accounted for correctly by the calculations carried out in Delius.

**Breaking Changes?**
None