### PR TITLE
IC-2050 When creating an NSI and in the case of multiple RAR requirements, take the latest

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/Requirement.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/Requirement.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Data
 @Builder
@@ -22,6 +23,7 @@ public class Requirement {
     private LocalDate terminationDate;
     private LocalDate expectedStartDate;
     private LocalDate expectedEndDate;
+    private LocalDateTime createdDatetime;
     @ApiModelProperty(value = "Is the requirement currently active")
     private Boolean active;
     private KeyValue requirementTypeSubCategory;

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Requirement.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Requirement.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor
@@ -37,6 +38,9 @@ public class Requirement {
 
     @Column(name = "EXPECTED_END_DATE")
     private LocalDate expectedEndDate;
+
+    @Column(name = "CREATED_DATETIME")
+    private LocalDateTime createdDatetime;
 
     @Column(name = "ACTIVE_FLAG")
     private Long activeFlag;

--- a/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
@@ -117,7 +117,8 @@ public class RequirementService {
     // In the context of NSI's for interventions, the offender's sentence is the event against which
     // the NSI is created. This sentence is supplied by interventions as part of the "referral sent
     // request". This method takes the sentence and finds any associated requirements and returns one
-    // that has a main category of F - rehab activity requirement. It is invalid for multiple active ones to exist.
+    // that has a main category of F - rehab activity requirement. If multiple active ones exist
+    // the one with the latest start date is chosen.
     // NB. The called method getRequirementsByConvictionId accepts an event id (conviction or sentence)
     // and perhaps should have been named getRequirementsByEventId
     public Optional<Requirement> getActiveRequirement(String crn, Long eventId, String requirementTypeCode) {

--- a/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import static java.lang.String.format;
+import static java.util.Comparator.comparing;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 
@@ -121,21 +122,14 @@ public class RequirementService {
     // and perhaps should have been named getRequirementsByEventId
     public Optional<Requirement> getActiveRequirement(String crn, Long eventId, String requirementTypeCode) {
 
-        var requirements = getRequirementsByConvictionId(crn, eventId)
+        return getRequirementsByConvictionId(crn, eventId)
             .getRequirements().stream()
             .filter(Requirement::getActive)
             .filter(requirement ->
                 ofNullable(requirement.getRequirementTypeMainCategory())
                     .map(cat -> requirementTypeCode.equals(cat.getCode()))
                     .orElse(false))
-            .collect(toList());
-
-        if ( requirements.size() > 1 ) {
-            throw new BadRequestException(format("CRN: %s EventId: %d has multiple referral requirements", crn, eventId));
-        }
-
-        return requirements.stream().findFirst();
+            .sorted(comparing(Requirement::getStartDate).reversed())
+            .findFirst();
     }
-
-
 }

--- a/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
@@ -24,6 +24,7 @@ import java.util.function.Predicate;
 
 import static java.lang.String.format;
 import static java.util.Comparator.comparing;
+import static java.util.Comparator.reverseOrder;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 
@@ -130,7 +131,7 @@ public class RequirementService {
                 ofNullable(requirement.getRequirementTypeMainCategory())
                     .map(cat -> requirementTypeCode.equals(cat.getCode()))
                     .orElse(false))
-            .sorted(comparing(Requirement::getStartDate).reversed())
+            .sorted(comparing(Requirement::getStartDate, reverseOrder()).thenComparing(Requirement::getCreatedDatetime, reverseOrder()))
             .findFirst();
     }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/RequirementTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/RequirementTransformer.java
@@ -24,6 +24,7 @@ public class RequirementTransformer {
                         .commencementDate(req.getCommencementDate())
                         .expectedEndDate(req.getExpectedEndDate())
                         .expectedStartDate(req.getExpectedStartDate())
+                        .createdDatetime(req.getCreatedDatetime())
                         .requirementId(req.getRequirementId())
                         .requirementNotes(req.getRequirementNotes())
                         .requirementTypeMainCategory(requirementTypeMainCategoryOf(req.getRequirementTypeMainCategory()))

--- a/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
+import static java.time.LocalDate.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.when;
@@ -260,17 +261,16 @@ public class RequirementServiceTest {
         }
 
         @Test
-        public void whenGetReferralRequirementByConvictionId_AndMultipleRequirementsExist_thenThrowException() {
+        public void whenGetReferralRequirementByConvictionId_AndMultipleRequirementsExist_thenSelectLatest() {
             when(disposal.getRequirements()).thenReturn(Arrays.asList(
-                Requirement.builder().requirementId(99L).activeFlag(1L)
+                Requirement.builder().requirementId(99L).activeFlag(1L).startDate(now().minusDays(1))
                     .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build()).build(),
-                Requirement.builder().requirementId(100L).activeFlag(1L)
+                Requirement.builder().requirementId(100L).activeFlag(1L).startDate(now())
                     .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build()).build())
             );
 
-            assertThatExceptionOfType(BadRequestException.class)
-                .isThrownBy(() -> requirementService.getActiveRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE))
-                .withMessage("CRN: CRN EventId: 987654321 has multiple referral requirements");
+            Optional<uk.gov.justice.digital.delius.data.api.Requirement> activeRequirement = requirementService.getActiveRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE);
+            assertThat(activeRequirement.get().getRequirementId()).isEqualTo(100L);
         }
 
         @Test

--- a/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
@@ -262,10 +262,16 @@ public class RequirementServiceTest {
 
         @Test
         public void whenGetReferralRequirementByConvictionId_AndMultipleRequirementsExist_thenSelectLatest() {
+            LocalDateTime now = LocalDateTime.now();
             when(disposal.getRequirements()).thenReturn(Arrays.asList(
-                Requirement.builder().requirementId(99L).activeFlag(1L).startDate(now().minusDays(1))
+                Requirement.builder().requirementId(99L).activeFlag(1L)
+                    .startDate(now.minusDays(1).toLocalDate()).createdDatetime(now)
                     .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build()).build(),
-                Requirement.builder().requirementId(100L).activeFlag(1L).startDate(now())
+                Requirement.builder().requirementId(100L).activeFlag(1L)
+                    .startDate(now.toLocalDate()).createdDatetime(now.plusHours(2))
+                    .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build()).build(),
+                Requirement.builder().requirementId(101L).activeFlag(1L)
+                    .startDate(now.toLocalDate()).createdDatetime(now.plusHours(1))
                     .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build()).build())
             );
 

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/RequirementTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/RequirementTransformerTest.java
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.RequirementTypeMainCate
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,6 +52,7 @@ public class RequirementTransformerTest {
         LocalDate startDate = LocalDate.of(2020, 3, 1);
         LocalDate terminationDate = LocalDate.of(2020, 4, 1);
         LocalDate expectedStartDate = LocalDate.of(2020, 5, 1);
+        LocalDateTime createdDatetime = LocalDateTime.of(2020, 5, 1, 2, 3, 4);
         Requirement requirement = Requirement.builder()
             .requirementId(88L)
             .activeFlag(1L)
@@ -59,6 +61,7 @@ public class RequirementTransformerTest {
             .expectedEndDate(expectedEndDate)
             .startDate(startDate)
             .terminationDate(terminationDate)
+            .createdDatetime(createdDatetime)
             .length(6L)
             .requirementNotes("Notes")
             .adRequirementTypeMainCategory(AdRequirementTypeMainCategory.builder()
@@ -90,6 +93,7 @@ public class RequirementTransformerTest {
         assertThat(pssRequirement.getRequirementNotes()).isEqualTo("Notes");
         assertThat(pssRequirement.getStartDate()).isEqualTo(startDate);
         assertThat(pssRequirement.getTerminationDate()).isEqualTo(terminationDate);
+        assertThat(pssRequirement.getCreatedDatetime()).isEqualTo(createdDatetime);
         assertThat(pssRequirement.getExpectedStartDate()).isEqualTo(expectedStartDate);
         assertThat(pssRequirement.getAdRequirementTypeMainCategory().getDescription()).isEqualTo("AdMain");
         assertThat(pssRequirement.getAdRequirementTypeSubCategory().getDescription()).isEqualTo("AdSub");


### PR DESCRIPTION
**What is included in this change?**
The creation of a NSI and the association of a referral was implemented on the basis that there is only ever one active requirement per service user sentence. This is not always the case. It has been agreed that should multiple exist, the one with the latest start date should be chosen and associated to the NSI. Where start date is the same, the later create date time is used.

**What is the intent behind these changes?**
This is to resolve a matter arising in production with approximately 1% of referrals raised by R&M.

**Are there any breaking changes?**
None, but introduced createDateTime in api class Requirement.