### PR TITLE
IC-2067 Exclude soft deleted RARs during NSI Creation/Referral Sent process

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/Requirement.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/Requirement.java
@@ -37,6 +37,7 @@ public class Requirement {
     private String lengthUnit;
     @ApiModelProperty(value = "Is the main category restrictive")
     private Boolean restrictive;
+    private Boolean softDeleted;
 
     @ApiModelProperty(value = "Total RAR days completed")
     private Long rarCount;

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Requirement.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Requirement.java
@@ -74,4 +74,7 @@ public class Requirement {
 
     @Column(name = "RAR_COUNT")
     private Long rarCount;
+
+    @Column(name = "SOFT_DELETED")
+    private Long softDeleted = 0L;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/RequirementService.java
@@ -127,6 +127,7 @@ public class RequirementService {
         return getRequirementsByConvictionId(crn, eventId)
             .getRequirements().stream()
             .filter(Requirement::getActive)
+            .filter(requirement -> !requirement.getSoftDeleted())
             .filter(requirement ->
                 ofNullable(requirement.getRequirementTypeMainCategory())
                     .map(cat -> requirementTypeCode.equals(cat.getCode()))

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/RequirementTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/RequirementTransformer.java
@@ -36,6 +36,7 @@ public class RequirementTransformer {
                         .lengthUnit(lengthUnitOf(req))
                         .restrictive(restrictiveOf(req.getRequirementTypeMainCategory()))
                         .rarCount(req.getRarCount())
+                        .softDeleted(zeroOneToBoolean(req.getSoftDeleted()))
                         .build())
                 .orElse(null);
     }

--- a/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
@@ -230,6 +230,7 @@ public class RequirementServiceTest {
                 .builder()
                 .requirementId(99L)
                 .activeFlag(1L)
+                .softDeleted(0L)
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build())
                 .build()));
             var requirement = requirementService.getActiveRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE);
@@ -242,6 +243,7 @@ public class RequirementServiceTest {
                 .builder()
                 .requirementId(99L)
                 .activeFlag(1L)
+                .softDeleted(0L)
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("X").build())
                 .build()));
 
@@ -261,16 +263,29 @@ public class RequirementServiceTest {
         }
 
         @Test
+        public void whenGetReferralRequirementByConvictionId_AndRequirementSoftDeleted_thenNoMatch() {
+            when(disposal.getRequirements()).thenReturn(Collections.singletonList(Requirement
+                .builder()
+                .requirementId(99L)
+                .activeFlag(1L)
+                .softDeleted(1L)
+                .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build())
+                .build()));
+
+            assertThat(requirementService.getActiveRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE)).isEmpty();
+        }
+
+        @Test
         public void whenGetReferralRequirementByConvictionId_AndMultipleRequirementsExist_thenSelectLatest() {
             LocalDateTime now = LocalDateTime.now();
             when(disposal.getRequirements()).thenReturn(Arrays.asList(
-                Requirement.builder().requirementId(99L).activeFlag(1L)
+                Requirement.builder().requirementId(99L).activeFlag(1L).softDeleted(0L)
                     .startDate(now.minusDays(1).toLocalDate()).createdDatetime(now)
                     .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build()).build(),
-                Requirement.builder().requirementId(100L).activeFlag(1L)
+                Requirement.builder().requirementId(100L).activeFlag(1L).softDeleted(0L)
                     .startDate(now.toLocalDate()).createdDatetime(now.plusHours(2))
                     .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build()).build(),
-                Requirement.builder().requirementId(101L).activeFlag(1L)
+                Requirement.builder().requirementId(101L).activeFlag(1L).softDeleted(0L)
                     .startDate(now.toLocalDate()).createdDatetime(now.plusHours(1))
                     .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build()).build())
             );

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/RequirementTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/RequirementTransformerTest.java
@@ -81,6 +81,7 @@ public class RequirementTransformerTest {
                 .codeDescription("Sub")
                 .build())
             .rarCount(10L)
+            .softDeleted(1L)
             .build();
         uk.gov.justice.digital.delius.data.api.Requirement pssRequirement = RequirementTransformer.requirementOf(requirement);
 
@@ -101,6 +102,7 @@ public class RequirementTransformerTest {
         assertThat(pssRequirement.getRequirementTypeSubCategory().getDescription()).isEqualTo("Sub");
         assertThat(pssRequirement.getRestrictive()).isEqualTo(true);
         assertThat(pssRequirement.getRarCount()).isEqualTo(10L);
+        assertThat(pssRequirement.getSoftDeleted()).isTrue();
     }
 
 }


### PR DESCRIPTION
What is included in this change?
During the referral start/NSI creation request, a requirement is selected from the specified sentence. Soft deleted requirements must be excluded from the selection.

What is the intent behind these changes?
This is to resolve a matter arising in production by R&M.

Are there any breaking changes?
None, but introduced attribute softDeleted in api class Requirement.