### PR TITLE
🐞PIC-1575 only consider latest outcome when looking for awaiting PSR

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceBasicTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceBasicTransformer.java
@@ -6,9 +6,11 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.Court;
 import uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Offender;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
+import uk.gov.justice.digital.delius.service.ReferenceDataService;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public class CourtAppearanceBasicTransformer {
@@ -50,4 +52,11 @@ public class CourtAppearanceBasicTransformer {
             );
     }
 
+    public static boolean outcomeContainsAwaitingPsr(final List<CourtAppearance> courtAppearances) {
+        return courtAppearances
+            .stream()
+            .map(CourtAppearance::getOutcome)
+            .filter(Objects::nonNull)
+            .anyMatch(outcome -> ReferenceDataService.REFERENCE_DATA_PSR_ADJOURNED_CODE.equals(outcome.getCodeValue()));
+    }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceBasicTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceBasicTransformer.java
@@ -6,11 +6,9 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.Court;
 import uk.gov.justice.digital.delius.jpa.standard.entity.CourtAppearance;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Offender;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
-import uk.gov.justice.digital.delius.service.ReferenceDataService;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 public class CourtAppearanceBasicTransformer {
@@ -52,11 +50,4 @@ public class CourtAppearanceBasicTransformer {
             );
     }
 
-    public static boolean awaitingPsrOf(final List<CourtAppearance> courtAppearances) {
-        return courtAppearances
-            .stream()
-            .map(CourtAppearance::getOutcome)
-            .filter(Objects::nonNull)
-            .anyMatch(outcome -> ReferenceDataService.REFERENCE_DATA_PSR_ADJOURNED_CODE.equals(outcome.getCodeValue()));
-    }
 }

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformerTest.java
@@ -455,14 +455,28 @@ class ConvictionTransformerTest {
         }
 
         @Test
