### PR TITLE
E2E-634: fix offender summary not returning preferred name

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/OffenderDetailSummary.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/OffenderDetailSummary.java
@@ -25,6 +25,8 @@ public class OffenderDetailSummary {
     private String surname;
     @ApiModelProperty(example = "Davis")
     private String previousSurname;
+    @ApiModelProperty(name = "Preferred name or commonly known as", example = "Bob")
+    private String preferredName;
     @ApiModelProperty(example = "1982-10-24")
     private LocalDate dateOfBirth;
     @ApiModelProperty(example = "Male")

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/OffenderTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/OffenderTransformer.java
@@ -225,6 +225,7 @@ public class OffenderTransformer {
                 .middleNames(combinedMiddleNamesOf(offender.getSecondName(), offender.getThirdName()))
                 .surname(offender.getSurname())
                 .previousSurname(offender.getPreviousSurname())
+                .preferredName(offender.getPreferredName())
                 .title(Optional.ofNullable(offender.getTitle()).map(StandardReference::getCodeDescription).orElse(null))
                 .contactDetails(contactDetailsSummaryOf(offender))
                 .otherIds(idsOf(offender))

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderByCrn.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderByCrn.java
@@ -91,6 +91,14 @@ public class OffendersResource_getOffenderByCrn extends IntegrationTestBase {
             .as(OffenderDetailSummary.class);
 
         assertThat(offenderDetail.getOtherIds().getCrn()).isEqualTo("X320741");
+
+        assertThat(offenderDetail)
+            .hasFieldOrPropertyWithValue("firstName", "Aadland")
+            .hasFieldOrPropertyWithValue("middleNames", List.of("Danger"))
+            .hasFieldOrPropertyWithValue("surname", "Bertrand")
+            .hasFieldOrPropertyWithValue("preferredName", "Bob")
+            .hasFieldOrPropertyWithValue("offenderProfile.genderIdentity", "Prefer to self-describe")
+            .hasFieldOrPropertyWithValue("offenderProfile.selfDescribedGender", "Jedi");
     }
 
     @Test


### PR DESCRIPTION
Preferred name was added to the offender detail api but not the offender summary api