### PR TITLE
E2E-794: contact level filter

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/OffendersResource.java
@@ -37,6 +37,7 @@ import uk.gov.justice.digital.delius.controller.advice.ErrorResponse;
 import uk.gov.justice.digital.delius.data.api.AccessLimitation;
 import uk.gov.justice.digital.delius.data.api.CommunityOrPrisonOffenderManager;
 import uk.gov.justice.digital.delius.data.api.Contact;
+import uk.gov.justice.digital.delius.data.api.ContactLevel;
 import uk.gov.justice.digital.delius.data.api.ContactSummary;
 import uk.gov.justice.digital.delius.data.api.Conviction;
 import uk.gov.justice.digital.delius.data.api.CreatePrisonOffenderManager;
@@ -263,6 +264,7 @@ public class OffendersResource {
         final @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @RequestParam(value = "contactDateTo", required = false) Optional<LocalDate> contactDateTo,
         final @RequestParam(value = "appointmentsOnly", required = false) Optional<Boolean> appointmentsOnly,
         final @RequestParam(value = "convictionId", required = false) Optional<Long> convictionId,
+        final @ApiParam(name = "contactLevel", value = "The primary entity type that a contact can be related to") Optional<ContactLevel> contactLevel,
         final @RequestParam(value = "attended", required = false) Optional<Boolean> attended,
         final @RequestParam(value = "complied", required = false) Optional<Boolean> complied,
         final @RequestParam(value = "nationalStandard", required = false) Optional<Boolean> nationalStandard,

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ContactLevel.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ContactLevel.java
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.delius.data.api;
+
+/**
+ * The primary entity type that a contact can be related to.
+ */
+public enum ContactLevel {
+    /**
+     * Contact is only related to an offender.
+     */
+    OFFENDER,
+
+    /**
+     * Contact is related to an offender & conviction.
+     */
+    CONVICTION,
+
+    /**
+     * Contact is related to an offender, conviction & requirement.
+     */
+    REQUIREMENT,
+
+    /**
+     * Contact is related to an offender, conviction & nsi.
+     */
+    NSI
+}


### PR DESCRIPTION
Added new contact level filter to contact summary API.

![image](https://user-images.githubusercontent.com/4509102/134176528-6a11bcec-1514-4276-8aeb-621998053f38.png)

This works in the same way that the addContact form in Delius works. 

* `OFFENDER` EVENT_ID is null and RQMNT_ID is null and NSI_ID is null
* `EVENT` EVENT_ID is not null and RQMNT_ID is null and NSI_ID is null
* `REQUIREMENT` EVENT_ID is not null and RQMNT_ID is not null and NSI_ID is null
* `NSI` EVENT_ID is not null and RQMNT_ID is null and NSI_ID is not null
