### PR TITLE
E2E-885 - Enhance appointment types metadata endpoint

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentType.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentType.java
@@ -30,6 +30,12 @@ public class AppointmentType {
     @ApiModelProperty(name = "Does this appointment type represent a national standard appointment")
     private Boolean nationalStandard;
 
+    @ApiModelProperty(name = "Appointment can be used on the whole order")
+    private Boolean wholeOrderLevel;
+
+    @ApiModelProperty(name = "Appointment can be used at the offender level")
+    private Boolean offenderLevel;
+
     @NotNull
     @JsonInclude
     @ApiModelProperty(
@@ -38,6 +44,8 @@ public class AppointmentType {
         position = 4
     )
     private List<OrderType> orderTypes;
+
+    private List<KeyValue> requirementTypeMainCategories;
 
     public enum OrderType {
         /**

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/ContactType.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/entity/ContactType.java
@@ -66,6 +66,14 @@ public class ContactType {
     @Column(name = "LEGACY_ORDERS", nullable = false, length = 1)
     private String  legacyOrderLevel;
 
+    @Column(name = "OFFENDER_LEVEL_CONTACT", nullable = false, length = 1)
+    @Type(type = "yes_no")
+    private Boolean wholeOrderLevel;
+
+    @Column(name = "OFFENDER_EVENT_0", nullable = false, length = 1)
+    @Type(type = "yes_no")
+    private Boolean offenderLevel;
+
     @Column(name = "SGC_FLAG")
     private Boolean systemGenerated;
 
@@ -76,4 +84,12 @@ public class ContactType {
         inverseJoinColumns = { @JoinColumn(name = "STANDARD_REFERENCE_LIST_ID", nullable = false) }
     )
     private List<StandardReference> contactCategories;
+
+    @ManyToMany
+    @JoinTable(
+        name = "R_CON_TYPE_REQ_TYPE_MAINCAT",
+        joinColumns = {@JoinColumn(name = "CONTACT_TYPE_ID", nullable = false)},
+    inverseJoinColumns = {@JoinColumn(name = "RQMNT_TYPE_MAIN_CATEGORY_ID", nullable = false)}
+        )
+    private List<RequirementTypeMainCategory> requirementTypeCategories;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/ContactTypeRepository.java
+++ b/src/main/java/uk/gov/justice/digital/delius/jpa/standard/repository/ContactTypeRepository.java
@@ -10,13 +10,11 @@ import java.util.Optional;
 public interface ContactTypeRepository extends JpaRepository<ContactType, Long> {
     Optional<ContactType> findByCode(String code);
 
-    /*
-        Category code "AL" refers to the "All" category.
-    */
-    @Query("SELECT DISTINCT type FROM ContactType type " +
-        "INNER JOIN FETCH type.contactCategories category " +
-        "WHERE category.codeValue = 'AL' AND type.selectable = true AND type.scheduleFutureAppointments = 'Y' " +
-        "AND type.attendanceContact = true")
+    @Query("""
+        SELECT DISTINCT type FROM ContactType type
+        WHERE type.selectable = true
+        AND type.attendanceContact = true
+        """)
     List<ContactType> findAllSelectableAppointmentTypes();
 
     List<ContactType> findAllByContactCategoriesCodeValueInAndSelectableTrue(final List<String> codeValue);

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentTransformer.java
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.ContactOutcomeType;
 import uk.gov.justice.digital.delius.jpa.standard.entity.ContactType;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Nsi;
 import uk.gov.justice.digital.delius.jpa.standard.entity.OfficeLocation;
+import uk.gov.justice.digital.delius.jpa.standard.entity.RequirementTypeMainCategory;
 import uk.gov.justice.digital.delius.utils.DateConverter;
 
 import java.util.List;
@@ -89,6 +90,12 @@ public class AppointmentTransformer {
                 Pair.of(OrderType.LEGACY, type.getLegacyOrderLevel())
             ).filter(x -> x.getValue().equals("Y")).map(Pair::getKey).collect(Collectors.toList()))
             .nationalStandard(type.getNationalStandardsContact())
+            .offenderLevel(type.getOffenderLevel())
+            .wholeOrderLevel(type.getWholeOrderLevel())
+            .requirementTypeMainCategories(Optional.ofNullable(type.getRequirementTypeCategories())
+                .map(cats -> cats.stream()
+                    .map(AppointmentTransformer::keyValueOf).collect(Collectors.toList()))
+                .orElse(null))
             .build();
     }
 
@@ -142,6 +149,13 @@ public class AppointmentTransformer {
         return KeyValue.builder()
             .code(contactType.getCode())
             .description(contactType.getDescription())
+            .build();
+    }
+
+    private static KeyValue keyValueOf(RequirementTypeMainCategory mainCategoryType) {
+        return KeyValue.builder()
+            .code(mainCategoryType.getCode())
+            .description(mainCategoryType.getDescription())
             .build();
     }
 

--- a/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AppointmentMetaAPITest.java
+++ b/src/testIntegration/java/uk/gov/justice/digital/delius/controller/secure/AppointmentMetaAPITest.java
@@ -6,11 +6,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.justice.digital.delius.data.api.KeyValue;
 
 import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.withArgs;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
@@ -51,12 +54,31 @@ public class AppointmentMetaAPITest extends IntegrationTestBase {
             .body("description", alcohol, equalTo("Citizenship Alcohol Session (NS)"))
             .body("requiresLocation", alcohol, equalTo("REQUIRED"))
             .body("orderTypes", alcohol, equalTo(List.of("CJA")))
+            .body("wholeOrderLevel", alcohol, equalTo(false))
+            .body("offenderLevel", alcohol, equalTo(false))
+            .body("requirementTypeMainCategories.size", alcohol, equalTo(3))
+            .body("requirementTypeMainCategories[0].code", alcohol, equalTo("Q"))
+            .body("requirementTypeMainCategories[0].description", alcohol, equalTo("Specified Activity"))
+            .body("requirementTypeMainCategories[1].code", alcohol, equalTo("Y"))
+            .body("requirementTypeMainCategories[1].description", alcohol, equalTo("Supervision"))
+            .body("requirementTypeMainCategories[2].code", alcohol, equalTo("F"))
+            .body("requirementTypeMainCategories[2].description", alcohol, equalTo("Rehabilitation Activity Requirement (RAR)"))
+
             .body("description", homeVisit, equalTo("Home Visit to Case (NS)"))
             .body("requiresLocation", homeVisit, equalTo("NOT_REQUIRED"))
             .body("orderTypes", homeVisit, equalTo(List.of("CJA", "LEGACY")))
+            .body("wholeOrderLevel", homeVisit, equalTo(true))
+            .body("offenderLevel", homeVisit, equalTo(false))
+            .body("requirementTypeMainCategories.size", homeVisit, equalTo(2))
+            .body("requirementTypeMainCategories[0].code", homeVisit, equalTo("Y"))
+            .body("requirementTypeMainCategories[0].description", homeVisit, equalTo("Supervision"))
+            .body("requirementTypeMainCategories[1].code", homeVisit, equalTo("RM39"))
+            .body("requirementTypeMainCategories[1].description", homeVisit, equalTo("Local - Herts Local Activities"))
+
             .body("description", other, equalTo("Other Appointment (Non NS)"))
             .body("requiresLocation", other, equalTo("OPTIONAL"))
             .body("orderTypes", other, equalTo(List.of("CJA", "LEGACY")))
+
             .body("orderTypes", polygraph, equalTo(List.of()));
     }
 }


### PR DESCRIPTION
Add additional metadata to the response, so it can be determined what the appointment can be booked against (the offender, events, requirement types)