### PR TITLE
IC-1722 Always set RAR Activity Flag when contact is linked to a RAR Requirement

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformer.java
@@ -12,7 +12,7 @@ import static java.util.Optional.ofNullable;
 /*
     Activity can count towards RAR    Sentence has RAR requirement    RAR Activity    Contact Type
     Yes - service delivery            Yes                             TRUE            CRSAPT
-    No  - initial assessment          Yes                             null            CRSSAA
+    No  - initial assessment          Yes                             FALSE           CRSSAA
     Yes - service delivery            No                              null            CRSAPT
     No  - initial assessment          No                              null            CRSSAA
 */
@@ -41,9 +41,9 @@ public class AppointmentCreateRequestTransformer {
     }
 
     private static Boolean isRarActivity(final Boolean nsiContainsRarRequirement, final Boolean canCountTowardsRarDays) {
-        if ( !canCountTowardsRarDays )
+        if ( !nsiContainsRarRequirement )
             return null;
-        return nsiContainsRarRequirement ? true : null;
+        return canCountTowardsRarDays ? true : false;
     }
 
     private static Boolean isRarRequirement(final Requirement requirement, final String requirementRehabilitationActivityType) {

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformerTest.java
@@ -107,7 +107,7 @@ class AppointmentCreateRequestTransformerTest {
             ).build(),
             anIntegrationContext())
         ).isEqualTo(
-            anAppointmentCreateRequest(start, end, NON_RAR_CONTACT_TYPE, null)
+            anAppointmentCreateRequest(start, end, NON_RAR_CONTACT_TYPE, false)
         );
     }
 


### PR DESCRIPTION
## What does this pull request do?
Always set RAR Activity Flag when contact is linked to a RAR Requirement, even when it doesn't count towards RAR days (i.e. false), regardless of whether the contact has a type that is defined as "RAR Activity No".

## What is the intent behind these changes?
Correction to the logic otherwise Delius-Api rejects the contact.

## Breaking Changes?
None