### PR TITLE
Trello-137 Creation of an appointment in the past by providing an outcome and enforcement values

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentCreateRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/AppointmentCreateRequest.java
@@ -58,4 +58,10 @@ public class AppointmentCreateRequest {
 
     @ApiModelProperty
     private Boolean rarActivity;
+
+    @ApiModelProperty
+    private String outcome;
+
+    @ApiModelProperty
+    private String enforcement;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessAppointmentCreateRequest.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/ContextlessAppointmentCreateRequest.java
@@ -47,4 +47,10 @@ public class ContextlessAppointmentCreateRequest {
     @NotNull
     @ApiModelProperty(required = true)
     private Boolean countsTowardsRarDays;
+
+    @ApiModelProperty
+    private String attended;
+
+    @ApiModelProperty
+    private Boolean notifyPPOfAttendanceBehaviour;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/deliusapi/NewContact.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/deliusapi/NewContact.java
@@ -31,4 +31,5 @@ public class NewContact {
     private Long nsiId;
     private Long eventId;
     private Long requirementId;
+    private String enforcement;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/AppointmentService.java
@@ -191,6 +191,8 @@ public class AppointmentService {
             .requirementId(request.getRequirementId())
             .sensitive(request.getSensitive())
             .rarActivity(request.getRarActivity())
+            .outcome(request.getOutcome())
+            .enforcement(request.getEnforcement())
             .build();
     }
 

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/AppointmentCreateRequestTransformer.java
@@ -7,7 +7,11 @@ import uk.gov.justice.digital.delius.data.api.KeyValue;
 import uk.gov.justice.digital.delius.data.api.Nsi;
 import uk.gov.justice.digital.delius.data.api.Requirement;
 
+import java.util.Optional;
+
 import static java.util.Optional.ofNullable;
+import static uk.gov.justice.digital.delius.transformers.AppointmentPatchRequestTransformer.getEnforcementReferToOffenderManager;
+import static uk.gov.justice.digital.delius.transformers.AppointmentPatchRequestTransformer.getOutcomeType;
 
 /*
     Activity can count towards RAR    Sentence has RAR requirement    RAR Activity    Contact Type
@@ -24,6 +28,9 @@ public class AppointmentCreateRequestTransformer {
         final var contactMapping = context.getContactMapping();
         final var nsiContainsRarRequirement = isRarRequirement(nsi.getRequirement(), context.getRequirementRehabilitationActivityType());
 
+        final Optional<String> outcomeType = getOutcomeType(context, request.getAttended(), request.getNotifyPPOfAttendanceBehaviour());
+        final Optional<String> enforcement = getEnforcementReferToOffenderManager(context, request.getNotifyPPOfAttendanceBehaviour());
+
         return AppointmentCreateRequest.builder()
                 .nsiId(nsi.getNsiId())
                 .contactType(request.getCountsTowardsRarDays() ?
@@ -37,6 +44,8 @@ public class AppointmentCreateRequestTransformer {
                 .staffCode(context.getStaffCode())
                 .teamCode(context.getTeamCode())
                 .rarActivity(isRarActivity(nsiContainsRarRequirement, request.getCountsTowardsRarDays()))
+                .outcome(outcomeType.orElse(null))
+                .enforcement(enforcement.orElse(null))
                 .build();
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/AppointmentPatchRequestTransformerTest.java
@@ -78,6 +78,31 @@ class AppointmentPatchRequestTransformerTest {
     }
 
     @Test
+    public void transformsJsonPatchNotPopulatingOutcomeWhenAttendedIsNull() throws JsonProcessingException {
+
+        final var notifyPPOfAttendanceBehaviourValue = true;
+        final var request = buildRequest(null, notifyPPOfAttendanceBehaviourValue);
+
+        final var patch = mapAttendanceFieldsToOutcomeOf(request, integrationContext);
+
+        assertThat(objectMapper.writeValueAsString(patch))
+            .isEqualTo("[{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}," +
+                "{\"op\":\"replace\",\"path\":\"/enforcement\",\"value\":\"ROM\"}]");
+    }
+
+    @Test
+    public void transformsJsonPatchNotPopulatingOutcomeAndEnforcementWhenNotifyPPIsNull() throws JsonProcessingException {
+
+        final var attendedValue = "LATE";
+        final var request = buildRequest(attendedValue, null);
+
+        final var patch = mapAttendanceFieldsToOutcomeOf(request, integrationContext);
+
+        assertThat(objectMapper.writeValueAsString(patch))
+            .isEqualTo("[{\"op\":\"replace\",\"path\":\"/notes\",\"value\":\"some notes\"}]");
+    }
+
+    @Test
     public void throwsExceptionWhenNoMapping() {
         final var attendedValue = "UnknownValue";
         final var request = buildRequest(attendedValue, true);


### PR DESCRIPTION
https://trello.com/c/HnxgCLKB/137-create-appointment-with-a-date-in-the-past

**What does this pull request do?**
This feature allows the creation of an appointment in the past. Outcome and enforcement values can now be provided for historic appointments which is required by delius-api. 

**What is the intent behind these changes?**
R&M users have been unable to create appointments retrospectively which is part of the practise they follow. This now facilitates that process.

**Any breaking changes?**
There are no breaking changes.
AppointmentCreateRequest body now contains optional fields for outcome and enforcement, e.g. "AFTC and ROM". These are now also included in requests to delius-api.  