### PR TITLE
IC-2028 Include Office Location as part of Appointment Reschedule

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentRescheduleRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentRescheduleRequest.java
@@ -26,4 +26,7 @@ public class AppointmentRescheduleRequest {
     @NotNull
     @ApiModelProperty(required = true)
     private String outcome;
+
+    @ApiModelProperty
+    private String officeLocationCode;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessAppointmentRescheduleRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessAppointmentRescheduleRequest.java
@@ -26,4 +26,7 @@ public class ContextlessAppointmentRescheduleRequest {
     @NotNull
     @ApiModelProperty(required = true)
     private Boolean initiatedByServiceProvider;
+
+    @ApiModelProperty
+    private String officeLocationCode;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/deliusapi/ReplaceContact.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/deliusapi/ReplaceContact.java
@@ -15,6 +15,7 @@ import java.time.LocalTime;
 public class ReplaceContact {
     private String offenderCrn;
     private String outcome;
+    private String officeLocation;  // Null location means no change
     private LocalDate date;
     private LocalTime startTime;
     private LocalTime endTime;

--- a/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
@@ -117,6 +117,7 @@ public class AppointmentService {
                 .updatedAppointmentStart(contextlessRequest.getUpdatedAppointmentStart())
                 .updatedAppointmentEnd(contextlessRequest.getUpdatedAppointmentEnd())
                 .outcome(outcomeType)
+                .officeLocationCode(contextlessRequest.getOfficeLocationCode())
                 .build())
             .orElseThrow(() -> new BadRequestException(format("Cannot find rescheduled outcome type for initiated-by-Service-Provider: %s", contextlessRequest.getInitiatedByServiceProvider())));
 
@@ -187,6 +188,7 @@ public class AppointmentService {
             .date(toLondonLocalDate(request.getUpdatedAppointmentStart()))
             .startTime(toLondonLocalTime(request.getUpdatedAppointmentStart()))
             .endTime(toLondonLocalTime(request.getUpdatedAppointmentEnd()))
+            .officeLocation(request.getOfficeLocationCode())
             .nsiId(existingContact.getNsi().getNsiId())
             .eventId(existingContact.getEvent().getEventId())
             .build();

--- a/src/test/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingControllerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingControllerTest.java
@@ -140,6 +140,34 @@ public class AppointmentBookingControllerTest {
     }
 
     @Test
+    public void reschedulesAppointmentWithOfficeLocationUsingContextlessClientEndpoint() {
+        OffsetDateTime now = Instant.now().atZone(ZoneId.of("UTC")).toOffsetDateTime().truncatedTo(ChronoUnit.SECONDS);
+
+        ContextlessAppointmentRescheduleRequest appointmentRescheduleRequest = ContextlessAppointmentRescheduleRequest.builder()
+            .updatedAppointmentStart(now)
+            .updatedAppointmentEnd(now.plusHours(1))
+            .officeLocationCode("CRSEXTL")
+            .initiatedByServiceProvider(true)
+            .build();
+        when(appointmentService.rescheduleAppointment("1", 2L, "commissioned-rehabilitation-services", appointmentRescheduleRequest))
+            .thenReturn(AppointmentRescheduleResponse.builder().appointmentId(3L).build());
+
+        Long appointmentIdResponse = given()
+            .contentType(APPLICATION_JSON_VALUE)
+            .body(appointmentRescheduleRequest)
+            .when()
+            .post("/secure/offenders/crn/1/appointments/2/reschedule/context/commissioned-rehabilitation-services")
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .as(AppointmentCreateResponse.class)
+            .getAppointmentId();
+
+        assertThat(appointmentIdResponse).isEqualTo(3L);
+    }
+
+    @Test
     public void updatesAppointmentOutcomeUsingContextlessClientEndpoint() {
 
         ContextlessAppointmentOutcomeRequest request = ContextlessAppointmentOutcomeRequest.builder()

--- a/src/test/java/uk/gov/justice/digital/delius/service/AppointmentServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/AppointmentServiceTest.java
@@ -448,7 +448,7 @@ public class AppointmentServiceTest {
                 .event(Event.builder().eventId(EVENT_ID).build())
                 .build()));
 
-            final var deliusNewContactRequest = aDeliusReplaceContactRequest(updatedStartTime, updatedEndTime, "CRSLOND", EVENT_ID, NSI_ID, SP_INITIATED_RESCHEDULE);
+            final var deliusNewContactRequest = aDeliusReplaceContactRequest(updatedStartTime, updatedEndTime, null, EVENT_ID, NSI_ID, SP_INITIATED_RESCHEDULE);
             final var replacedContact = ContactDto.builder()
                 .id(2L)
                 .nsiId(NSI_ID)


### PR DESCRIPTION
**What is included in this change?**
This change allows an office location to be provided as part of an appointment rescheduling. If not supplied it remains unchanged. 

What is the intent behind these changes?
Provide R&M the functionality it needs.

**Are there any breaking changes?**
No, but introduced an optional office location field to the reschedule request dto's