### PR TITLE
IC-2016 Referral Send must exclude inactive RAR requirements

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig;
 import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.IntegrationContext;
 import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.NsiMapping;
 import uk.gov.justice.digital.delius.controller.BadRequestException;
-import uk.gov.justice.digital.delius.controller.ConflictingRequestException;
 import uk.gov.justice.digital.delius.data.api.ContextlessReferralEndRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessReferralStartRequest;
 import uk.gov.justice.digital.delius.data.api.Nsi;
@@ -151,7 +150,7 @@ public class ReferralService {
             .orElse(existingNsis);
 
         if (filteredNsis.size() > 1) {
-            throw new ConflictingRequestException("Multiple existing matching NSIs found");
+            throw new BadRequestException("Multiple existing matching NSIs found");
         }
         return filteredNsis;
     }

--- a/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
@@ -181,7 +181,7 @@ public class ReferralService {
     }
 
     Optional<Long> getRequirement(String crn, Long sentenceId, IntegrationContext context) {
-        return requirementService.getRequirement(crn, sentenceId, context.getRequirementRehabilitationActivityType())
+        return requirementService.getActiveRequirement(crn, sentenceId, context.getRequirementRehabilitationActivityType())
             .map(Requirement::getRequirementId);
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
@@ -116,7 +116,7 @@ public class RequirementService {
     // In the context of NSI's for interventions, the offender's sentence is the event against which
     // the NSI is created. This sentence is supplied by interventions as part of the "referral sent
     // request". This method takes the sentence and finds any associated requirements and returns one
-    // that has a main category of F - rehab activity requirement. It is invalid for multiple to exist.
+    // that has a main category of F - rehab activity requirement. It is invalid for multiple active ones to exist.
     // NB. The called method getRequirementsByConvictionId accepts an event id (conviction or sentence)
     // and perhaps should have been named getRequirementsByEventId
     public Optional<Requirement> getActiveRequirement(String crn, Long eventId, String requirementTypeCode) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
@@ -123,6 +123,7 @@ public class RequirementService {
 
         var requirements = getRequirementsByConvictionId(crn, eventId)
             .getRequirements().stream()
+            .filter(Requirement::getActive)
             .filter(requirement ->
                 ofNullable(requirement.getRequirementTypeMainCategory())
                     .map(cat -> requirementTypeCode.equals(cat.getCode()))

--- a/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
@@ -119,7 +119,7 @@ public class RequirementService {
     // that has a main category of F - rehab activity requirement. It is invalid for multiple to exist.
     // NB. The called method getRequirementsByConvictionId accepts an event id (conviction or sentence)
     // and perhaps should have been named getRequirementsByEventId
-    public Optional<Requirement> getRequirement(String crn, Long eventId, String requirementTypeCode) {
+    public Optional<Requirement> getActiveRequirement(String crn, Long eventId, String requirementTypeCode) {
 
         var requirements = getRequirementsByConvictionId(crn, eventId)
             .getRequirements().stream()

--- a/src/test/java/uk/gov/justice/digital/delius/service/ReferralServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ReferralServiceTest.java
@@ -13,7 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig;
 import uk.gov.justice.digital.delius.config.DeliusIntegrationContextConfig.IntegrationContext;
 import uk.gov.justice.digital.delius.controller.BadRequestException;
-import uk.gov.justice.digital.delius.controller.ConflictingRequestException;
 import uk.gov.justice.digital.delius.data.api.ContextlessReferralEndRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessReferralStartRequest;
 import uk.gov.justice.digital.delius.data.api.KeyValue;
@@ -160,7 +159,7 @@ public class ReferralServiceTest {
         public void creatingNewNsiCallsDeliusApi() {
 
             Requirement requirement = Requirement.builder().requirementId(REQUIREMENT_ID).build();
-            when(requirementService.getRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(of(requirement));
+            when(requirementService.getActiveRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(of(requirement));
             var deliusApiResponse = NsiDto.builder().id(66853L).build();
 
             when(deliusApiClient.createNewNsi(any())).thenReturn(deliusApiResponse);
@@ -193,7 +192,7 @@ public class ReferralServiceTest {
         public void creatingNewNsiFromReferralRequestWithNoId() {
 
             Requirement requirement = Requirement.builder().requirementId(REQUIREMENT_ID).build();
-            when(requirementService.getRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(of(requirement));
+            when(requirementService.getActiveRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(of(requirement));
             var deliusApiResponse = NsiDto.builder().id(66853L).build();
 
             when(deliusApiClient.createNewNsi(any())).thenReturn(deliusApiResponse);
@@ -225,7 +224,7 @@ public class ReferralServiceTest {
         @Test
         public void creatingNewNsiCallsDeliusApi_withNoRequirement() {
 
-            when(requirementService.getRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(empty());
+            when(requirementService.getActiveRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(empty());
             var deliusApiResponse = NsiDto.builder().id(66853L).build();
 
             when(deliusApiClient.createNewNsi(any())).thenReturn(deliusApiResponse);
@@ -454,7 +453,7 @@ public class ReferralServiceTest {
     public void throwsExceptionIfNsiTypeMappingNotFound() {
 
         Requirement requirement = Requirement.builder().requirementId(REQUIREMENT_ID).build();
-        when(requirementService.getRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(of(requirement));
+        when(requirementService.getActiveRequirement(OFFENDER_CRN, SENTENCE_ID, RAR_TYPE_CODE)).thenReturn(of(requirement));
 
         var nsiRequest = REFERRAL_START_REQUEST
             .toBuilder()

--- a/src/test/java/uk/gov/justice/digital/delius/service/ReferralServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ReferralServiceTest.java
@@ -443,7 +443,7 @@ public class ReferralServiceTest {
             when(nsiService.getNsiByCodes(any(), any(), any())).thenReturn(
                 of(NsiWrapper.builder().nsis(asList(MATCHING_NSI, MATCHING_NSI)).build()));
 
-            final var exception = assertThrows(ConflictingRequestException.class,
+            final var exception = assertThrows(BadRequestException.class,
                 () -> referralService.getExistingMatchingNsi(OFFENDER_CRN, INTEGRATION_CONTEXT, REFERRAL_START_REQUEST.getSentenceId(), REFERRAL_START_REQUEST.getContractType(), REFERRAL_START_REQUEST.getStartedAt(), REFERRAL_START_REQUEST.getReferralId()));
 
             assertThat(exception.getMessage()).isEqualTo("Multiple existing matching NSIs found");

--- a/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
@@ -228,6 +228,7 @@ public class RequirementServiceTest {
             when(disposal.getRequirements()).thenReturn(Collections.singletonList(Requirement
                 .builder()
                 .requirementId(99L)
+                .activeFlag(1L)
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build())
                 .build()));
             var requirement = requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE);
@@ -235,11 +236,24 @@ public class RequirementServiceTest {
         }
 
         @Test
-        public void whenGetReferralRequirementByConvictionId_AndRequirementNotMatchingCategory_thenThrowException() {
+        public void whenGetReferralRequirementByConvictionId_AndRequirementNotMatchingCategory_thenNoMatch() {
             when(disposal.getRequirements()).thenReturn(Collections.singletonList(Requirement
                 .builder()
                 .requirementId(99L)
+                .activeFlag(1L)
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("X").build())
+                .build()));
+
+            assertThat(requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE)).isEmpty();
+        }
+
+        @Test
+        public void whenGetReferralRequirementByConvictionId_AndRequirementNotActive_thenNoMatch() {
+            when(disposal.getRequirements()).thenReturn(Collections.singletonList(Requirement
+                .builder()
+                .requirementId(99L)
+                .activeFlag(0L)
+                .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build())
                 .build()));
 
             assertThat(requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE)).isEmpty();
@@ -248,9 +262,9 @@ public class RequirementServiceTest {
         @Test
         public void whenGetReferralRequirementByConvictionId_AndMultipleRequirementsExist_thenThrowException() {
             when(disposal.getRequirements()).thenReturn(Arrays.asList(
-                Requirement.builder().requirementId(99L)
+                Requirement.builder().requirementId(99L).activeFlag(1L)
                     .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build()).build(),
-                Requirement.builder().requirementId(100L)
+                Requirement.builder().requirementId(100L).activeFlag(1L)
                     .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build()).build())
             );
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
@@ -231,7 +231,7 @@ public class RequirementServiceTest {
                 .activeFlag(1L)
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build())
                 .build()));
-            var requirement = requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE);
+            var requirement = requirementService.getActiveRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE);
             assertThat(requirement.orElse(null).getRequirementId()).isEqualTo(99L);
         }
 
@@ -244,7 +244,7 @@ public class RequirementServiceTest {
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("X").build())
                 .build()));
 
-            assertThat(requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE)).isEmpty();
+            assertThat(requirementService.getActiveRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE)).isEmpty();
         }
 
         @Test
@@ -256,7 +256,7 @@ public class RequirementServiceTest {
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build())
                 .build()));
 
-            assertThat(requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE)).isEmpty();
+            assertThat(requirementService.getActiveRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE)).isEmpty();
         }
 
         @Test
@@ -269,7 +269,7 @@ public class RequirementServiceTest {
             );
 
             assertThatExceptionOfType(BadRequestException.class)
-                .isThrownBy(() -> requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE))
+                .isThrownBy(() -> requirementService.getActiveRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE))
                 .withMessage("CRN: CRN EventId: 987654321 has multiple referral requirements");
         }
 
@@ -277,7 +277,7 @@ public class RequirementServiceTest {
         public void whenGetReferralRequirementByConvictionId_AndNoRequirementsExist_thenReturnEmptyOptional() {
             when(disposal.getRequirements()).thenReturn(Collections.emptyList());
 
-            assertThat(requirementService.getRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE)).isEmpty();
+            assertThat(requirementService.getActiveRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE)).isEmpty();
         }
 
         @Test


### PR DESCRIPTION
**What does this pull request do?**
Community Api should exclude inactive requirements when deriving the RAR requirement for a CRN sentence during the process of initiating a NSI in Delius. Also, any post request made for an NSI that has duplicates in Delius should result in a 400. The NSIs must be cleaned up in Delius before they can be acted upon.

**What is the intent behind these changes?**
Fix issues arising in production

**Breaking Changes**
None.