### PR TITLE
IC-2141 Exclude "soft-deleted" nsi's

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/Nsi.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/Nsi.java
@@ -35,6 +35,7 @@ public class Nsi {
     private String notes;
     private ProbationArea intendedProvider;
     private Boolean active;
+    private Boolean softDeleted;
 
     static <E extends Enum<E>> E valueOf(E defaultValue, String code) {
         try {

--- a/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/ReferralService.java
@@ -115,6 +115,7 @@ public class ReferralService {
         var existingNsis = nsiService.getNsiByCodes(offenderId, sentenceId, Collections.singletonList(getNsiType(nsiMapping, contractType)))
             .map(wrapper -> wrapper.getNsis().stream()
                 // eventID, offenderID, nsi type are handled in the NSI service
+                .filter(nsi -> !nsi.getSoftDeleted())
                 .filter(nsi -> ofNullable(nsi.getReferralDate()).map(n -> n.equals(toLondonLocalDate(startedAt))).orElse(false))
                 .filter(nsi -> ofNullable(nsi.getNsiStatus()).map(n -> n.getCode().equals(nsiMapping.getNsiStatus())).orElse(false))
                 .filter(nsi -> Objects.isNull(nsi.getNsiOutcome()))

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/NsiTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/NsiTransformer.java
@@ -38,6 +38,7 @@ public class NsiTransformer {
                 .notes(n.getNotes())
                 .intendedProvider(ProbationAreaTransformer.probationAreaOf(n.getIntendedProvider(), INCLUDE_INTENDED_PROVIDER_TEAMS))
                 .active(zeroOneToBoolean(nsi.getActiveFlag()))
+                .softDeleted(zeroOneToBoolean(nsi.getSoftDeleted()))
 
                 .build()).orElse(null);
     }

--- a/src/test/java/uk/gov/justice/digital/delius/service/ReferralServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/ReferralServiceTest.java
@@ -83,6 +83,7 @@ public class ReferralServiceTest {
         .referralDate(LocalDate.of(2021, 1, 20))
         .nsiStatus(KeyValue.builder().code(NSI_STATUS).build())
         .requirement(Requirement.builder().requirementId(REQUIREMENT_ID).build())
+        .softDeleted(false)
         .intendedProvider(ProbationArea.builder().code(PROVIDER_CODE).build())
         .nsiManagers(singletonList(
             NsiManager.builder()
@@ -467,6 +468,8 @@ public class ReferralServiceTest {
         return Stream.of(
             Arguments.of(REFERRAL_START_REQUEST, MATCHING_NSI, true),
             Arguments.of(REFERRAL_START_REQUEST, MATCHING_NSI.withNsiOutcome(KeyValue.builder().code("CANCELLED").build()), false),
+            Arguments.of(REFERRAL_START_REQUEST, MATCHING_NSI.withSoftDeleted(false), true),
+            Arguments.of(REFERRAL_START_REQUEST, MATCHING_NSI.withSoftDeleted(true), false),
             Arguments.of(REFERRAL_START_REQUEST.withStartedAt(OffsetDateTime.of(2017, 1, 1, 12, 0, 0, 0, ZoneOffset.UTC)), MATCHING_NSI, false)
         );
     }

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/NsiTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/NsiTransformerTest.java
@@ -75,6 +75,7 @@ class NsiTransformerTest {
         assertThat(nsi.getLengthUnit()).isEqualTo("Months");
         assertThat(nsi.getNotes()).isEqualTo("Some notes");
         assertThat(nsi.getActive()).isEqualTo(true);
+        assertThat(nsi.getSoftDeleted()).isEqualTo(false);
 
         assertThat(nsi.getNsiManagers()).isNotNull();
         assertThat(nsi.getNsiManagers()).hasSize(2);


### PR DESCRIPTION
**What does this pull request do?**
As part of the integration with R&M, when finding a matching NSI Community-api must exclude "soft-deleted" NSI's.

**What is the intent behind these changes?**
This is to fix a rare situation after which duplicate NSIs are present in nDelius, which then need to be manually deleted from nDelius.

**Any breaking changes?**
None 