### PR TITLE
fix default value lombok build warnings

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Event.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Event.java
@@ -47,7 +47,7 @@ public class Event {
     private boolean inBreach;
 
     @Column(name = "FTC_COUNT", nullable = false)
-    private Long failureToComplyCount = 0L;
+    private Long failureToComplyCount;
 
     @Column(name = "BREACH_END")
     private LocalDate breachEnd;

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Requirement.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/Requirement.java
@@ -79,6 +79,7 @@ public class Requirement {
     private Long rarCount;
 
     @Column(name = "SOFT_DELETED")
+    @Builder.Default
     private Boolean softDeleted = false;
 
     public boolean isRarRequirement() {


### PR DESCRIPTION
Fixed a couple of these warnings:
warning: @Builder will ignore the initializing expression entirely. If you want the initializing expression to serve as default, add @Builder.Default. If it is not supposed to be settable during building, make the field final.