### PR TITLE
IC-2207 - For all unattended appointments a Refer to Office Manager alert is now requested

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformer.java
@@ -18,6 +18,7 @@ import static java.util.Optional.ofNullable;
 @AllArgsConstructor
 public class AppointmentPatchRequestTransformer {
 
+    private static final String NON_ATTENDANCE_VALUE = "no";
     private static final String TARGET_NOTES_FIELD_NAME = "notes";
     private static final String TARGET_OUTCOME_FIELD_NAME = "outcome";
     private static final String TARGET_ENFORCEMENT_FIELD_NAME = "enforcement";
@@ -55,7 +56,7 @@ public class AppointmentPatchRequestTransformer {
 
         patchOperations.add(new ReplaceOperation(of(TARGET_OUTCOME_FIELD_NAME), valueOf(outcomeType)));
 
-        if ( notifyBehaviour ) {
+        if ( notifyBehaviour || NON_ATTENDANCE_VALUE.equalsIgnoreCase(attended)) {
             patchOperations.add(new ReplaceOperation(of(TARGET_ENFORCEMENT_FIELD_NAME),
                 valueOf(context.getContactMapping().getEnforcementReferToOffenderManager())));
         }

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformerTest.java
@@ -69,6 +69,35 @@ class AppointmentPatchRequestTransformerTest {
     }
 
     @Test
+    public void transformsJsonPatchCollapsingNonAttendedToOutcomeWithEnforcement() throws JsonProcessingException {
+
+        final var attendedValue = "No";
+        final var notifyPPOfAttendanceBehaviourValue = false;
+        final var request = buildRequest(attendedValue, notifyPPOfAttendanceBehaviourValue);
+
+        final var patch = mapAttendanceFieldsToOutcomeOf(request, integrationContext);
+
+        assertThat(objectMapper.writeValueAsString(patch))
+            .isEqualTo("[{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}," +
+                "{\"op\":\"replace\",\"path\":\"/outcome\",\"value\":\"AFTA\"}," +
+                "{\"op\":\"replace\",\"path\":\"/enforcement\",\"value\":\"ROM\"}]");
+    }
+
+    @Test
+    public void transformsJsonPatchCollapsingAttendedToOutcomeWithoutEnforcement() throws JsonProcessingException {
+
+        final var attendedValue = "lAtE";
+        final var notifyPPOfAttendanceBehaviourValue = false;
+        final var request = buildRequest(attendedValue, notifyPPOfAttendanceBehaviourValue);
+
+        final var patch = mapAttendanceFieldsToOutcomeOf(request, integrationContext);
+
+        assertThat(objectMapper.writeValueAsString(patch))
+            .isEqualTo("[{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}," +
+                "{\"op\":\"replace\",\"path\":\"/outcome\",\"value\":\"ATTC\"}]");
+    }
+
+    @Test
     public void transformsJsonPatchUsingOfficeLocation() throws JsonProcessingException {
 
         final var patch = mapOfficeLocation("CRSLOND");


### PR DESCRIPTION
**What does this pull request do?**
Prior to this change a "refer to office manager" alert was only raised when the offender's behaviour was bad. After this change, the alert is also raised for all non attendance, both supplier assessments and service delivery.

**What is the intent behind these changes?**
In using R&M, Probation Practitioners were also expecting a ROM alert for non-attendance which was highlighted during feedback sessions.

**Are there any breaking changes?**
None