### PR TITLE
✨ PIC-1527 add awaiting PSR to conviction

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/Conviction.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/Conviction.java
@@ -26,6 +26,9 @@ public class Conviction {
     @ApiModelProperty(name = "Conviction in breach flag", example = "true")
     private Boolean inBreach;
 
+    @ApiModelProperty(name = "Conviction is awaiting pre-sentence report", example = "true")
+    private boolean awaitingPsr;
+
     @ApiModelProperty(name = "Date of this conviction", example = "2021-06-10")
     private LocalDate convictionDate;
 

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformer.java
@@ -95,6 +95,7 @@ public class ConvictionTransformer {
                 .latestCourtAppearanceOutcome(courtAppearances.map(ConvictionTransformer::outcomeOf).orElse(null))
                 .responsibleCourt(Optional.ofNullable(event.getCourt()).map(CourtTransformer::courtOf).orElse(null))
                 .courtAppearance(courtAppearances.map(CourtAppearanceBasicTransformer::latestOrSentencingCourtAppearanceOf).orElse(null))
+                .awaitingPsr(courtAppearances.map(CourtAppearanceBasicTransformer::awaitingPsrOf).orElse(false))
                 .build();
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceBasicTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceBasicTransformer.java
@@ -6,9 +6,11 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.Court;
 import uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Offender;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
+import uk.gov.justice.digital.delius.service.ReferenceDataService;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public class CourtAppearanceBasicTransformer {
@@ -48,5 +50,13 @@ public class CourtAppearanceBasicTransformer {
                 .map(CourtAppearanceBasicTransformer::courtAppearanceOf)
                 .orElse(null)
             );
+    }
+
+    public static boolean awaitingPsrOf(final List<CourtAppearance> courtAppearances) {
+        return courtAppearances
+            .stream()
+            .map(CourtAppearance::getOutcome)
+            .filter(Objects::nonNull)
+            .anyMatch(outcome -> ReferenceDataService.REFERENCE_DATA_PSR_ADJOURNED_CODE.equals(outcome.getCodeValue()));
     }
 }

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformerTest.java
@@ -26,11 +26,12 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.digital.delius.service.ReferenceDataService.REFERENCE_DATA_PSR_ADJOURNED_CODE;
 import static uk.gov.justice.digital.delius.util.EntityHelper.aKeyDate;
 
-public class ConvictionTransformerTest {
+class ConvictionTransformerTest {
     @Test
-    public void convictionIdMappedFromEventId() {
+    void convictionIdMappedFromEventId() {
         assertThat(ConvictionTransformer.convictionOf(
             anEvent()
                 .toBuilder()
@@ -41,7 +42,7 @@ public class ConvictionTransformerTest {
     }
 
     @Test
-    public void offencesCollatedFromMainAndAdditionalOffences() {
+    void offencesCollatedFromMainAndAdditionalOffences() {
 
         assertThat(ConvictionTransformer.convictionOf(
             anEvent()
@@ -54,33 +55,33 @@ public class ConvictionTransformerTest {
     }
 
     @Test
-    public void activeMappedForZeroOneActiveFlag() {
+    void activeMappedForZeroOneActiveFlag() {
         assertThat((ConvictionTransformer.convictionOf(anEvent().toBuilder().activeFlag(true).build()).getActive())).isTrue();
         assertThat((ConvictionTransformer.convictionOf(anEvent().toBuilder().activeFlag(false).build()).getActive())).isFalse();
 
     }
 
     @Test
-    public void inBreachMappedForZeroOneInBreach() {
+    void inBreachMappedForZeroOneInBreach() {
         assertThat((ConvictionTransformer.convictionOf(anEvent().toBuilder().inBreach(true).build()).getInBreach())).isTrue();
         assertThat((ConvictionTransformer.convictionOf(anEvent().toBuilder().inBreach(false).build()).getInBreach())).isFalse();
 
     }
 
     @Test
-    public void sentenceIsMappedWhenEvenHasDisposal() {
+    void sentenceIsMappedWhenEvenHasDisposal() {
         assertThat((ConvictionTransformer.convictionOf(anEvent().toBuilder().disposal(null).build()).getSentence())).isNull();
         assertThat((ConvictionTransformer.convictionOf(anEvent().toBuilder().disposal(aDisposal()).build()).getSentence())).isNotNull();
     }
 
     @Test
-    public void sentenceIdIsMappedWhenEventHasDisposal() {
+    void sentenceIdIsMappedWhenEventHasDisposal() {
         Sentence sentence = ConvictionTransformer.convictionOf(anEvent().toBuilder().disposal(disposalBuilder().disposalId(1234L).build()).build()).getSentence();
         assertThat(sentence.getSentenceId()).isEqualTo(1234L);
     }
 
     @Test
-    public void enteredSentenceEndDateOverridesExpectedSentenceEndDate() {
+    void enteredSentenceEndDateOverridesExpectedSentenceEndDate() {
         final var expectedEndDate = LocalDate.now().minusDays(1);
         final var enteredEndDate = LocalDate.now().minusDays(2);
         final var disposal = disposalBuilder().enteredSentenceEndDate(enteredEndDate).expectedSentenceEndDate(expectedEndDate).build();
@@ -88,36 +89,21 @@ public class ConvictionTransformerTest {
     }
 
     @Test
-    public void expectedSentenceEndDateIsMappedIfEnteredSentenceEndDateNotPresent() {
+    void expectedSentenceEndDateIsMappedIfEnteredSentenceEndDateNotPresent() {
         final var expectedEndDate = LocalDate.now().minusDays(1);
         final var disposal = disposalBuilder().expectedSentenceEndDate(expectedEndDate).build();
         assertThat(ConvictionTransformer.convictionOf(anEvent().toBuilder().disposal(disposal).build()).getSentence().getExpectedSentenceEndDate()).isEqualTo(expectedEndDate);
     }
 
     @Test
-    public void expectedSentenceEndDateMappingCanHandleNulls() {
+    void expectedSentenceEndDateMappingCanHandleNulls() {
         assertThat(ConvictionTransformer.convictionOf(anEvent().toBuilder().disposal(aDisposal()).build()).getSentence().getExpectedSentenceEndDate()).isNull();
     }
 
-    @Test
-    public void outcomeMappedFromLastCourtAppearance() {
-        assertThat(ConvictionTransformer.convictionOf(
-            anEvent()
-                .toBuilder()
-                .courtAppearances(ImmutableList.of(
-                    aCourtAppearanceWithNoOutcome(LocalDateTime.now()),
-                    aCourtAppearance("Final Review", "Y", LocalDateTime.now().minusDays(1)),
-                    aCourtAppearance("Adjourned", "X", LocalDateTime.now().minusDays(2))
-                ))
-                .build()).getLatestCourtAppearanceOutcome())
-            .isNotNull()
-            .hasFieldOrPropertyWithValue("code", "Y")
-            .hasFieldOrPropertyWithValue("description", "Final Review");
 
-    }
 
     @Test
-    public void responsibleCourtMappedFromCourt() {
+    void responsibleCourtMappedFromCourt() {
         assertThat(ConvictionTransformer.convictionOf(
             anEvent()
                 .toBuilder()
@@ -129,26 +115,12 @@ public class ConvictionTransformerTest {
     }
 
     @Test
-    public void courtMappedFromLatestAppearance() {
-        assertThat(ConvictionTransformer.convictionOf(
-            anEvent()
-                .toBuilder()
-                .courtAppearances(List.of(
-                    aCourtAppearanceWithNoOutcome(LocalDateTime.of(2015, 6, 10, 12, 0)),
-                    aCourtAppearanceWithNoOutcome(LocalDateTime.of(2015, 6, 11, 12, 0))
-                ))
-                .build()))
-            .isNotNull()
-            .hasFieldOrPropertyWithValue("courtAppearance.appearanceDate", LocalDateTime.of(2015, 6, 11, 12, 0));
-    }
-
-    @Test
-    public void indexMappedFromEventNumberString() {
+    void indexMappedFromEventNumberString() {
         assertThat((ConvictionTransformer.convictionOf(anEvent().toBuilder().eventNumber("5").build()).getIndex())).isEqualTo("5");
     }
 
     @Test
-    public void custodyNotSetWhenDisposalNotPresent() {
+    void custodyNotSetWhenDisposalNotPresent() {
         assertThat(
             ConvictionTransformer.convictionOf(
                 anEvent()
@@ -160,7 +132,7 @@ public class ConvictionTransformerTest {
     }
 
     @Test
-    public void custodyNotSetWhenCustodyNotPresentInDisposal() {
+    void custodyNotSetWhenCustodyNotPresentInDisposal() {
         assertThat(
             ConvictionTransformer.convictionOf(
                 anEvent()
@@ -176,7 +148,7 @@ public class ConvictionTransformerTest {
     }
 
     @Test
-    public void custodySetWhenCustodyPresentInDisposal() {
+    void custodySetWhenCustodyPresentInDisposal() {
         assertThat(
             ConvictionTransformer.convictionOf(
                 anEvent()
@@ -192,7 +164,7 @@ public class ConvictionTransformerTest {
     }
 
     @Test
-    public void bookingNumberCopiedFromCustodyPrisonerNumber() {
+    void bookingNumberCopiedFromCustodyPrisonerNumber() {
         assertThat(
             ConvictionTransformer.convictionOf(
                 anEvent()
@@ -213,7 +185,7 @@ public class ConvictionTransformerTest {
     }
 
     @Test
-    public void institutionCopiedFromCustodyWhenPresent() {
+    void institutionCopiedFromCustodyWhenPresent() {
         assertThat(
             ConvictionTransformer.convictionOf(
                 anEvent()
@@ -235,7 +207,7 @@ public class ConvictionTransformerTest {
     }
 
     @Test
-    public void institutionNotCopiedFromCustodyWhenNotPresent() {
+    void institutionNotCopiedFromCustodyWhenNotPresent() {
 
         assertThat(
             ConvictionTransformer.convictionOf(
@@ -259,7 +231,7 @@ public class ConvictionTransformerTest {
 
 
     @Test
-    public void unpaidWorkMappedWherePresent() {
+    void unpaidWorkMappedWherePresent() {
 
         Event event = EntityHelper.anEvent().toBuilder()
             .disposal(Disposal.builder()
@@ -319,7 +291,7 @@ public class ConvictionTransformerTest {
     }
 
     @Test
-    public void unpaidWorkIsNullWhereNonePresent() {
+    void unpaidWorkIsNullWhereNonePresent() {
         Event event = EntityHelper.anEvent().toBuilder()
             .disposal(Disposal.builder()
                 .unpaidWorkDetails(null)
@@ -332,7 +304,7 @@ public class ConvictionTransformerTest {
     }
 
     @Test
-    public void sentenceStartDateCopiedWhenPresent() {
+    void sentenceStartDateCopiedWhenPresent() {
         Event event = EntityHelper.anEvent().toBuilder()
             .disposal(Disposal.builder()
                 .startDate(LocalDate.of(2020, 2, 22))
@@ -344,7 +316,7 @@ public class ConvictionTransformerTest {
     }
 
     @Test
-    public void sentenceTerminationDetailsCopiedWhenPresent() {
+    void sentenceTerminationDetailsCopiedWhenPresent() {
 
         final StandardReference standardReference = StandardReference.builder()
             .standardReferenceListId(3758L)
@@ -365,7 +337,7 @@ public class ConvictionTransformerTest {
     }
 
     @Test
-    public void sentenceType(){
+    void sentenceType(){
         Event event = EntityHelper.anEvent().toBuilder()
             .disposal(Disposal.builder()
                 .disposalType(DisposalType.builder().sentenceType("SC").description("SC Description").build())
@@ -441,18 +413,66 @@ public class ConvictionTransformerTest {
         }
     }
 
-    private CourtAppearance aCourtAppearance(String outcomeDescription, String outcomeCode, LocalDateTime appearanceDate) {
-        return EntityHelper.aCourtAppearanceWithOutcome(outcomeCode,outcomeDescription)
-            .toBuilder()
-            .appearanceDate(appearanceDate)
-            .build();
-    }
+    @Nested
+    class CourtAppearanceRelated {
+        @Test
+        void outcomeMappedFromLastCourtAppearance() {
+            assertThat(ConvictionTransformer.convictionOf(
+                anEvent()
+                    .toBuilder()
+                    .courtAppearances(ImmutableList.of(
+                        aCourtAppearanceWithNoOutcome(LocalDateTime.now()),
+                        aCourtAppearance("Final Review", "Y", LocalDateTime.now().minusDays(1)),
+                        aCourtAppearance("Adjourned", "X", LocalDateTime.now().minusDays(2))
+                    ))
+                    .build()).getLatestCourtAppearanceOutcome())
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("code", "Y")
+                .hasFieldOrPropertyWithValue("description", "Final Review");
+        }
 
-    private CourtAppearance aCourtAppearanceWithNoOutcome(LocalDateTime appearanceDate) {
-        return EntityHelper.aCourtAppearanceWithOutOutcome()
-            .toBuilder()
-            .appearanceDate(appearanceDate)
-            .build();
+        @Test
+        void outcomeIndicatesAwaitingPsr() {
+            assertThat(ConvictionTransformer.convictionOf(
+                anEvent()
+                    .toBuilder()
+                    .courtAppearances(ImmutableList.of(
+                        aCourtAppearanceWithNoOutcome(LocalDateTime.now()),
+                        aCourtAppearance("Final Review", "Y", LocalDateTime.now().minusDays(1)),
+                        aCourtAppearance("PSR Adjourned", REFERENCE_DATA_PSR_ADJOURNED_CODE, LocalDateTime.now().minusDays(2))
+                    ))
+                    .build()))
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("awaitingPsr", true);
+        }
+
+        @Test
+        void courtMappedFromLatestAppearance() {
+            assertThat(ConvictionTransformer.convictionOf(
+                anEvent()
+                    .toBuilder()
+                    .courtAppearances(List.of(
+                        aCourtAppearanceWithNoOutcome(LocalDateTime.of(2015, 6, 10, 12, 0)),
+                        aCourtAppearanceWithNoOutcome(LocalDateTime.of(2015, 6, 11, 12, 0))
+                    ))
+                    .build()))
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("courtAppearance.appearanceDate", LocalDateTime.of(2015, 6, 11, 12, 0));
+        }
+
+        private CourtAppearance aCourtAppearance(String outcomeDescription, String outcomeCode, LocalDateTime appearanceDate) {
+            return EntityHelper.aCourtAppearanceWithOutcome(outcomeCode,outcomeDescription)
+                .toBuilder()
+                .appearanceDate(appearanceDate)
+                .build();
+        }
+
+        private CourtAppearance aCourtAppearanceWithNoOutcome(LocalDateTime appearanceDate) {
+            return EntityHelper.aCourtAppearanceWithOutOutcome()
+                .toBuilder()
+                .appearanceDate(appearanceDate)
+                .build();
+        }
     }
 
     private AdditionalOffence anAdditionalOffence() {

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderConvictionsByCrn.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderConvictionsByCrn.java
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.delius.controller.secure;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.digital.delius.data.api.Conviction;
-import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.data.api.Offence;
 
 import java.util.stream.Stream;
@@ -13,9 +12,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-public class OffendersResource_getOffenderConvictionsByCrn extends IntegrationTestBase {
+class OffendersResource_getOffenderConvictionsByCrn extends IntegrationTestBase {
     @Test
-    public void canGetOffenderConvictionsByCrn() {
+    void canGetOffenderConvictionsByCrn() {
         final var convictions = given()
                 .auth()
                 .oauth2(tokenWithRoleCommunity())
@@ -29,9 +28,10 @@ public class OffendersResource_getOffenderConvictionsByCrn extends IntegrationTe
                 .as(Conviction[].class);
 
         final var conviction = Stream.of(convictions).filter(Conviction::getActive).findAny().orElseThrow();
+        assertThat(conviction.isAwaitingPsr()).isTrue();
         final var offence = conviction.getOffences().stream().filter(Offence::getMainOffence).findAny().orElseThrow();
         assertThat(offence.getDetail().getCode()).isEqualTo("00102");
-        KeyValue sentenceType = conviction.getSentence().getSentenceType();
+        final var sentenceType = conviction.getSentence().getSentenceType();
         assertThat(sentenceType.getCode()).isEqualTo("SC");
         assertThat(sentenceType.getDescription()).isEqualTo("CJA - Indeterminate Public Prot.");
 
@@ -44,7 +44,7 @@ public class OffendersResource_getOffenderConvictionsByCrn extends IntegrationTe
     }
 
     @Test
-    public void canGetOffenderConvictionByCrnAndConvictionId() {
+    void canGetOffenderConvictionByCrnAndConvictionId() {
         final var conviction = given()
             .auth()
             .oauth2(tokenWithRoleCommunity())
@@ -59,11 +59,10 @@ public class OffendersResource_getOffenderConvictionsByCrn extends IntegrationTe
 
         final var offence = conviction.getOffences().stream().filter(Offence::getMainOffence).findAny().orElseThrow();
         assertThat(offence.getDetail().getCode()).isEqualTo("05600");
-
     }
 
     @Test
-    public void convictionsHaveAssociatedUnpaidWorkData() {
+    void convictionsHaveAssociatedUnpaidWorkData() {
         given()
                 .auth()
                 .oauth2(tokenWithRoleCommunity())
@@ -83,7 +82,7 @@ public class OffendersResource_getOffenderConvictionsByCrn extends IntegrationTe
     }
 
     @Test
-    public void getOffenderConvictionsByCrn_offenderNotFound_returnsNotFound() {
+    void getOffenderConvictionsByCrn_offenderNotFound_returnsNotFound() {
         given()
                 .auth()
                 .oauth2(tokenWithRoleCommunity())
@@ -95,7 +94,7 @@ public class OffendersResource_getOffenderConvictionsByCrn extends IntegrationTe
     }
 
     @Test
-    public void canGetActiveConvictionsOnly(){
+    void canGetActiveConvictionsOnly(){
         final var convictions = given()
             .auth()
             .oauth2(tokenWithRoleCommunity())


### PR DESCRIPTION
Adds a flag to the Conviction to indicate whether or not that conviction is awaiting a PSR.  It looks amongst the outcomes on the appearances, which are already fetched as part of another field. 