### PR TITLE
Arn 770 add active flag to personal circumstance

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/data/api/PersonalCircumstance.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/PersonalCircumstance.java
@@ -39,6 +39,6 @@ public class PersonalCircumstance {
     private LocalDateTime createdDatetime;
     @ApiModelProperty(name = "Date and time that this personal circumstance was last updated", example = "2021-06-11T14:00:00")
     private LocalDateTime lastUpdatedDatetime;
-    @ApiModelProperty(value = "The active status of this personal circumstance, if the start date is before today or on and the end date is after today", example = "true")
+    @ApiModelProperty(value = "The active status of this personal circumstance, if the start date is before or on today and the end date is after today", example = "true")
     private Boolean activeFlag;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/PersonalCircumstance.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/PersonalCircumstance.java
@@ -39,6 +39,6 @@ public class PersonalCircumstance {
     private LocalDateTime createdDatetime;
     @ApiModelProperty(name = "Date and time that this personal circumstance was last updated", example = "2021-06-11T14:00:00")
     private LocalDateTime lastUpdatedDatetime;
-    @ApiModelProperty(value = "The active status of this personal circumstance, if the start date is before today and the end date is after today", example = "true")
+    @ApiModelProperty(value = "The active status of this personal circumstance, if the start date is before today or on and the end date is after today", example = "true")
     private Boolean activeFlag;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/PersonalCircumstance.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/PersonalCircumstance.java
@@ -39,6 +39,6 @@ public class PersonalCircumstance {
     private LocalDateTime createdDatetime;
     @ApiModelProperty(name = "Date and time that this personal circumstance was last updated", example = "2021-06-11T14:00:00")
     private LocalDateTime lastUpdatedDatetime;
-    @ApiModelProperty(value = "The active status of this personal circumstance, if the start date is before or on today and the end date is after today", example = "true")
-    private Boolean activeFlag;
+    @ApiModelProperty(value = "The active status of this personal circumstance, if the start date is before or on today and the end date is after today or null", example = "true")
+    private Boolean isActive;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/PersonalCircumstance.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/PersonalCircumstance.java
@@ -39,4 +39,6 @@ public class PersonalCircumstance {
     private LocalDateTime createdDatetime;
     @ApiModelProperty(name = "Date and time that this personal circumstance was last updated", example = "2021-06-11T14:00:00")
     private LocalDateTime lastUpdatedDatetime;
+    @ApiModelProperty(value = "The active status of this personal circumstance, if the start date is before today and the end date is after today", example = "true")
+    private Boolean activeFlag;
 }

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformer.java
@@ -25,7 +25,7 @@ public class PersonalCircumstanceTransformer {
                 .evidenced(ynToBoolean(personalCircumstance.getEvidenced()))
                 .createdDatetime(personalCircumstance.getCreatedDatetime())
                 .lastUpdatedDatetime(personalCircumstance.getLastUpdatedDatetime())
-                .activeFlag(activeFlagOf(personalCircumstance.getStartDate(), personalCircumstance.getEndDate()))
+                .isActive(isActive(personalCircumstance, LocalDate.now()))
             .build();
     }
 
@@ -50,14 +50,12 @@ public class PersonalCircumstanceTransformer {
                 .build();
     }
 
-    private static Boolean activeFlagOf(LocalDate startDate, LocalDate endDate) {
-        LocalDate today = LocalDate.now();
-        if (startDate.isAfter(today)) {
+    private static Boolean isActive(uk.gov.justice.digital.delius.jpa.standard.entity.PersonalCircumstance personalCircumstance, LocalDate dateToCompare) {
+        if (personalCircumstance.getStartDate().isAfter(dateToCompare)) {
             return false;
-        } else {
-            if (endDate == null) {
-                return true;
-            } else return endDate.isAfter(today);
         }
+        return Optional.ofNullable(personalCircumstance.getEndDate()).map(
+            end -> personalCircumstance.getEndDate().isAfter(dateToCompare)
+        ).orElse(true);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformer.java
@@ -51,11 +51,13 @@ public class PersonalCircumstanceTransformer {
     }
 
     private static Boolean activeFlagOf(LocalDate startDate, LocalDate endDate) {
-        if (endDate == null){
+        LocalDate today = LocalDate.now();
+        if (startDate.isAfter(today)) {
             return false;
         } else {
-            LocalDate today = LocalDate.now();
-            return endDate.isAfter(today) && (startDate.isEqual(today) || startDate.isBefore(today));
+            if (endDate == null) {
+                return true;
+            } else return endDate.isAfter(today);
         }
     }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformer.java
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.CircumstanceSubType;
 import uk.gov.justice.digital.delius.jpa.standard.entity.CircumstanceType;
 import uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import static uk.gov.justice.digital.delius.transformers.TypesTransformer.ynToBoolean;
@@ -24,6 +25,7 @@ public class PersonalCircumstanceTransformer {
                 .evidenced(ynToBoolean(personalCircumstance.getEvidenced()))
                 .createdDatetime(personalCircumstance.getCreatedDatetime())
                 .lastUpdatedDatetime(personalCircumstance.getLastUpdatedDatetime())
+                .activeFlag(activeFlagOf(personalCircumstance.getStartDate(), personalCircumstance.getEndDate()))
             .build();
     }
 
@@ -48,5 +50,12 @@ public class PersonalCircumstanceTransformer {
                 .build();
     }
 
-
+    private static Boolean activeFlagOf(LocalDate startDate, LocalDate endDate) {
+        if (endDate == null){
+            return false;
+        } else {
+            LocalDate today = LocalDate.now();
+            return endDate.isAfter(today) && (startDate.isEqual(today) || startDate.isBefore(today));
+        }
+    }
 }

--- a/src/test/java/uk/gov/justice/digital/delius/service/PersonalCircumstanceServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/PersonalCircumstanceServiceTest.java
@@ -65,9 +65,9 @@ public class PersonalCircumstanceServiceTest {
 
     @Test
     public void personalCircumstancesHaveIsActiveFlag() {
-        final LocalDate today = LocalDate.now();
-        final LocalDate futureDate = LocalDate.now().plusDays(1);
-        final LocalDate pastDate = LocalDate.now().minusDays(1);
+        final var today = LocalDate.now();
+        final var futureDate = LocalDate.now().plusDays(1);
+        final var pastDate = LocalDate.now().minusDays(1);
 
         Mockito.when(personalCircumstanceRepository.findByOffenderId(1L))
                 .thenReturn(ImmutableList.of(

--- a/src/test/java/uk/gov/justice/digital/delius/service/PersonalCircumstanceServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/PersonalCircumstanceServiceTest.java
@@ -64,10 +64,10 @@ public class PersonalCircumstanceServiceTest {
     }
 
     @Test
-    public void personalCircumstancesHaveActiveFlag() {
-        LocalDate today = LocalDate.now();
-        LocalDate futureDate = LocalDate.now().plusDays(1);
-        LocalDate pastDate = LocalDate.now().minusDays(1);
+    public void personalCircumstancesHaveIsActiveFlag() {
+        final LocalDate today = LocalDate.now();
+        final LocalDate futureDate = LocalDate.now().plusDays(1);
+        final LocalDate pastDate = LocalDate.now().minusDays(1);
 
         Mockito.when(personalCircumstanceRepository.findByOffenderId(1L))
                 .thenReturn(ImmutableList.of(
@@ -80,11 +80,11 @@ public class PersonalCircumstanceServiceTest {
             personalCircumstanceService.personalCircumstancesFor(1L);
 
         assertThat(personalCircumstances.stream().filter(c -> c.getPersonalCircumstanceId().equals(1L))
-            .findFirst().get().getActiveFlag()).isEqualTo(false);
+            .findFirst().get().getIsActive()).isEqualTo(false);
         assertThat(personalCircumstances.stream().filter(c -> c.getPersonalCircumstanceId().equals(2L))
-            .findFirst().get().getActiveFlag()).isEqualTo(true);
+            .findFirst().get().getIsActive()).isEqualTo(true);
         assertThat(personalCircumstances.stream().filter(c -> c.getPersonalCircumstanceId().equals(3L))
-            .findFirst().get().getActiveFlag()).isEqualTo(true);
+            .findFirst().get().getIsActive()).isEqualTo(true);
 
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/PersonalCircumstanceServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/PersonalCircumstanceServiceTest.java
@@ -78,7 +78,7 @@ public class PersonalCircumstanceServiceTest {
         assertThat(personalCircumstanceService.personalCircumstancesFor(1L)
                 .stream().map(uk.gov.justice.digital.delius.data.api.PersonalCircumstance::getActiveFlag)
                 .collect(Collectors.toList()))
-                .containsSequence(false, true, false);
+                .containsSequence(false, true, true);
 
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/service/PersonalCircumstanceServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/PersonalCircumstanceServiceTest.java
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.delius.jpa.standard.entity.PersonalCircumstance;
 import uk.gov.justice.digital.delius.jpa.standard.repository.PersonalCircumstanceRepository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -75,10 +76,15 @@ public class PersonalCircumstanceServiceTest {
                         aPersonalCircumstance().toBuilder().personalCircumstanceId(3L).startDate(pastDate).build()
                 ));
 
-        assertThat(personalCircumstanceService.personalCircumstancesFor(1L)
-                .stream().map(uk.gov.justice.digital.delius.data.api.PersonalCircumstance::getActiveFlag)
-                .collect(Collectors.toList()))
-                .containsSequence(false, true, true);
+        List<uk.gov.justice.digital.delius.data.api.PersonalCircumstance> personalCircumstances =
+            personalCircumstanceService.personalCircumstancesFor(1L);
+
+        assertThat(personalCircumstances.stream().filter(c -> c.getPersonalCircumstanceId().equals(1L))
+            .findFirst().get().getActiveFlag()).isEqualTo(false);
+        assertThat(personalCircumstances.stream().filter(c -> c.getPersonalCircumstanceId().equals(2L))
+            .findFirst().get().getActiveFlag()).isEqualTo(true);
+        assertThat(personalCircumstances.stream().filter(c -> c.getPersonalCircumstanceId().equals(3L))
+            .findFirst().get().getActiveFlag()).isEqualTo(true);
 
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformerTest.java
@@ -57,50 +57,51 @@ public class PersonalCircumstanceTransformerTest {
             .hasFieldOrPropertyWithValue("personalCircumstanceSubType.code", "CST")
             .hasFieldOrPropertyWithValue("personalCircumstanceSubType.description", "MiP approved")
             .hasFieldOrPropertyWithValue("createdDatetime", LocalDateTime.of(2021, 7, 9, 9, 12))
-            .hasFieldOrPropertyWithValue("lastUpdatedDatetime", LocalDateTime.of(2021, 7, 9, 9, 32));
+            .hasFieldOrPropertyWithValue("lastUpdatedDatetime", LocalDateTime.of(2021, 7, 9, 9, 32))
+            .hasFieldOrPropertyWithValue("isActive", false);
     }
 
     @Test
-    public void activeFlagIsTrueWhenStartDateTodayAndEndDateInFuture() {
+    public void isActiveIsTrueWhenStartDateTodayAndEndDateInFuture() {
         final var source = aPersonalCircumstance(LocalDate.now(), LocalDate.now().plusDays(1));
         final var observed = PersonalCircumstanceTransformer.personalCircumstanceOf(source);
         assertThat(observed)
             .hasFieldOrPropertyWithValue("personalCircumstanceId", 1000L)
             .hasFieldOrPropertyWithValue("startDate", LocalDate.now())
             .hasFieldOrPropertyWithValue("endDate", LocalDate.now().plusDays(1))
-            .hasFieldOrPropertyWithValue("activeFlag", true);
+            .hasFieldOrPropertyWithValue("isActive", true);
     }
 
     @Test
-    public void activeFlagIsTrueWhenEndDateIsNull() {
+    public void isActiveIsTrueWhenEndDateIsNull() {
         final var source = aPersonalCircumstance(LocalDate.now().minusDays(1), null);
         final var observed = PersonalCircumstanceTransformer.personalCircumstanceOf(source);
         assertThat(observed)
             .hasFieldOrPropertyWithValue("personalCircumstanceId", 1000L)
             .hasFieldOrPropertyWithValue("startDate", LocalDate.now().minusDays(1))
             .hasFieldOrPropertyWithValue("endDate", null)
-            .hasFieldOrPropertyWithValue("activeFlag", true);
+            .hasFieldOrPropertyWithValue("isActive", true);
     }
 
     @Test
-    public void activeFlagIsFalseWhenEndDateIsToday() {
+    public void isActiveIsFalseWhenEndDateIsToday() {
         final var source = aPersonalCircumstance(LocalDate.now().minusDays(1), LocalDate.now());
         final var observed = PersonalCircumstanceTransformer.personalCircumstanceOf(source);
         assertThat(observed)
             .hasFieldOrPropertyWithValue("personalCircumstanceId", 1000L)
             .hasFieldOrPropertyWithValue("startDate", LocalDate.now().minusDays(1))
             .hasFieldOrPropertyWithValue("endDate", LocalDate.now())
-            .hasFieldOrPropertyWithValue("activeFlag", false);
+            .hasFieldOrPropertyWithValue("isActive", false);
     }
 
     @Test
-    public void activeFlagIsFalseWhenStartDateInFuture() {
+    public void isActiveIsFalseWhenStartDateInFuture() {
         final var source = aPersonalCircumstance(LocalDate.now().plusDays(1), LocalDate.now().plusDays(2));
         final var observed = PersonalCircumstanceTransformer.personalCircumstanceOf(source);
         assertThat(observed)
             .hasFieldOrPropertyWithValue("personalCircumstanceId", 1000L)
             .hasFieldOrPropertyWithValue("startDate", LocalDate.now().plusDays(1))
             .hasFieldOrPropertyWithValue("endDate", LocalDate.now().plusDays(2))
-            .hasFieldOrPropertyWithValue("activeFlag", false);
+            .hasFieldOrPropertyWithValue("isActive", false);
     }
 }

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformerTest.java
@@ -61,13 +61,24 @@ public class PersonalCircumstanceTransformerTest {
     }
 
     @Test
-    public void activeFlagIsTrueWhenStartDateTodayOrPastAndEndDateInFuture() {
+    public void activeFlagIsTrueWhenStartDateTodayAndEndDateInFuture() {
         final var source = aPersonalCircumstance(LocalDate.now(), LocalDate.now().plusDays(1));
         final var observed = PersonalCircumstanceTransformer.personalCircumstanceOf(source);
         assertThat(observed)
             .hasFieldOrPropertyWithValue("personalCircumstanceId", 1000L)
             .hasFieldOrPropertyWithValue("startDate", LocalDate.now())
             .hasFieldOrPropertyWithValue("endDate", LocalDate.now().plusDays(1))
+            .hasFieldOrPropertyWithValue("activeFlag", true);
+    }
+
+    @Test
+    public void activeFlagIsTrueWhenEndDateIsNull() {
+        final var source = aPersonalCircumstance(LocalDate.now().minusDays(1), null);
+        final var observed = PersonalCircumstanceTransformer.personalCircumstanceOf(source);
+        assertThat(observed)
+            .hasFieldOrPropertyWithValue("personalCircumstanceId", 1000L)
+            .hasFieldOrPropertyWithValue("startDate", LocalDate.now().minusDays(1))
+            .hasFieldOrPropertyWithValue("endDate", null)
             .hasFieldOrPropertyWithValue("activeFlag", true);
     }
 
@@ -79,17 +90,6 @@ public class PersonalCircumstanceTransformerTest {
             .hasFieldOrPropertyWithValue("personalCircumstanceId", 1000L)
             .hasFieldOrPropertyWithValue("startDate", LocalDate.now().minusDays(1))
             .hasFieldOrPropertyWithValue("endDate", LocalDate.now())
-            .hasFieldOrPropertyWithValue("activeFlag", false);
-    }
-
-    @Test
-    public void activeFlagIsFalseWhenEndDateIsNull() {
-        final var source = aPersonalCircumstance(LocalDate.now(), null);
-        final var observed = PersonalCircumstanceTransformer.personalCircumstanceOf(source);
-        assertThat(observed)
-            .hasFieldOrPropertyWithValue("personalCircumstanceId", 1000L)
-            .hasFieldOrPropertyWithValue("startDate", LocalDate.now())
-            .hasFieldOrPropertyWithValue("endDate", null)
             .hasFieldOrPropertyWithValue("activeFlag", false);
     }
 

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/PersonalCircumstanceTransformerTest.java
@@ -60,4 +60,47 @@ public class PersonalCircumstanceTransformerTest {
             .hasFieldOrPropertyWithValue("lastUpdatedDatetime", LocalDateTime.of(2021, 7, 9, 9, 32));
     }
 
+    @Test
+    public void activeFlagIsTrueWhenStartDateTodayOrPastAndEndDateInFuture() {
+        final var source = aPersonalCircumstance(LocalDate.now(), LocalDate.now().plusDays(1));
+        final var observed = PersonalCircumstanceTransformer.personalCircumstanceOf(source);
+        assertThat(observed)
+            .hasFieldOrPropertyWithValue("personalCircumstanceId", 1000L)
+            .hasFieldOrPropertyWithValue("startDate", LocalDate.now())
+            .hasFieldOrPropertyWithValue("endDate", LocalDate.now().plusDays(1))
+            .hasFieldOrPropertyWithValue("activeFlag", true);
+    }
+
+    @Test
+    public void activeFlagIsFalseWhenEndDateIsToday() {
+        final var source = aPersonalCircumstance(LocalDate.now().minusDays(1), LocalDate.now());
+        final var observed = PersonalCircumstanceTransformer.personalCircumstanceOf(source);
+        assertThat(observed)
+            .hasFieldOrPropertyWithValue("personalCircumstanceId", 1000L)
+            .hasFieldOrPropertyWithValue("startDate", LocalDate.now().minusDays(1))
+            .hasFieldOrPropertyWithValue("endDate", LocalDate.now())
+            .hasFieldOrPropertyWithValue("activeFlag", false);
+    }
+
+    @Test
+    public void activeFlagIsFalseWhenEndDateIsNull() {
+        final var source = aPersonalCircumstance(LocalDate.now(), null);
+        final var observed = PersonalCircumstanceTransformer.personalCircumstanceOf(source);
+        assertThat(observed)
+            .hasFieldOrPropertyWithValue("personalCircumstanceId", 1000L)
+            .hasFieldOrPropertyWithValue("startDate", LocalDate.now())
+            .hasFieldOrPropertyWithValue("endDate", null)
+            .hasFieldOrPropertyWithValue("activeFlag", false);
+    }
+
+    @Test
+    public void activeFlagIsFalseWhenStartDateInFuture() {
+        final var source = aPersonalCircumstance(LocalDate.now().plusDays(1), LocalDate.now().plusDays(2));
+        final var observed = PersonalCircumstanceTransformer.personalCircumstanceOf(source);
+        assertThat(observed)
+            .hasFieldOrPropertyWithValue("personalCircumstanceId", 1000L)
+            .hasFieldOrPropertyWithValue("startDate", LocalDate.now().plusDays(1))
+            .hasFieldOrPropertyWithValue("endDate", LocalDate.now().plusDays(2))
+            .hasFieldOrPropertyWithValue("activeFlag", false);
+    }
 }

--- a/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
+++ b/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
@@ -540,18 +540,7 @@ public class EntityHelper {
     }
 
     public static PersonalCircumstance aPersonalCircumstance() {
-        return PersonalCircumstance.builder()
-            .personalCircumstanceId(1000L)
-            .offenderId(1001L)
-            .notes("Some notes")
-            .evidenced("Y")
-            .startDate(LocalDate.of(2021, 7, 9))
-            .endDate(LocalDate.of(2021, 7, 10))
-            .circumstanceType(CircumstanceType.builder().codeValue("CT").codeDescription("AP - Medication in Posession - Assessment").build())
-            .circumstanceSubType(CircumstanceSubType.builder().codeValue("CST").codeDescription("MiP approved").build())
-            .createdDatetime(LocalDateTime.of(2021, 7, 9, 9, 12))
-            .lastUpdatedDatetime(LocalDateTime.of(2021, 7, 9, 9, 32))
-            .build();
+        return aPersonalCircumstance(LocalDate.of(2021, 7, 9), LocalDate.of(2021, 7, 10));
     }
 
     public static PersonalCircumstance aPersonalCircumstance(final LocalDate startDate, final LocalDate endDate) {

--- a/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
+++ b/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
@@ -554,6 +554,21 @@ public class EntityHelper {
             .build();
     }
 
+    public static PersonalCircumstance aPersonalCircumstance(final LocalDate startDate, final LocalDate endDate) {
+        return PersonalCircumstance.builder()
+            .personalCircumstanceId(1000L)
+            .offenderId(1001L)
+            .notes("Some notes")
+            .evidenced("Y")
+            .startDate(startDate)
+            .endDate(endDate)
+            .circumstanceType(CircumstanceType.builder().codeValue("CT").codeDescription("AP - Medication in Posession - Assessment").build())
+            .circumstanceSubType(CircumstanceSubType.builder().codeValue("CST").codeDescription("MiP approved").build())
+            .createdDatetime(LocalDateTime.of(2021, 7, 9, 9, 12))
+            .lastUpdatedDatetime(LocalDateTime.of(2021, 7, 9, 9, 32))
+            .build();
+    }
+
     public static UPWAppointmentDocument aUPWAppointmentDocument(final Long eventId) {
         final var document = new UPWAppointmentDocument();
         populateBasics(document);


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/ARN-770

**What does this pull request do?**

This PR adds an activeFlag property to the PersonalCircumstance DTO. The active flag is determined in the PersonalCircumstanceTransformer as true if the start date is before or is today and the end date is after today or null, otherwise the active flag is false.

**What is the intent behind these changes?**
The Assess Risks and Needs service requires the activeFlag field to use with the existing jsonPath to filter only the currently active PersonalCircumstances for use in Unpaid Work assessments. 

**Any breaking changes?**
There are no breaking API changes.