### PR TITLE
DT-2054 Exclude recall NSIs which is in PSS phase

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Custody.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Custody.java
@@ -127,7 +127,9 @@ public class Custody extends AuditableEntity {
     }
 
     public boolean hasReleaseLicenceExpired() {
-        return keyDates.stream().anyMatch(keyDate -> keyDate.isLicenceExpiryDate() && keyDate.isDateInPast());
+        return isPostSentenceSupervision() || keyDates
+            .stream()
+            .anyMatch(keyDate -> keyDate.isLicenceExpiryDate() && keyDate.isDateInPast());
     }
 
 }

--- a/src/test/java/uk/gov/justice/digital/delius/jpa/standard/entity/CustodyTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/jpa/standard/entity/CustodyTest.java
@@ -86,6 +86,17 @@ public class CustodyTest {
         }
 
         @Test
+        @DisplayName("licence is expired when no LED within key dates but is PSS phase")
+        void licenceIsExpiredWhenNoLEDWithinKeyDatesButIsPSSPhase() {
+            final var futureSentenceExpiryDate = aKeyDate("SED", "SentenceExpiryDate", LocalDate.now().plusMonths(12));
+            final var custodyInPSSWithNoLED = custody.toBuilder()
+                .custodialStatus(StandardReference.builder().codeValue("P").build())
+                .keyDates(List.of(futureSentenceExpiryDate)).build();
+
+            assertThat(custodyInPSSWithNoLED.hasReleaseLicenceExpired()).isTrue();
+        }
+
+        @Test
         @DisplayName("licence not expired when future LED found")
         void licenceNotExpiredWhenFutureLEDFound() {
             final var pastSentenceExpiryDate = aKeyDate("SED", "SentenceExpiryDate", LocalDate.now().minusMonths(12));


### PR DESCRIPTION
Endpoint does not return recall NSIs after the licence period, however in live it was observed that some Events had no licence expiry date but had entered the PPS phase (so therefore had passed licence expiry) - e.g LED was just not present in Delius but obviously does exists in real world.

So if sentence has entered PSS no need to consult LED since by definition licence period has expired.