### PR TITLE
E2E-634: expose rar requirement id on appointment apis

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentDetail.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentDetail.java
@@ -56,4 +56,22 @@ public class AppointmentDetail {
 
     @ApiModelProperty(name = "RAR activity flag", example = "true")
     private Boolean rarActivity;
+
+    @ApiModelProperty(name = "The related requirement if present")
+    private AppointmentRequirementDetail requirement;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AppointmentRequirementDetail {
+        @ApiModelProperty(name = "The unique identifier for an associated requirement", example = "25000000")
+        private Long requirementId;
+
+        @ApiModelProperty(name = "The requirement is a RAR requirement", example = "true")
+        private Boolean isRar;
+
+        @ApiModelProperty(name = "The requirement is active", example = "true")
+        private Boolean isActive;
+    }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Requirement.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Requirement.java
@@ -8,6 +8,9 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static uk.gov.justice.digital.delius.jpa.standard.entity.RequirementTypeMainCategory.REHABILITATION_ACTIVITY_REQUIREMENT_CODE;
 
 @Data
 @NoArgsConstructor
@@ -43,7 +46,7 @@ public class Requirement {
     private LocalDateTime createdDatetime;
 
     @Column(name = "ACTIVE_FLAG")
-    private Long activeFlag;
+    private Boolean activeFlag;
 
     @JoinColumn(name = "RQMNT_TYPE_SUB_CATEGORY_ID")
     @OneToOne
@@ -76,5 +79,11 @@ public class Requirement {
     private Long rarCount;
 
     @Column(name = "SOFT_DELETED")
-    private Long softDeleted = 0L;
+    private Boolean softDeleted = false;
+
+    public boolean isRarRequirement() {
+        return Optional.ofNullable(getRequirementTypeMainCategory())
+            .map(t -> REHABILITATION_ACTIVITY_REQUIREMENT_CODE.equals(t.getCode()))
+            .orElse(false);
+    }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/service/ConvictionService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ConvictionService.java
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.Disposal;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Event;
 import uk.gov.justice.digital.delius.jpa.standard.entity.KeyDate;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Offender;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Requirement;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 import uk.gov.justice.digital.delius.jpa.standard.repository.EventRepository;
 import uk.gov.justice.digital.delius.jpa.standard.repository.OffenderRepository;
@@ -154,7 +155,7 @@ public class ConvictionService {
                     .map(Disposal::getRequirements)
                     .stream()
                     .flatMap(Collection::stream)
-                    .filter(requirement -> convertToBoolean(requirement.getActiveFlag()))
+                    .filter(Requirement::getActiveFlag)
                     .map(requirement -> requirement.getRequirementTypeMainCategory().getCode())
                     .anyMatch(code -> requirementTypeMainCategoryCode.equals(code)))
             .sorted(Comparator.comparing(uk.gov.justice.digital.delius.jpa.standard.entity.Event::getReferralDate).reversed())

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentTransformer.java
@@ -11,7 +11,10 @@ import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Contact;
 import uk.gov.justice.digital.delius.jpa.standard.entity.ContactOutcomeType;
 import uk.gov.justice.digital.delius.jpa.standard.entity.ContactType;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Nsi;
 import uk.gov.justice.digital.delius.jpa.standard.entity.OfficeLocation;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Requirement;
+import uk.gov.justice.digital.delius.jpa.standard.entity.RequirementTypeMainCategory;
 import uk.gov.justice.digital.delius.utils.DateConverter;
 
 import java.util.List;
@@ -48,6 +51,18 @@ public class AppointmentTransformer {
             .sensitive(ynToBoolean(contact.getSensitive()))
             .outcome(appointmentOutcomeOf(contact))
             .rarActivity(ynToBoolean(contact.getRarActivity()))
+            .requirement(
+                Optional.ofNullable(contact.getNsi())
+                    .filter(nsi -> !nsi.isSoftDeleted())
+                    .map(Nsi::getRqmnt)
+                    .filter(r -> !r.getSoftDeleted())
+                    .map(r -> AppointmentDetail.AppointmentRequirementDetail.builder()
+                        .requirementId(r.getRequirementId())
+                        .isActive(r.getActiveFlag())
+                        .isRar(r.isRarRequirement())
+                        .build())
+                    .orElse(null)
+            )
             .build();
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/RequirementTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/RequirementTransformer.java
@@ -11,14 +11,12 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 
 import java.util.Optional;
 
-import static uk.gov.justice.digital.delius.transformers.TypesTransformer.zeroOneToBoolean;
-
 public class RequirementTransformer {
 
     public static uk.gov.justice.digital.delius.data.api.Requirement requirementOf(Requirement requirement) {
         return Optional.ofNullable(requirement)
                 .map(req -> uk.gov.justice.digital.delius.data.api.Requirement.builder()
-                        .active(zeroOneToBoolean(req.getActiveFlag()))
+                        .active(req.getActiveFlag())
                         .adRequirementTypeMainCategory(adRequirementMainCategoryOf(req.getAdRequirementTypeMainCategory()))
                         .adRequirementTypeSubCategory(KeyValueTransformer.keyValueOf(req.getAdRequirementTypeSubCategory()))
                         .commencementDate(req.getCommencementDate())
@@ -36,7 +34,7 @@ public class RequirementTransformer {
                         .lengthUnit(lengthUnitOf(req))
                         .restrictive(restrictiveOf(req.getRequirementTypeMainCategory()))
                         .rarCount(req.getRarCount())
-                        .softDeleted(zeroOneToBoolean(req.getSoftDeleted()))
+                        .softDeleted(req.getSoftDeleted())
                         .build())
                 .orElse(null);
     }

--- a/src/test/java/uk/gov/justice/digital/delius/service/ConvictionServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ConvictionServiceTest.java
@@ -246,7 +246,7 @@ class ConvictionServiceTest {
                 .thenReturn(asList(
                     aEvent().toBuilder().eventId(99L).offenderId(1L).softDeleted(false)
                         .disposal(Disposal.builder().disposalId(98L).requirements(
-                            singletonList(Requirement.builder().activeFlag(0L).build())).build())
+                            singletonList(Requirement.builder().activeFlag(false).build())).build())
                         .build()
                 ));
 
@@ -260,7 +260,7 @@ class ConvictionServiceTest {
                 .thenReturn(asList(
                     aEvent().toBuilder().eventId(99L).offenderId(1L).softDeleted(false)
                         .disposal(Disposal.builder().disposalId(98L).requirements(
-                            singletonList(Requirement.builder().activeFlag(1L).requirementTypeMainCategory(
+                            singletonList(Requirement.builder().activeFlag(false).requirementTypeMainCategory(
                                 RequirementTypeMainCategory.builder().code(EXCLUSION_REQUIREMENT_CODE).build()).build())).build())
                         .build()
                 ));
@@ -275,12 +275,12 @@ class ConvictionServiceTest {
                 .thenReturn(asList(
                     aEvent().toBuilder().eventId(99L).offenderId(1L).referralDate(now()).softDeleted(false)
                         .disposal(Disposal.builder().disposalId(98L).disposalType(aNcDisposalType()).requirements(
-                            singletonList(Requirement.builder().activeFlag(1L).requirementTypeMainCategory(
+                            singletonList(Requirement.builder().activeFlag(true).requirementTypeMainCategory(
                                 RequirementTypeMainCategory.builder().code(REHABILITATION_ACTIVITY_REQUIREMENT_CODE).build()).build())).build())
                         .build(),
                     aEvent().toBuilder().eventId(101L).offenderId(1L).referralDate(now().plusDays(1)).softDeleted(false)
                         .disposal(Disposal.builder().disposalId(100L).disposalType(aNcDisposalType()).requirements(
-                            singletonList(Requirement.builder().activeFlag(1L).requirementTypeMainCategory(
+                            singletonList(Requirement.builder().activeFlag(true).requirementTypeMainCategory(
                                 RequirementTypeMainCategory.builder().code(REHABILITATION_ACTIVITY_REQUIREMENT_CODE).build()).build())).build())
                         .build()
                 ));

--- a/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/RequirementServiceTest.java
@@ -229,8 +229,8 @@ public class RequirementServiceTest {
             when(disposal.getRequirements()).thenReturn(Collections.singletonList(Requirement
                 .builder()
                 .requirementId(99L)
-                .activeFlag(1L)
-                .softDeleted(0L)
+                .activeFlag(true)
+                .softDeleted(false)
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build())
                 .build()));
             var requirement = requirementService.getActiveRequirement(CRN, CONVICTION_ID, REHABILITATION_ACTIVITY_REQUIREMENT_TYPE);
@@ -242,8 +242,8 @@ public class RequirementServiceTest {
             when(disposal.getRequirements()).thenReturn(Collections.singletonList(Requirement
                 .builder()
                 .requirementId(99L)
-                .activeFlag(1L)
-                .softDeleted(0L)
+                .activeFlag(true)
+                .softDeleted(false)
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("X").build())
                 .build()));
 
@@ -255,7 +255,7 @@ public class RequirementServiceTest {
             when(disposal.getRequirements()).thenReturn(Collections.singletonList(Requirement
                 .builder()
                 .requirementId(99L)
-                .activeFlag(0L)
+                .activeFlag(false)
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build())
                 .build()));
 
@@ -267,8 +267,8 @@ public class RequirementServiceTest {
             when(disposal.getRequirements()).thenReturn(Collections.singletonList(Requirement
                 .builder()
                 .requirementId(99L)
-                .activeFlag(1L)
-                .softDeleted(1L)
+                .activeFlag(true)
+                .softDeleted(true)
                 .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build())
                 .build()));
 
@@ -279,13 +279,13 @@ public class RequirementServiceTest {
         public void whenGetReferralRequirementByConvictionId_AndMultipleRequirementsExist_thenSelectLatest() {
             LocalDateTime now = LocalDateTime.now();
             when(disposal.getRequirements()).thenReturn(Arrays.asList(
-                Requirement.builder().requirementId(99L).activeFlag(1L).softDeleted(0L)
+                Requirement.builder().requirementId(99L).activeFlag(true).softDeleted(false)
                     .startDate(now.minusDays(1).toLocalDate()).createdDatetime(now)
                     .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build()).build(),
-                Requirement.builder().requirementId(100L).activeFlag(1L).softDeleted(0L)
+                Requirement.builder().requirementId(100L).activeFlag(true).softDeleted(false)
                     .startDate(now.toLocalDate()).createdDatetime(now.plusHours(2))
                     .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build()).build(),
-                Requirement.builder().requirementId(101L).activeFlag(1L).softDeleted(0L)
+                Requirement.builder().requirementId(101L).activeFlag(true).softDeleted(false)
                     .startDate(now.toLocalDate()).createdDatetime(now.plusHours(1))
                     .requirementTypeMainCategory(RequirementTypeMainCategory.builder().code("F").build()).build())
             );

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentTransformerTest.java
@@ -104,6 +104,22 @@ public class AppointmentTransformerTest {
     }
 
     @Test
+    public void rarRequirementMappedFromRarRequirement() {
+        final var requirement = EntityHelper.aRarRequirement();
+        final var source = EntityHelper.aContact()
+            .toBuilder()
+            .nsi(EntityHelper.aNsi().toBuilder().rqmnt(requirement).build())
+            .build();
+
+        final var observed = AppointmentTransformer.appointmentDetailOf(source);
+
+        assertThat(observed)
+            .hasFieldOrPropertyWithValue("requirement.requirementId", requirement.getRequirementId())
+            .hasFieldOrPropertyWithValue("requirement.isRar", true)
+            .hasFieldOrPropertyWithValue("requirement.isActive", true);
+    }
+
+    @Test
     public void appointmentDetailFromContactHandlesNulls() {
         final var contact = EntityHelper.aContact().toBuilder()
             .contactStartTime(null)
@@ -113,6 +129,7 @@ public class AppointmentTransformerTest {
             .sensitive(null)
             .contactOutcomeType(null)
             .rarActivity(null)
+            .nsi(null)
             .build();
         final var observed = AppointmentTransformer.appointmentDetailOf(contact);
         final var expectedDate = DateConverter.toOffsetDateTime(LocalDateTime.of(contact.getContactDate(), LocalTime.MIDNIGHT));
@@ -125,7 +142,8 @@ public class AppointmentTransformerTest {
             .hasFieldOrPropertyWithValue("notes", null)
             .hasFieldOrPropertyWithValue("sensitive", null)
             .hasFieldOrPropertyWithValue("outcome", null)
-            .hasFieldOrPropertyWithValue("rarActivity", null);
+            .hasFieldOrPropertyWithValue("rarActivity", null)
+            .hasFieldOrPropertyWithValue("requirement", null);
     }
 
     private Contact aContact() {

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/NsiTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/NsiTransformerTest.java
@@ -116,7 +116,7 @@ class NsiTransformerTest {
                 .activeFlag(1L)
                 .softDeleted(0L)
                 .nsiManagers(List.of(EntityHelper.aNsiManager(), EntityHelper.aNsiManager()))
-                .rqmnt(Requirement.builder().activeFlag(1L).build()).build();
+                .rqmnt(Requirement.builder().activeFlag(true).build()).build();
     }
 
 }

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/RequirementTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/RequirementTransformerTest.java
@@ -55,7 +55,7 @@ public class RequirementTransformerTest {
         LocalDateTime createdDatetime = LocalDateTime.of(2020, 5, 1, 2, 3, 4);
         Requirement requirement = Requirement.builder()
             .requirementId(88L)
-            .activeFlag(1L)
+            .activeFlag(true)
             .commencementDate(commencementDate)
             .expectedStartDate(expectedStartDate)
             .expectedEndDate(expectedEndDate)
@@ -81,7 +81,7 @@ public class RequirementTransformerTest {
                 .codeDescription("Sub")
                 .build())
             .rarCount(10L)
-            .softDeleted(1L)
+            .softDeleted(true)
             .build();
         uk.gov.justice.digital.delius.data.api.Requirement pssRequirement = RequirementTransformer.requirementOf(requirement);
 

--- a/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
+++ b/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
@@ -59,6 +59,8 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.RecallReason;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Referral;
 import uk.gov.justice.digital.delius.jpa.standard.entity.ReferralDocument;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Release;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Requirement;
+import uk.gov.justice.digital.delius.jpa.standard.entity.RequirementTypeMainCategory;
 import uk.gov.justice.digital.delius.jpa.standard.entity.ResponsibleOfficer;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Staff;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
@@ -482,6 +484,18 @@ public class EntityHelper {
                 .toBuilder()
                 .event(anEvent(eventId))
                 .build();
+    }
+
+    public static Requirement aRarRequirement() {
+        return Requirement.builder()
+            .requirementId(1000L)
+            .requirementTypeMainCategory(RequirementTypeMainCategory.builder()
+                .code(RequirementTypeMainCategory.REHABILITATION_ACTIVITY_REQUIREMENT_CODE)
+                .description("Rehabilitation activity")
+                .build())
+            .activeFlag(true)
+            .softDeleted(false)
+            .build();
     }
 
     public static Nsi aNsi() {


### PR DESCRIPTION
Appointment consumers are interested in whether or not an appointment relates to a RAR requirement. This compliments the RAR_ACTIVITY flag for determining whether the appoint had anything to do with RAR. Decided not to include the entire requirement in the response for performance.