### PR TITLE
DT-2054 Exclude recall NSIs with an expired licence

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
@@ -89,7 +89,6 @@ import static uk.gov.justice.digital.delius.jpa.standard.entity.RequirementTypeM
 @Validated
 public class OffendersResource {
 
-    private static final String RECALL_NSI_TYPE_CODE = "REC";
     private final OffenderService offenderService;
     private final ContactService contactService;
     private final ConvictionService convictionService;
@@ -558,7 +557,7 @@ public class OffendersResource {
                 .orElseThrow(() -> new NotFoundException(String.format("Offender with crn %s not found", crn)));
     }
 
-    @ApiOperation(value = "Return all the recall NSIs for the noms number, active convictions only", tags = "Sentence requirements and breach")
+    @ApiOperation(value = "Return all the recall NSIs for the noms number, active convictions only when licence has not expired", tags = "Sentence requirements and breach")
     @ApiResponses(
         value = {
             @ApiResponse(code = 404, message = "The offender NOMS number is not found", response = ErrorResponse.class)
@@ -569,7 +568,7 @@ public class OffendersResource {
         @NotNull @PathVariable(value = "nomsNumber") final String nomsNumber) {
 
         return offenderService.offenderIdOfNomsNumber(nomsNumber)
-            .map((offenderId) -> nsiService.getNsiByCodesForOffenderActiveConvictions(offenderId, List.of(RECALL_NSI_TYPE_CODE)))
+            .map(nsiService::getNonExpiredRecallNsiForOffenderActiveConvictions)
             .orElseThrow(() -> new NotFoundException(String.format("Offender with nomsNumber %s not found", nomsNumber)));
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Custody.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Custody.java
@@ -126,4 +126,8 @@ public class Custody extends AuditableEntity {
                 .orElse(false);
     }
 
+    public boolean hasReleaseLicenceExpired() {
+        return keyDates.stream().anyMatch(keyDate -> keyDate.isLicenceExpiryDate() && keyDate.isDateInPast());
+    }
+
 }

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/KeyDate.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/KeyDate.java
@@ -1,10 +1,23 @@
 package uk.gov.justice.digital.delius.jpa.standard.entity;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Data
 @ToString(exclude = {"custody"})
@@ -14,6 +27,8 @@ import java.time.LocalDateTime;
 @Builder(toBuilder = true)
 @Table(name = "KEY_DATE")
 public class KeyDate {
+    private static final String LICENCE_EXPIRY_DATE_CODE = "LED";
+    private static final String SENTENCE_EXPIRY_DATE_CODE = "SED";
     @Id
     @SequenceGenerator(name = "KEY_DATE_ID_GENERATOR", sequenceName = "KEY_DATE_ID_SEQ", allocationSize = 1)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "KEY_DATE_ID_GENERATOR")
@@ -45,6 +60,14 @@ public class KeyDate {
     private LocalDateTime lastUpdatedDatetime;
 
     public static boolean isSentenceExpiryKeyDate(String keyDateCode) {
-        return "SED".equals(keyDateCode);
+        return SENTENCE_EXPIRY_DATE_CODE.equals(keyDateCode);
+    }
+
+    public boolean isLicenceExpiryDate() {
+        return Optional.ofNullable(keyDateType).map(StandardReference::getCodeValue).filter(LICENCE_EXPIRY_DATE_CODE::equals).isPresent();
+    }
+
+    public boolean isDateInPast() {
+        return Optional.ofNullable(keyDate).filter(date -> date.isBefore(LocalDate.now())).isPresent();
     }
 }

--- a/src/test/java/uk/gov/justice/digital/delius/jpa/standard/entity/CustodyTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/jpa/standard/entity/CustodyTest.java
@@ -1,20 +1,31 @@
 package uk.gov.justice.digital.delius.jpa.standard.entity;
 
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.digital.delius.util.EntityHelper;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aKeyDate;
 
 @ExtendWith(MockitoExtension.class)
 public class CustodyTest {
 
-    private Custody custody = new Custody();
+    private Custody custody;
+
+    @BeforeEach
+    void setUp() {
+        custody = EntityHelper.aCustodyEvent().getDisposal().getCustody();
+    }
 
     @Test
     public void findLatestRelease_noReleases_returnsEmpty() {
@@ -54,6 +65,47 @@ public class CustodyTest {
         custody.setReleases(List.of(release));
 
         assertThat(custody.findLatestRelease()).isEmpty();
+    }
+
+    @Nested
+    class HasReleaseLicenceExpired {
+        @Test
+        @DisplayName("licence not expired when key dates found")
+        void licenceNotExpiredWhenNoKeyDatesDateFound() {
+             final var custodyWithNoKeyDates = custody.toBuilder().keyDates(List.of()).build();
+
+            assertThat(custodyWithNoKeyDates.hasReleaseLicenceExpired()).isFalse();
+        }
+        @Test
+        @DisplayName("licence not expired when no LED within key dates")
+        void licenceNotExpiredWhenNoLEDWithinKeyDates() {
+            final var futureSentenceExpiryDate = aKeyDate("SED", "SentenceExpiryDate", LocalDate.now().plusMonths(12));
+            final var custodyWithNoLED = custody.toBuilder().keyDates(List.of(futureSentenceExpiryDate)).build();
+
+            assertThat(custodyWithNoLED.hasReleaseLicenceExpired()).isFalse();
+        }
+
+        @Test
+        @DisplayName("licence not expired when future LED found")
+        void licenceNotExpiredWhenFutureLEDFound() {
+            final var pastSentenceExpiryDate = aKeyDate("SED", "SentenceExpiryDate", LocalDate.now().minusMonths(12));
+            final var futureLicenceExpiryDate = aKeyDate("LED", "LicenceExpiryDate", LocalDate.now().plusDays(1));
+
+            final var custodyWithFutureLED = custody.toBuilder().keyDates(List.of(pastSentenceExpiryDate, futureLicenceExpiryDate)).build();
+
+            assertThat(custodyWithFutureLED.hasReleaseLicenceExpired()).isFalse();
+        }
+
+        @Test
+        @DisplayName("licence has expired when LED date has past")
+        void licenceHasExpiredWhenLEDDateHasPast() {
+            final var futureSentenceExpiryDate = aKeyDate("SED", "SentenceExpiryDate", LocalDate.now().plusMonths(12));
+            final var pastLicenceExpiryDate = aKeyDate("LED", "LicenceExpiryDate", LocalDate.now().minusDays(1));
+
+            final var custodyWithExpiredLED = custody.toBuilder().keyDates(List.of(futureSentenceExpiryDate, pastLicenceExpiryDate)).build();
+
+            assertThat(custodyWithExpiredLED.hasReleaseLicenceExpired()).isTrue();
+        }
     }
 
 }

--- a/src/test/java/uk/gov/justice/digital/delius/jpa/standard/entity/KeyDateTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/jpa/standard/entity/KeyDateTest.java
@@ -1,9 +1,13 @@
 package uk.gov.justice.digital.delius.jpa.standard.entity;
 
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.digital.delius.util.EntityHelper.aKeyDate;
 
 public class KeyDateTest {
 
@@ -19,5 +23,22 @@ public class KeyDateTest {
     @Test
     public void isNotSentenceExpiryWhenKeyDateIsNULL() {
         assertThat(KeyDate.isSentenceExpiryKeyDate(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("is licence expiry date when code is LED")
+    void isLicenceExpiryDateWhenCodeIsLED() {
+      assertThat(aKeyDate("SED", "Sentence expiry").isLicenceExpiryDate()).isFalse();
+      assertThat(new KeyDate().isLicenceExpiryDate()).isFalse();
+      assertThat(aKeyDate("LED", "Licence expiry").isLicenceExpiryDate()).isTrue();
+    }
+
+    @Test
+    @DisplayName("is in the past when date is in the past")
+    void isInThePastWhenDateIsInThePast() {
+        assertThat(new KeyDate().isDateInPast()).isFalse();
+        assertThat(aKeyDate("SED", "Sentence expiry", LocalDate.now()).isDateInPast()).isFalse();
+        assertThat(aKeyDate("SED", "Sentence expiry", LocalDate.now().plusDays(1)).isDateInPast()).isFalse();
+        assertThat(aKeyDate("SED", "Sentence expiry", LocalDate.now().minusDays(1)).isDateInPast()).isTrue();
     }
 }


### PR DESCRIPTION
This specialised endpoint has intent of returning RECALL requests that maybe "active", e.g an outstanding request or released to a current custodial sentence.

If a licence period is past then this is a historic NSI and is no longer of interest.