### PR TITLE
E2E-730 - Add include filter to contacts endpoint. Previously it was …

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
@@ -266,7 +266,8 @@ public class OffendersResource {
         final @RequestParam(value = "attended", required = false) Optional<Boolean> attended,
         final @RequestParam(value = "complied", required = false) Optional<Boolean> complied,
         final @RequestParam(value = "nationalStandard", required = false) Optional<Boolean> nationalStandard,
-        final @RequestParam(value = "outcome", required = false) Optional<Boolean> outcome) {
+        final @RequestParam(value = "outcome", required = false) Optional<Boolean> outcome,
+        final @ApiParam(name = "include", value = "Contacts to include. Can be a contact type code, prefixed with 'type_' or appointments", example = "type_ccmp", allowMultiple = true) @RequestParam(value = "include", required = false) Optional<List<String>> include) {
 
         final var contactFilter = ContactFilter.builder()
             .contactTypes(contactTypes)
@@ -280,6 +281,7 @@ public class OffendersResource {
             .complied(complied)
             .nationalStandard(nationalStandard)
             .outcome(outcome)
+            .include(include)
             .build();
 
         return offenderService.offenderIdOfCrn(crn)

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderContactSummariesByCrn.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource_getOffenderContactSummariesByCrn.java
@@ -345,6 +345,53 @@ public class OffendersResource_getOffenderContactSummariesByCrn extends Integrat
     }
 
     @Test
+    public void gettingOffenderContactSummariesByCrnAndFilteringByIncludeTypesAndAppointments() {
+        given()
+            .auth().oauth2(tokenWithRoleCommunity())
+            .when()
+            .get("/offenders/crn/X320741/contact-summary?include=appointments&include=type_eter&include=type_ccmp")
+            .then()
+            .assertThat()
+            .statusCode(HttpStatus.OK.value())
+            .body("number", equalTo(0))
+            .body("first", equalTo(true))
+            .body("last", equalTo(true))
+            .body("totalPages", equalTo(1))
+            .body("totalElements", equalTo(7))
+            .body("size", equalTo(1000))
+            .body("numberOfElements", equalTo(7))
+            .body("content.size()", equalTo(7))
+            .root("content.find { it.contactId == %d }")
+
+            // appointments
+            .body("type.code", withArgs(2502719240L), equalTo("C084"))
+            .body("type.appointment", withArgs(2502719240L), equalTo(true))
+
+            .body("type.code", withArgs(2502719245L), equalTo("C084"))
+            .body("type.appointment", withArgs(2502719245L), equalTo(true))
+
+            .body("type.code", withArgs(2502719245L), equalTo("C084"))
+            .body("type.appointment", withArgs(2502719245L), equalTo(true))
+
+            .body("type.code", withArgs(2502719244L), equalTo("C084"))
+            .body("type.appointment", withArgs(2502719244L), equalTo(true))
+
+            // type matching CCMP
+            .body("type.code", withArgs(2502721488L), equalTo("CCMP"))
+            .body("type.appointment", withArgs(2502721488L), equalTo(false))
+
+            // type matching ETER
+            .body("type.code", withArgs(2512709905L), equalTo("ETER"))
+            .body("type.appointment", withArgs(2512709905L), equalTo(false))
+
+            .body("type.code", withArgs(2502709905L), equalTo("ETER"))
+            .body("type.appointment", withArgs(2502709905L), equalTo(false))
+
+            .body("type.code", withArgs(2502709898L), equalTo("ETER"))
+            .body("type.appointment", withArgs(2502709898L), equalTo(false));
+    }
+
+    @Test
     public void gettingOffenderContactSummariesByCrnDefaultsToFirstPage() {
         given()
             .auth().oauth2(tokenWithRoleCommunity())


### PR DESCRIPTION
…not possible to return contacts of a particular type AND appointments. The new include qurey parameter allows multiple filters to be added together. In the future this could be potentially expanded to include a category filter