### PR TITLE
IC-2165 New endpoint for only changing the location of an appointment

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingController.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingController.java
@@ -18,10 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.justice.digital.delius.controller.advice.ErrorResponse;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateResponse;
+import uk.gov.justice.digital.delius.data.api.AppointmentRelocateResponse;
 import uk.gov.justice.digital.delius.data.api.AppointmentRescheduleResponse;
 import uk.gov.justice.digital.delius.data.api.AppointmentUpdateResponse;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentOutcomeRequest;
+import uk.gov.justice.digital.delius.data.api.AppointmentRelocateRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentRescheduleRequest;
 import uk.gov.justice.digital.delius.service.AppointmentService;
 
@@ -97,6 +99,25 @@ public class AppointmentBookingController {
                                                                               final @RequestBody ContextlessAppointmentRescheduleRequest appointmentRescheduleRequest) {
 
         return appointmentService.rescheduleAppointment(crn, appointmentId, context, appointmentRescheduleRequest);
+    }
+
+    @RequestMapping(value = "/offenders/crn/{crn}/appointments/{appointmentId}/relocate",
+        method = RequestMethod.POST,
+        consumes = "application/json")
+    @ApiResponses(
+        value = {
+            @ApiResponse(code = 200, message = "Updated", response = String.class),
+            @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
+            @ApiResponse(code = 403, message = "Requires role ROLE_COMMUNITY_INTERVENTIONS_UPDATE"),
+            @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
+        })
+
+    @ApiOperation(value = "Relocates an appointment")
+    public AppointmentRelocateResponse relocateAppointment(final @PathVariable("crn") String crn,
+                                                           final @PathVariable("appointmentId") Long appointmentId,
+                                                           final @RequestBody AppointmentRelocateRequest appointmentRelocateRequest) {
+
+        return appointmentService.relocateAppointment(crn, appointmentId, appointmentRelocateRequest);
     }
 
     @RequestMapping(value = "/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}",

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentRelocateRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentRelocateRequest.java
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.delius.data.api;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppointmentRelocateRequest {
+
+    @NotNull
+    @ApiModelProperty(required = true)
+    private String officeLocationCode;
+}

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentRelocateResponse.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentRelocateResponse.java
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.delius.data.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppointmentRelocateResponse {
+
+    @NotNull
+    private Long appointmentId;
+}

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformer.java
@@ -21,6 +21,7 @@ public class AppointmentPatchRequestTransformer {
     private static final String TARGET_NOTES_FIELD_NAME = "notes";
     private static final String TARGET_OUTCOME_FIELD_NAME = "outcome";
     private static final String TARGET_ENFORCEMENT_FIELD_NAME = "enforcement";
+    private static final String TARGET_OFFICE_LOCATION_FIELD_NAME = "officeLocation";
 
     public static JsonPatch mapAttendanceFieldsToOutcomeOf(final ContextlessAppointmentOutcomeRequest request, final IntegrationContext context) {
 
@@ -30,6 +31,15 @@ public class AppointmentPatchRequestTransformer {
 
         addReplaceOperationForOutcomeIfAttended(
             context, request.getAttended(), request.getNotifyPPOfAttendanceBehaviour(), patchOperations);
+
+        return new JsonPatch(patchOperations);
+    }
+
+    public static JsonPatch mapOfficeLocation(final String officeLocation) {
+
+        final var patchOperations = new ArrayList<JsonPatchOperation>();
+
+        patchOperations.add(new ReplaceOperation(of(TARGET_OFFICE_LOCATION_FIELD_NAME), valueOf(officeLocation)));
 
         return new JsonPatch(patchOperations);
     }

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformer.java
@@ -37,11 +37,7 @@ public class AppointmentPatchRequestTransformer {
 
     public static JsonPatch mapOfficeLocation(final String officeLocation) {
 
-        final var patchOperations = new ArrayList<JsonPatchOperation>();
-
-        patchOperations.add(new ReplaceOperation(of(TARGET_OFFICE_LOCATION_FIELD_NAME), valueOf(officeLocation)));
-
-        return new JsonPatch(patchOperations);
+        return new JsonPatch(List.of(new ReplaceOperation(of(TARGET_OFFICE_LOCATION_FIELD_NAME), valueOf(officeLocation))));
     }
 
     private static void addReplaceOperationForOutcomeIfAttended(final IntegrationContext context,

--- a/src/test/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingControllerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingControllerTest.java
@@ -10,6 +10,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateResponse;
+import uk.gov.justice.digital.delius.data.api.AppointmentRelocateRequest;
+import uk.gov.justice.digital.delius.data.api.AppointmentRelocateResponse;
 import uk.gov.justice.digital.delius.data.api.AppointmentRescheduleResponse;
 import uk.gov.justice.digital.delius.data.api.AppointmentUpdateResponse;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateRequest;
@@ -162,6 +164,29 @@ public class AppointmentBookingControllerTest {
             .extract()
             .body()
             .as(AppointmentCreateResponse.class)
+            .getAppointmentId();
+
+        assertThat(appointmentIdResponse).isEqualTo(3L);
+    }
+
+    @Test
+    public void relocatesAppointmentWithOfficeLocation() {
+        AppointmentRelocateRequest appointmentRelocateRequest = AppointmentRelocateRequest.builder()
+            .officeLocationCode("CRSLOND")
+            .build();
+        when(appointmentService.relocateAppointment("1", 2L, appointmentRelocateRequest))
+            .thenReturn(AppointmentRelocateResponse.builder().appointmentId(3L).build());
+
+        Long appointmentIdResponse = given()
+            .contentType(APPLICATION_JSON_VALUE)
+            .body(appointmentRelocateRequest)
+            .when()
+            .post("/secure/offenders/crn/1/appointments/2/relocate")
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .as(AppointmentRelocateResponse.class)
             .getAppointmentId();
 
         assertThat(appointmentIdResponse).isEqualTo(3L);

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformerTest.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.justice.digital.delius.transformers.AppointmentPatchRequestTransformer.mapAttendanceFieldsToOutcomeOf;
+import static uk.gov.justice.digital.delius.transformers.AppointmentPatchRequestTransformer.mapOfficeLocation;
 
 class AppointmentPatchRequestTransformerTest {
 
@@ -65,6 +66,15 @@ class AppointmentPatchRequestTransformerTest {
             .isEqualTo("[{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}," +
                 "{\"op\":\"replace\",\"path\":\"/outcome\",\"value\":\"AFTC\"}," +
                 "{\"op\":\"replace\",\"path\":\"/enforcement\",\"value\":\"ROM\"}]");
+    }
+
+    @Test
+    public void transformsJsonPatchUsingOfficeLocation() throws JsonProcessingException {
+
+        final var patch = mapOfficeLocation("CRSLOND");
+
+        assertThat(objectMapper.writeValueAsString(patch))
+            .isEqualTo("[{\"op\":\"replace\",\"path\":\"/officeLocation\",\"value\":\"CRSLOND\"}]");
     }
 
     @Test

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AppointmentBookingAPITest.java
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.delius.JwtParameters;
 import uk.gov.justice.digital.delius.controller.wiremock.DeliusApiExtension;
 import uk.gov.justice.digital.delius.controller.wiremock.DeliusApiMockServer;
 import uk.gov.justice.digital.delius.data.api.AppointmentCreateRequest;
+import uk.gov.justice.digital.delius.data.api.AppointmentRelocateRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentCreateRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentOutcomeRequest;
 import uk.gov.justice.digital.delius.data.api.ContextlessAppointmentRescheduleRequest;
@@ -139,7 +140,7 @@ public class AppointmentBookingAPITest extends IntegrationTestBase {
     @Test
     public void shouldReturnOKAfterPatchingUpdatingAppointmentUsingContextlessClientEndpoint() {
 
-        deliusApiMockServer.stubPatchContactToDeliusApi();
+        deliusApiMockServer.stubPatchContactToDeliusApi(2500029015L);
 
         final var token = createJwt("bob", Collections.singletonList("ROLE_COMMUNITY_INTERVENTIONS_UPDATE"));
 
@@ -180,6 +181,27 @@ public class AppointmentBookingAPITest extends IntegrationTestBase {
             .assertThat()
             .statusCode(HttpStatus.OK.value())
             .body("appointmentId", equalTo(2500029016L));
+    }
+
+    @Test
+    public void shouldReturnOKAfterRelocatingAppointment() {
+
+        deliusApiMockServer.stubPatchContactToDeliusApi(2512709905L);
+
+        final var token = createJwt("bob", Collections.singletonList("ROLE_COMMUNITY_INTERVENTIONS_UPDATE"));
+
+        given()
+            .when()
+            .auth().oauth2(token)
+            .contentType(String.valueOf(ContentType.APPLICATION_JSON))
+            .body(AppointmentRelocateRequest.builder()
+                .officeLocationCode("CRSLOND")
+                .build())
+            .post("offenders/crn/X320741/appointments/2512709905/relocate")
+            .then()
+            .assertThat()
+            .statusCode(HttpStatus.OK.value())
+            .body("appointmentId", equalTo(2512709905L));
     }
 
     private String createJwt(final String user, final List<String> roles) {

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/wiremock/DeliusApiMockServer.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/wiremock/DeliusApiMockServer.java
@@ -131,12 +131,12 @@ public class DeliusApiMockServer extends WireMockServer {
         ));
     }
 
-    public void stubPatchContactToDeliusApi() {
-        stubFor(patch(urlPathMatching("/v1/contact/2500029015")).willReturn(aResponse()
+    public void stubPatchContactToDeliusApi(Long appointmentId) {
+        stubFor(patch(urlPathMatching("/v1/contact/" + appointmentId)).willReturn(aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(200)
             .withBody("{\n" +
-                "    \"id\": 2500029015,\n" +
+                "    \"id\": " + appointmentId + ",\n" +
                 "    \"offenderCrn\": \"X320741\",\n" +
                 "    \"type\": \"CRSAPT\",\n" +
                 "    \"provider\": \"CRS\",\n" +


### PR DESCRIPTION
**What does this pull request do?**
Added a new community-api endpoint for relocation of an existing appointment where location is the only thing that has changed.

**What is the intent behind these changes?**
To avoid using the reschedule endpoint. The endpoint makes the original rescheduled time slot unavailable for any new appointments which would means a second change of location not possible even when the times remain the same.

**Any breaking changes?**
None