### PR TITLE
CVSL-334: Initial suggestions for team view of managed/unallocated cases.

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/TeamResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/TeamResource.java
@@ -80,7 +80,7 @@ public class TeamResource {
     @PreAuthorize("hasRole('ROLE_COMMUNITY')")
     @ApiResponses(
         value = {
-            @ApiResponse(code = 200, message = "All active office locations for the specified team", response = OfficeLocation.class, responseContainer = "List"),
+            @ApiResponse(code = 200, message = "All active office locations for the specified team", response = TeamManagedOffender.class, responseContainer = "List"),
             @ApiResponse(code = 403, message = "Requires role ROLE_COMMUNITY"),
             @ApiResponse(code = 404, message = "The specified team does not exist or is not active"),
             @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)

--- a/src/main/java/uk/gov/justice/digital/delius/controller/secure/TeamResource.java
+++ b/src/main/java/uk/gov/justice/digital/delius/controller/secure/TeamResource.java
@@ -13,10 +13,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.justice.digital.delius.controller.advice.ErrorResponse;
 import uk.gov.justice.digital.delius.data.api.OfficeLocation;
 import uk.gov.justice.digital.delius.data.api.TeamCreationResult;
+import uk.gov.justice.digital.delius.data.api.TeamManagedOffender;
 import uk.gov.justice.digital.delius.service.TeamService;
 
 import java.util.List;
@@ -72,5 +74,26 @@ public class TeamResource {
         String teamCode
     ) {
         return teamService.getAllOfficeLocations(teamCode);
+    }
+
+    @GetMapping("/teams/managedOffenders")
+    @PreAuthorize("hasRole('ROLE_COMMUNITY')")
+    @ApiResponses(
+        value = {
+            @ApiResponse(code = 200, message = "All active office locations for the specified team", response = OfficeLocation.class, responseContainer = "List"),
+            @ApiResponse(code = 403, message = "Requires role ROLE_COMMUNITY"),
+            @ApiResponse(code = 404, message = "The specified team does not exist or is not active"),
+            @ApiResponse(code = 500, message = "Unrecoverable error whilst processing request.", response = ErrorResponse.class)
+        })
+    @ApiOperation(
+        value = "EXPERIMENTAL: Given a list of team codes find the offenders being managed and details of the staff who are managing them.",
+        tags = {"Teams"},
+        authorizations = {@Authorization("ROLE_COMMUNITY")}
+    )
+    public List<TeamManagedOffender> getManagedOffendersForTeams(
+        @RequestParam(name = "teamCode") List<String> teamCodes,
+        @RequestParam(name = "current", required = false, defaultValue = "true") boolean current
+    ) {
+        return teamService.getManagedOffendersForTeams(teamCodes, current);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/delius/data/api/TeamManagedOffender.java
+++ b/src/main/java/uk/gov/justice/digital/delius/data/api/TeamManagedOffender.java
@@ -1,0 +1,86 @@
+package uk.gov.justice.digital.delius.data.api;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeamManagedOffender {
+
+  @ApiModelProperty(value = "The probation area code", example = "N55", required = true)
+  private String probationAreaCode;
+
+  @ApiModelProperty(value = "Probation area description", example = "Yorkshire and Humberside NPS")
+  private String probationAreaDescription;
+
+  @ApiModelProperty(value = "PDU or cluster code", example = "N556AT", required = true)
+  private String pduCode;
+
+  @ApiModelProperty(value = "PDU or cluster description", example = "Hull NPS")
+  private String pduDescription;
+
+  @ApiModelProperty(value = "LDU code", example = "N556AT001", required = true)
+  private String lduCode;
+
+  @ApiModelProperty(value = "LDU description", example = "Hull North NPS ")
+  private String lduDescription;
+
+  @ApiModelProperty(value = "Unique internal team identifier", example = "1432", required = true)
+  private Long teamId;
+
+  @ApiModelProperty(value = "Team code", example = "N556AT001A", required = true)
+  private String teamCode;
+
+  @ApiModelProperty(value = "Team description", example = "Hull North NPS team A")
+  private String teamDescription;
+
+  @ApiModelProperty(value = "Case reference number (CRN) in nDelius", example = "X87655", required = true)
+  private String crnNumber;
+
+  @ApiModelProperty(value = "Prison reference number in Nomis", example = "A8778AA", required = true)
+  private String nomsNumber;
+
+  @ApiModelProperty(value = "Internal offender identifier in nDelius", example = "109987", required = true)
+  private Long offenderId;
+
+  @ApiModelProperty(value = "The surname of the managed offender", example = "Smith", required = true)
+  private String offenderSurname;
+
+  @ApiModelProperty(value = "The middle names of the managed offender", example = "Brian James")
+  private String offenderMiddleNames;
+
+  @ApiModelProperty(value = "The forename of the managed offender", example = "Thomas", required = true)
+  private String offenderForename;
+
+  @ApiModelProperty(value = "The date of birth for this managed offender", example = "21/02/1987")
+  private LocalDate offenderDob;
+
+  @ApiModelProperty(value = "The staff code of the offender manager in nDelius", example = "CRA20223")
+  private String staffCode;
+
+  @ApiModelProperty(value = "The staff identifier of the offender manager in nDelius", example = "1088777")
+  private Long staffIdentifier;
+
+  @ApiModelProperty(value = "The username of the offender manager in nDelius", example = "X766SNI")
+  private String staffUsername;
+
+  @ApiModelProperty(value = "The offender manager surname", example = "Cartwright")
+  private String staffSurname;
+
+  @ApiModelProperty(value = "The offender manager forename", example = "Ben")
+  private String staffForename;
+
+  @ApiModelProperty(
+      value = "True if no staff member is allocated or when the unallocated staff member in this team is assigned",
+      example = "true",
+      required = true
+  )
+  private boolean allocated;
+}

--- a/src/main/java/uk/gov/justice/digital/delius/service/TeamService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/TeamService.java
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.delius.service;
 
 import com.microsoft.applicationinsights.TelemetryClient;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -8,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.digital.delius.controller.NotFoundException;
 import uk.gov.justice.digital.delius.data.api.StaffHuman;
 import uk.gov.justice.digital.delius.data.api.OfficeLocation;
+import uk.gov.justice.digital.delius.data.api.TeamManagedOffender;
 import uk.gov.justice.digital.delius.jpa.standard.entity.Borough;
 import uk.gov.justice.digital.delius.jpa.standard.entity.District;
 import uk.gov.justice.digital.delius.jpa.standard.entity.LocalDeliveryUnit;
@@ -119,6 +122,44 @@ public class TeamService {
             .filter(this::isPOMTeamMissingUnallocatedStaff)
             .map(team -> StaffTransformer.staffOf(createUnallocatedStaffInTeam(team)))
             .collect(Collectors.toList());
+    }
+
+    public List<TeamManagedOffender> getManagedOffendersForTeams(List<String> teamCodes, boolean current) {
+        final var uppercaseTeamCodes = teamCodes.stream().map(String::toUpperCase).collect(Collectors.toSet());
+
+        // TODO: Requires domain knowledge of entity relationships here - from caseload repository?
+        // The response can be altered to split into Area, PDU, LDU, Team, Offender and Staff objects, if required?
+        // There is probably no need for the current parameter - we are only interested in the current view, not historical or planned.
+
+       // Stubbed response
+       List<TeamManagedOffender> response = new ArrayList<>();
+       response.add(
+           TeamManagedOffender.builder()
+               .probationAreaCode("N55")
+               .probationAreaDescription("Yorkshire and Humberside")
+               .pduCode("N55A")
+               .pduDescription("Hull")
+               .lduCode("N55A01")
+               .lduDescription("Hull North Unit")
+               .teamCode("N55A01AA")
+               .teamDescription("Hull North AA")
+               .teamId(12345L)
+               .crnNumber("X12345")
+               .offenderId(12345L)
+               .nomsNumber("A1234AA")
+               .offenderForename("James")
+               .offenderMiddleNames("Malcolm")
+               .offenderSurname("Smith")
+               .offenderDob(LocalDate.of(1987, 2, 27))
+               .staffCode("NA556222")
+               .staffIdentifier(23456L)
+               .staffForename("Margaret")
+               .staffSurname("Brody")
+               .staffUsername("X09098")
+               .allocated(true)
+               .build()
+       );
+       return response;
     }
 
     private Team createPOMTeamInArea(String code, ProbationArea probationArea) {


### PR DESCRIPTION
Implements controller & part of the service layer where it currently returns a stubbed response.

The presentation of results is very "flat" at present and I'm not sure this fits with the rest of the service? Quite happy to alter this so we get more structure in responses, for example, attributes for probationArea (code, desc), PDU (code, desc), LDU (code, desc), Team (id, code, desc), Staff (details), Offender (details) details separated out within the list of response objects?

I don't really see a need for the `current` parameter unless you have other needs where this might be useful? For CVL we're only interested in the current view - as it stands now, and which offenders are allocated or unallocated within the team.

The next challenge is to understand where this data will come from in the repository layer, which might then inform its structure a bit more. I know the caseload table was mentioned? 

I've left the tests until the intended structure of data is better understood, so it's just a starter for ten.
