### PR TITLE
Add telephone number from LDAP to staff details endpoint

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/service/StaffService.java
+++ b/src/main/java/uk/gov/justice/digital/delius/service/StaffService.java
@@ -62,13 +62,7 @@ public class StaffService {
         return staffRepository
             .findByStaffId(staffIdentifier)
             .map(StaffTransformer::staffDetailsOf)
-            .map(staffDetails ->
-                Optional.ofNullable(staffDetails.getUsername())
-                    .map(username -> staffDetails
-                        .toBuilder()
-                        .email(ldapRepository.getEmail(username))
-                        .build())
-                    .orElse(staffDetails));
+            .map(addFieldsFromLdap());
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/uk/gov/justice/digital/delius/service/StaffServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/StaffServiceTest.java
@@ -102,7 +102,7 @@ public class StaffServiceTest {
     }
 
     @Test
-    public void willCopyEmailWhenUserFoundInLDAP_getStaffDetailsByStaffIdentifier() {
+    public void willCopyEmailAndTelephoneWhenUserFoundInLDAP_getStaffDetailsByStaffIdentifier() {
         when(staffRepository.findByStaffId(10L))
             .thenReturn(
                 Optional.of(
@@ -115,12 +115,16 @@ public class StaffServiceTest {
                                 .build())
                         .build()));
 
-        var nDeliusUser = NDeliusUser.builder().mail("user@service.com").build();
+        var nDeliusUser = NDeliusUser.builder()
+            .mail("user@service.com")
+            .telephoneNumber("0800101010")
+            .build();
+
         when(ldapRepository.getDeliusUserNoRoles("sandrasmith")).thenReturn(Optional.of(nDeliusUser));
 
         var staffDetails = staffService.getStaffDetailsByStaffIdentifier(10L).get();
         assertThat(staffDetails.getEmail()).isEqualTo("user@service.com");
-        assertThat(staffDetails.getTelephoneNumber()).isNull();
+        assertThat(staffDetails.getTelephoneNumber()).isEqualTo("0800101010");
     }
 
     @Test
@@ -158,7 +162,7 @@ public class StaffServiceTest {
     }
 
     @Test
-    public void willCopyEmailWhenUserFoundInLDAP_getStaffDetailsByUsername() {
+    public void willCopyEmailAndTelephoneWhenUserFoundInLDAP_getStaffDetailsByUsername() {
         when(staffRepository.findByUsername("sandrasmith"))
                 .thenReturn(
                         Optional.of(
@@ -171,12 +175,16 @@ public class StaffServiceTest {
                                                         .build())
                                         .build()));
 
-        var nDeliusUser = NDeliusUser.builder().mail("user@service.com").build();
+        var nDeliusUser = NDeliusUser.builder()
+            .mail("user@service.com")
+            .telephoneNumber("0800101010")
+            .build();
+
         when(ldapRepository.getDeliusUserNoRoles("sandrasmith")).thenReturn(Optional.of(nDeliusUser));
 
         var staffDetails = staffService.getStaffDetailsByUsername("sandrasmith").get();
         assertThat(staffDetails.getEmail()).isEqualTo("user@service.com");
-        assertThat(staffDetails.getTelephoneNumber()).isNull();
+        assertThat(staffDetails.getTelephoneNumber()).isEqualTo("0800101010");
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/digital/delius/service/StaffServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/service/StaffServiceTest.java
@@ -98,43 +98,46 @@ public class StaffServiceTest {
 
         staffService.getStaffDetailsByStaffIdentifier(10L);
 
-        verify(ldapRepository).getEmail("username");
+        verify(ldapRepository).getDeliusUserNoRoles("username");
     }
 
     @Test
     public void willCopyEmailWhenUserFoundInLDAP_getStaffDetailsByStaffIdentifier() {
         when(staffRepository.findByStaffId(10L))
-                .thenReturn(
-                        Optional.of(
-                                aStaff()
-                                        .toBuilder()
-                                        .user(
-                                                aUser()
-                                                        .toBuilder()
-                                                        .distinguishedName("username")
-                                                        .build())
-                                        .build()));
+            .thenReturn(
+                Optional.of(
+                    aStaff()
+                        .toBuilder()
+                        .user(
+                            aUser()
+                                .toBuilder()
+                                .distinguishedName("sandrasmith")
+                                .build())
+                        .build()));
 
-        when(ldapRepository.getEmail("username")).thenReturn("user@service.com");
+        var nDeliusUser = NDeliusUser.builder().mail("user@service.com").build();
+        when(ldapRepository.getDeliusUserNoRoles("sandrasmith")).thenReturn(Optional.of(nDeliusUser));
 
-        assertThat(staffService.getStaffDetailsByStaffIdentifier(10L)).get().extracting(StaffDetails::getEmail).isEqualTo("user@service.com");
+        var staffDetails = staffService.getStaffDetailsByStaffIdentifier(10L).get();
+        assertThat(staffDetails.getEmail()).isEqualTo("user@service.com");
+        assertThat(staffDetails.getTelephoneNumber()).isNull();
     }
 
     @Test
     public void willSetNullEmailWhenUserNotFoundInLDAP_getStaffDetailsByStaffIdentifier() {
         when(staffRepository.findByStaffId(10L))
-                .thenReturn(
-                        Optional.of(
-                                aStaff()
-                                        .toBuilder()
-                                        .user(
-                                                aUser()
-                                                        .toBuilder()
-                                                        .distinguishedName("username")
-                                                        .build())
-                                        .build()));
+            .thenReturn(
+                Optional.of(
+                    aStaff()
+                        .toBuilder()
+                        .user(
+                            aUser()
+                                .toBuilder()
+                                .distinguishedName("sandrasmith")
+                                .build())
+                        .build()));
 
-        when(ldapRepository.getEmail("username")).thenReturn(null);
+        when(ldapRepository.getDeliusUserNoRoles("sandrasmith")).thenReturn(Optional.empty());
 
         assertThat(staffService.getStaffDetailsByStaffIdentifier(10L)).get().extracting(StaffDetails::getEmail).isNull();
     }


### PR DESCRIPTION
* Telephone number exists on the staff details by username endpoint, but is missing from the staff details by staffId endpoint
* This PR adds it by re-using the `addFieldsFromLdap` private function