### PR TITLE
DT-2606 Add attributes on Nsi when recall to indicate outcome and status

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/Nsi.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/Nsi.java
@@ -1,14 +1,17 @@
 package uk.gov.justice.digital.delius.data.api;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.With;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Data
 @Builder
@@ -32,4 +35,88 @@ public class Nsi {
     private String notes;
     private ProbationArea intendedProvider;
     private Boolean active;
+
+    static <E extends Enum<E>> E valueOf(E defaultValue, String code) {
+        try {
+            return Enum.valueOf(defaultValue.getDeclaringClass(), code);
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    @ApiModelProperty("present only for recalls, convenience property indicating this resulted in a recall")
+    public Boolean isOutcomeRecall() {
+        return Optional.ofNullable(asOutcomeType()).map(OutcomeType::getIsOutcomeRecall).orElse(null);
+    }
+
+    @ApiModelProperty("present only for recalls, convenience property indicating the recall was never accepted")
+    public Boolean isRecallRejectedOrWithdrawn() {
+        return Optional.ofNullable(asStatus())
+            .map(Status::getIsRejectedOrWithdrawn)
+            .map(rejectedOrWithdrawn -> {
+                if (rejectedOrWithdrawn) {
+                    return true;
+                } else {
+                    return Optional
+                        .ofNullable(asOutcomeType())
+                        .map(OutcomeType::getIsOutcomeRejectedOrWithdrawn)
+                        .orElse(false);
+                }
+            }).orElse(null);
+    }
+
+    private OutcomeType asOutcomeType() {
+        return Optional
+            .ofNullable(nsiOutcome)
+            .map(outcome -> valueOf(OutcomeType.UNKNOWN, outcome.getCode()))
+            .orElse(null);
+    }
+
+    private Status asStatus() {
+        return Optional.ofNullable(nsiStatus).map(status -> valueOf(Status.UNKNOWN, status.getCode())).orElse(null);
+    }
+
+    @Getter
+    enum OutcomeType {
+        REC01("Fixed Term Recall", true, false),
+        REC02("Standard Term Recall", true, false),
+        REC03("Recall Rejected by NPS", false, true),
+        REC04("Recall Rejected by PPCS", false, true),
+        REC05("Request Withdrawn by OM", false, true),
+        UNKNOWN("No recall matching code", null, null);
+
+        private final String description;
+        private final Boolean isOutcomeRejectedOrWithdrawn;
+        private final Boolean isOutcomeRecall;
+
+        OutcomeType(String description, Boolean isOutcomeRecall, Boolean isOutcomeRejectedOrWithdrawn) {
+            this.description = description;
+            this.isOutcomeRecall = isOutcomeRecall;
+            this.isOutcomeRejectedOrWithdrawn = isOutcomeRejectedOrWithdrawn;
+        }
+    }
+
+    @Getter
+    enum Status {
+        REC01("Recall Initiated", false),
+        REC02("Part A Completed by NPS/CRC OM", false),
+        REC03("Part A Countersigned by NPS/CRC Manager", false),
+        REC04("NPS Recall Endorsed by Senior Manager", false),
+        REC05("NPS Recall Rejected by Senior Manager", true),
+        REC06("Recall Referred to NPS", false),
+        REC07("PPCS Recall Decision Received", false),
+        REC08("Recall Submitted to PPCS", false),
+        REC09("Out-of-hours Recall Instigated", false),
+        REC10("Request Withdrawn by OM", true),
+        UNKNOWN("No recall matching code", null);
+
+        private final String description;
+        private final Boolean isRejectedOrWithdrawn;
+
+        Status(String description, Boolean isRejectedOrWithdrawn) {
+            this.description = description;
+            this.isRejectedOrWithdrawn = isRejectedOrWithdrawn;
+        }
+    }
 }
+

--- a/src/test/java/uk/gov/justice/digital/delius/data/api/NsiTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/data/api/NsiTest.java
@@ -1,0 +1,115 @@
+package uk.gov.justice.digital.delius.data.api;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.justice.digital.delius.data.api.Nsi.OutcomeType;
+import uk.gov.justice.digital.delius.data.api.Nsi.Status;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NsiTest {
+    @Nested
+    class IsOutcomeRecall {
+        @SuppressWarnings("unused")
+        private static Stream<Arguments> outcomeMap() {
+            return Stream.of(
+                Arguments.of(OutcomeType.REC01, true),
+                Arguments.of(OutcomeType.REC02, true),
+                Arguments.of(OutcomeType.REC03, false),
+                Arguments.of(OutcomeType.REC04, false),
+                Arguments.of(OutcomeType.REC05, false)
+            );
+        }
+
+        @ParameterizedTest
+        @DisplayName("outcome is recalled")
+        @MethodSource("outcomeMap")
+        void outcomeIsRecalled(OutcomeType outcomeTypeCode, boolean isRecall) {
+            final var nsi = Nsi.builder().nsiOutcome(KeyValue.builder().code(outcomeTypeCode.name()).build()).build();
+            assertThat(nsi.isOutcomeRecall()).isEqualTo(isRecall);
+        }
+
+        @Test
+        @DisplayName("outcome is null when no outcome")
+        void outcomeIsNullWhenNoOutcome() {
+            final var nsi = Nsi.builder().nsiOutcome(null).build();
+            assertThat(nsi.isOutcomeRecall()).isNull();
+        }
+
+        @Test
+        @DisplayName("outcome is null when code is not recognisable recall outcome")
+        void outcomeIsNotRecallWhenCodeIsNotRecognisable() {
+            final var nsi = Nsi.builder().nsiOutcome(KeyValue.builder().code("BANANA").build()).build();
+            assertThat(nsi.isOutcomeRecall()).isNull();
+        }
+    }
+
+    @Nested
+    class IsRecallRejectedOrWithdrawn {
+        @SuppressWarnings("unused")
+        private static Stream<Arguments> outcomeMap() {
+            return Stream.of(
+                Arguments.of(OutcomeType.REC01, false),
+                Arguments.of(OutcomeType.REC02, false),
+                Arguments.of(OutcomeType.REC03, true),
+                Arguments.of(OutcomeType.REC04, true),
+                Arguments.of(OutcomeType.REC05, true)
+            );
+        }
+
+        @SuppressWarnings("unused")
+        private static Stream<Arguments> statusMap() {
+            return Stream.of(
+                Arguments.of(Status.REC01, false),
+                Arguments.of(Status.REC02, false),
+                Arguments.of(Status.REC03, false),
+                Arguments.of(Status.REC04, false),
+                Arguments.of(Status.REC05, true),
+                Arguments.of(Status.REC06, false),
+                Arguments.of(Status.REC07, false),
+                Arguments.of(Status.REC08, false),
+                Arguments.of(Status.REC09, false),
+                Arguments.of(Status.REC10, true)
+            );
+        }
+
+        @ParameterizedTest
+        @DisplayName("is rejected or withdrawn with no outcome is recalled")
+        @MethodSource("statusMap")
+        void isRejectedOrWithdrawnWithNoOutcome(Status status, boolean isRejectedOrWithdrawn) {
+            final var nsi = Nsi
+                .builder()
+                .nsiOutcome(null)
+                .nsiStatus(KeyValue.builder().code(status.name()).build())
+                .build();
+            assertThat(nsi.isRecallRejectedOrWithdrawn()).isEqualTo(isRejectedOrWithdrawn);
+        }
+
+        @ParameterizedTest
+        @DisplayName("is rejected or withdrawn with outcome present where status is not rejected")
+        @MethodSource("outcomeMap")
+        void isRejectedOrWithdrawnWithOutcomePresent(OutcomeType outcomeTypeCode, boolean isRejectedOrWithdrawn) {
+            assertThat(Status.REC01.getIsRejectedOrWithdrawn()).isFalse();
+
+            final var nsi = Nsi
+                .builder()
+                .nsiStatus(KeyValue.builder().code(Status.REC01.name()).build())
+                .nsiOutcome(KeyValue.builder().code(outcomeTypeCode.name()).build())
+                .build();
+            assertThat(nsi.isRecallRejectedOrWithdrawn()).isEqualTo(isRejectedOrWithdrawn);
+        }
+
+        @Test
+        @DisplayName("is rejected or withdrawn is null when status is not a recall status")
+        void isRejectedOrWithdrawnIsNullWhenStatusIsNotARecallStatus() {
+            final var nsi = Nsi.builder().nsiStatus(KeyValue.builder().code("BANANA").build()).build();
+            assertThat(nsi.isRecallRejectedOrWithdrawn()).isNull();
+        }
+    }
+}

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderNsisByCrn.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderNsisByCrn.java
@@ -63,6 +63,8 @@ public class OffendersResource_getOffenderNsisByCrn extends IntegrationTestBase 
         assertThat(nsi.getNsiManagers().get(0).getTeam().getCode()).isEqualTo("N02UAT");
         assertThat(nsi.getNsiManagers().get(0).getStaff().getStaff().getForenames()).isEqualTo("Unallocated Staff(N02)");
         assertThat(nsi.getNsiManagers().get(0).getStaff().getStaff().getSurname()).isEqualTo("Staff");
+        assertThat(nsi.isRecallRejectedOrWithdrawn()).isNull();
+        assertThat(nsi.isOutcomeRecall()).isNull();
     }
 
     @Test

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getRecallNsisForOffenderByNomsNumberAndActiveConvictions.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getRecallNsisForOffenderByNomsNumberAndActiveConvictions.java
@@ -58,9 +58,13 @@ public class OffendersResource_getRecallNsisForOffenderByNomsNumberAndActiveConv
             .body("nsiType.code", recallNoOutcome, equalTo("REC"))
             .body("nsiOutcome", recallNoOutcome, nullValue())
             .body("nsiStatus.description", recallNoOutcome, equalTo("Recall Initiated"))
+            .body("outcomeRecall", recallNoOutcome, nullValue())
+            .body("recallRejectedOrWithdrawn", recallNoOutcome, equalTo(false))
 
             .body("nsiType.code", recallWithOutcome, equalTo("REC"))
             .body("nsiOutcome.code", recallWithOutcome, equalTo("REC01"))
+            .body("outcomeRecall", recallWithOutcome, equalTo(true))
+            .body("recallRejectedOrWithdrawn", recallWithOutcome, equalTo(false))
             .body("nsiStatus.description", recallWithOutcome, equalTo("PPCS Recall Decision Received"));
     }
 


### PR DESCRIPTION
* Added isOutcomeRecall and isRecallRejectedOrWithdrawn on Nsi API 
* Only present when NSI is a recall

Added so that clients have a quick view of the recall without having to understand the meaning of Delius ref data codes