-        void outcomeIndicatesAwaitingPsr() {
+        void givenPsrAdjournmentIsSuperseded_outcomeDoesNotContainAwaitingPsr() {
             assertThat(ConvictionTransformer.convictionOf(
                 anEvent()
                     .toBuilder()
                     .courtAppearances(ImmutableList.of(
-                        aCourtAppearanceWithNoOutcome(LocalDateTime.now()),
+                        aCourtAppearance("ORA Adult Custody (inc PSS)", "325", LocalDateTime.now()),
                         aCourtAppearance("Final Review", "Y", LocalDateTime.now().minusDays(1)),
                         aCourtAppearance("PSR Adjourned", REFERENCE_DATA_PSR_ADJOURNED_CODE, LocalDateTime.now().minusDays(2))
+                    ))
+                    .build()))
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("awaitingPsr", false);
+        }
+
+        @Test
+        void givenMostRecentOutcomeIsPsr_outcomeIsAwaitingPsr() {
+            assertThat(ConvictionTransformer.convictionOf(
+                anEvent()
+                    .toBuilder()
+                    .courtAppearances(ImmutableList.of(
+                        aCourtAppearance("PSR Adjourned", REFERENCE_DATA_PSR_ADJOURNED_CODE, LocalDateTime.now().minusDays(2)),
+                        aCourtAppearance("Something else", "100", LocalDateTime.now().minusDays(5))
                     ))
                     .build()))
                 .isNotNull()

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/ConvictionTransformerTest.java
@@ -456,8 +456,9 @@ class ConvictionTransformerTest {
 
         @Test
         void givenPsrAdjournmentIsSuperseded_outcomeDoesNotContainAwaitingPsr() {
+
             assertThat(ConvictionTransformer.convictionOf(
-                anEvent()
+                anEvent(aDisposal())
                     .toBuilder()
                     .courtAppearances(ImmutableList.of(
                         aCourtAppearance("ORA Adult Custody (inc PSS)", "325", LocalDateTime.now()),
@@ -576,6 +577,15 @@ class ConvictionTransformerTest {
         return Offence
             .builder()
             .ogrsOffenceCategory(StandardReference.builder().build())
+            .build();
+    }
+
+    private Event anEvent(Disposal disposal) {
+        return Event
+            .builder()
+            .disposal(disposal)
+            .additionalOffences(ImmutableList.of())
+            .courtAppearances(ImmutableList.of())
             .build();
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceBasicTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceBasicTransformerTest.java
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.Offender;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.justice.digital.delius.service.ReferenceDataService.REFERENCE_DATA_PSR_ADJOURNED_CODE;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -53,34 +52,6 @@ class CourtAppearanceBasicTransformerTest {
         final var observed = CourtAppearanceBasicTransformer.latestOrSentencingCourtAppearanceOf(List.of(appearance, latestAppearance));
 
         shouldBeCourtAppearanceBasic(observed, latestDate, APPEARANCE_TYPE_CODE);
-    }
-
-    @Test
-    void givenNoOutcomes_whenGetAwaitingPsr_thenFalse() {
-        final var awaitingPsr = CourtAppearanceBasicTransformer.awaitingPsrOf(List.of(CourtAppearance.builder().build()));
-
-        assertThat(awaitingPsr).isFalse();
-    }
-
-    @Test
-    void givenOutcomeWithWrongCode_whenGetAwaitingPsr_thenFalse() {
-        final var outcome = StandardReference.builder().codeValue("XXX").codeDescription("some other outcome").build();
-
-        final var awaitingPsr = CourtAppearanceBasicTransformer.awaitingPsrOf(List.of(CourtAppearance.builder().outcome(outcome).build()));
-
-        assertThat(awaitingPsr).isFalse();
-    }
-
-    @Test
-    void givenOutcomeWithRequiredCode_whenGetAwaitingPsr_thenTrue() {
-        final var outcome = StandardReference.builder()
-                                                            .codeValue(REFERENCE_DATA_PSR_ADJOURNED_CODE)
-                                                            .codeDescription("A PSR")
-                                                            .build();
-
-        final var awaitingPsr = CourtAppearanceBasicTransformer.awaitingPsrOf(List.of(CourtAppearance.builder().outcome(outcome).build()));
-
-        assertThat(awaitingPsr).isTrue();
     }
 
     private CourtAppearance aCourtAppearance(LocalDateTime date, String typeCode) {

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceBasicTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/CourtAppearanceBasicTransformerTest.java
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.Offender;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.digital.delius.service.ReferenceDataService.REFERENCE_DATA_PSR_ADJOURNED_CODE;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -52,6 +53,34 @@ class CourtAppearanceBasicTransformerTest {
         final var observed = CourtAppearanceBasicTransformer.latestOrSentencingCourtAppearanceOf(List.of(appearance, latestAppearance));
 
         shouldBeCourtAppearanceBasic(observed, latestDate, APPEARANCE_TYPE_CODE);
+    }
+
+    @Test
+    void givenNoOutcomes_whenGetAwaitingPsr_thenFalse() {
+        final var awaitingPsr = CourtAppearanceBasicTransformer.outcomeContainsAwaitingPsr(List.of(CourtAppearance.builder().build()));
+
+        assertThat(awaitingPsr).isFalse();
+    }
+
+    @Test
+    void givenOutcomeWithWrongCode_whenGetAwaitingPsr_thenFalse() {
+        final var outcome = StandardReference.builder().codeValue("XXX").codeDescription("some other outcome").build();
+
+        final var awaitingPsr = CourtAppearanceBasicTransformer.outcomeContainsAwaitingPsr(List.of(CourtAppearance.builder().outcome(outcome).build()));
+
+        assertThat(awaitingPsr).isFalse();
+    }
+
+    @Test
+    void givenOutcomeWithRequiredCode_whenGetAwaitingPsr_thenTrue() {
+        final var outcome = StandardReference.builder()
+                                                            .codeValue(REFERENCE_DATA_PSR_ADJOURNED_CODE)
+                                                            .codeDescription("A PSR")
+                                                            .build();
+
+        final var awaitingPsr = CourtAppearanceBasicTransformer.outcomeContainsAwaitingPsr(List.of(CourtAppearance.builder().outcome(outcome).build()));
+
+        assertThat(awaitingPsr).isTrue();
     }
 
     private CourtAppearance aCourtAppearance(LocalDateTime date, String typeCode) {

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderConvictionsByCrn.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderConvictionsByCrn.java
@@ -30,7 +30,7 @@ class OffendersResource_getOffenderConvictionsByCrn extends IntegrationTestBase 
                 .as(Conviction[].class);
 
         final var conviction = Stream.of(convictions).filter(Conviction::getActive).findAny().orElseThrow();
-        assertThat(conviction.isAwaitingPsr()).isTrue();
+        assertThat(conviction.isAwaitingPsr()).isFalse();
         final var offence = conviction.getOffences().stream().filter(Offence::getMainOffence).findAny().orElseThrow();
         assertThat(offence.getDetail().getCode()).isEqualTo("00102");
         final var sentenceType = conviction.getSentence().getSentenceType();


### PR DESCRIPTION
We had an issue whereby a conviction was still deemed to be awaitingPsr because we were looking for any occurence of the ouctome in the appearances. This fix adopts the approach in ConvictionService when looking at the offender as a whole where we look for that code only for convictions (event) with no disposal