### PR TITLE
Update 'user access' endpoints to be more flexible 

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
@@ -614,6 +614,7 @@ public class OffendersResource {
             @ApiResponse(code = 403, message = "User is restricted from access to offender", response = AccessLimitation.class),
             @ApiResponse(code = 404, message = "No such offender, or no such User (see body for detail)")
     })
+    @PreAuthorize("hasRole('ROLE_COMMUNITY') || hasRole('ROLE_PROBATION')")
     public ResponseEntity<AccessLimitation> checkUserAccessByCrn(
             final @PathVariable("crn") String crn) {
         return offenderService.getOffenderByCrn(crn)

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
@@ -622,7 +622,19 @@ public class OffendersResource {
             .orElse(new ResponseEntity<>(NOT_FOUND));
     }
 
-
+    @ApiOperation(value = "Reveals if the specified user can access details about the supplied offender", tags = "Authentication and users")
+    @RequestMapping(value = "/offenders/crn/{crn}/user/{username}/userAccess", method = RequestMethod.GET)
+    @ApiResponses(value = {
+        @ApiResponse(code = 403, message = "User is restricted from access to offender", response = AccessLimitation.class),
+        @ApiResponse(code = 404, message = "No such offender, or no such User (see body for detail)")
+    })
+    public ResponseEntity<AccessLimitation> checkUserAccessByCrn(
+        final @PathVariable("crn") String crn,
+        final @PathVariable("username") String username) {
+        return offenderService.getOffenderByCrn(crn)
+            .map(offender -> accessLimitationResponseEntityOf(offender, username))
+            .orElse(new ResponseEntity<>(NOT_FOUND));
+    }
 
     @RequestMapping(value = "/offenders/crn/{crn}/probationStatus", method = RequestMethod.GET)
     @ApiResponses(value = {
@@ -636,9 +648,11 @@ public class OffendersResource {
     }
 
     private ResponseEntity<AccessLimitation> accessLimitationResponseEntityOf(final OffenderDetail offender) {
+        return accessLimitationResponseEntityOf(offender, currentUserSupplier.username().orElseThrow());
+    }
 
-        final var accessLimitation = userService.accessLimitationOf(currentUserSupplier.username().orElseThrow(), offender);
-
+    private ResponseEntity<AccessLimitation> accessLimitationResponseEntityOf(final OffenderDetail offender, final String username) {
+        final var accessLimitation = userService.accessLimitationOf(username, offender);
         return new ResponseEntity<>(accessLimitation, (accessLimitation.isUserExcluded() || accessLimitation.isUserRestricted()) ? FORBIDDEN : OK);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
@@ -614,7 +614,7 @@ public class OffendersResource {
             @ApiResponse(code = 403, message = "User is restricted from access to offender", response = AccessLimitation.class),
             @ApiResponse(code = 404, message = "No such offender, or no such User (see body for detail)")
     })
-    @PreAuthorize("hasRole('ROLE_COMMUNITY') || hasRole('ROLE_PROBATION')")
+    @PreAuthorize("hasAnyRole('ROLE_COMMUNITY', 'ROLE_PROBATION')")
     public ResponseEntity<AccessLimitation> checkUserAccessByCrn(
             final @PathVariable("crn") String crn) {
         return offenderService.getOffenderByCrn(crn)


### PR DESCRIPTION
this change has two parts

1. change the permissions on the existing `/offenders/crn/{crn}/userAccess` endpoint to allow it to be called with delius user tokens (ROLE_PROBATION).
2. add a new endpoint which allows specifying the username in the url to allow regular client credentials granted tokens the ability to use the endpoint without requesting a new 'username' scoped token.