### PR TITLE
PI-101 Handle null staff/team on OrderManager

### DIFF
--- a/src/main/java/uk/gov/justice/digital/delius/transformers/OrderManagerTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/delius/transformers/OrderManagerTransformer.java
@@ -1,28 +1,32 @@
 package uk.gov.justice.digital.delius.transformers;
 
+import org.flywaydb.core.internal.util.StringUtils;
 import uk.gov.justice.digital.delius.data.api.OrderManager;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Staff;
 import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
+import uk.gov.justice.digital.delius.jpa.standard.entity.Team;
 
-import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.joining;
 
 public class OrderManagerTransformer {
 
-    public static OrderManager orderManagerOf(uk.gov.justice.digital.delius.jpa.standard.entity.OrderManager entity){
+    public static OrderManager orderManagerOf(uk.gov.justice.digital.delius.jpa.standard.entity.OrderManager entity) {
         return OrderManager.builder()
-                .name(Stream.of(Optional.ofNullable(entity.getStaff().getForename()),
-                (Optional.ofNullable(entity.getStaff().getForname2())),
-                (Optional.ofNullable(entity.getStaff().getSurname())))
-                    .filter(Optional::isPresent).map(Optional::get)
-                    .collect(Collectors.joining(" ")))
-                .staffCode(Optional.ofNullable(entity.getStaff().getOfficerCode()).orElse(""))
+                .name(ofNullable(entity.getStaff())
+                    .map(staff -> Stream.of(staff.getForename(), staff.getForname2(), staff.getSurname())
+                        .filter(StringUtils::hasLength)
+                        .collect(joining(" ")))
+                    .orElse(null))
+                .staffCode(ofNullable(entity.getStaff()).map(Staff::getOfficerCode).orElse(null))
+                .gradeCode(ofNullable(entity.getStaff()).map(Staff::getGrade).map(StandardReference::getCodeValue).orElse(null))
+                .teamId(ofNullable(entity.getTeam()).map(Team::getTeamId).orElse(null))
                 .dateStartOfAllocation(entity.getAllocationDate())
                 .dateEndOfAllocation(entity.getEndDate())
                 .officerId(entity.getOrderManagerId())
                 .probationAreaId(entity.getProbationArea().getProbationAreaId())
-                .gradeCode(Optional.ofNullable(entity.getStaff().getGrade()).map(StandardReference::getCodeValue).orElse(""))
-                .teamId(entity.getTeam().getTeamId()).build();
+                .build();
     }
-
 }

--- a/src/test/java/uk/gov/justice/digital/delius/transformers/OrderManagerTransformerTest.java
+++ b/src/test/java/uk/gov/justice/digital/delius/transformers/OrderManagerTransformerTest.java
@@ -1,45 +1,45 @@
 package uk.gov.justice.digital.delius.transformers;
 
+import lombok.val;
 import org.junit.jupiter.api.Test;
-import uk.gov.justice.digital.delius.jpa.standard.entity.OrderManager;
-import uk.gov.justice.digital.delius.jpa.standard.entity.ProbationArea;
-import uk.gov.justice.digital.delius.jpa.standard.entity.Staff;
-import uk.gov.justice.digital.delius.jpa.standard.entity.StandardReference;
-import uk.gov.justice.digital.delius.jpa.standard.entity.Team;
+
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.digital.delius.util.EntityHelper.anOrderManager;
 
 class OrderManagerTransformerTest {
 
     @Test
-    void orderManagerOf() {
-        assertThat(OrderManagerTransformer.orderManagerOf(aOrderManagerEntity())).isNotNull();
-        assertThat(OrderManagerTransformer.orderManagerOf(aOrderManagerEntity()).getName()).isEqualTo("forename forename2 surname");
-        assertThat(OrderManagerTransformer.orderManagerOf(aOrderManagerEntity()).getStaffCode()).isEqualTo("10001");
-        assertThat(OrderManagerTransformer.orderManagerOf(aOrderManagerEntity()).getOfficerId()).isEqualTo(10002);
-        assertThat(OrderManagerTransformer.orderManagerOf(aOrderManagerEntity()).getTeamId()).isEqualTo(10003);
-        assertThat(OrderManagerTransformer.orderManagerOf(aOrderManagerEntity()).getProbationAreaId()).isEqualTo(10004);
-        assertThat(OrderManagerTransformer.orderManagerOf(aOrderManagerEntity()).getDateStartOfAllocation()).isEqualTo(LocalDate.of(2021,4,1).atStartOfDay());
-        assertThat(OrderManagerTransformer.orderManagerOf(aOrderManagerEntity()).getDateEndOfAllocation()).isEqualTo(LocalDate.of(2021,5,1).atStartOfDay());
-        assertThat(OrderManagerTransformer.orderManagerOf(aOrderManagerEntity()).getGradeCode()).isEqualTo("123");
-
+    void valuesAreMappedCorrectly() {
+        val entity = anOrderManager();
+        val observed = OrderManagerTransformer.orderManagerOf(entity);
+        assertThat(observed).isNotNull();
+        assertThat(observed.getName()).isEqualTo("John Smith");
+        assertThat(observed.getStaffCode()).isEqualTo("A1234");
+        assertThat(observed.getGradeCode()).isEqualTo("SPO");
+        assertThat(observed.getOfficerId()).isEqualTo(entity.getOrderManagerId());
+        assertThat(observed.getTeamId()).isEqualTo(entity.getTeam().getTeamId());
+        assertThat(observed.getProbationAreaId()).isEqualTo(entity.getProbationArea().getProbationAreaId());
+        assertThat(observed.getDateStartOfAllocation()).isEqualTo(LocalDate.of(2021,4,1).atStartOfDay());
+        assertThat(observed.getDateEndOfAllocation()).isEqualTo(LocalDate.of(2021,5,1).atStartOfDay());
     }
 
-    private OrderManager aOrderManagerEntity(){
-        return OrderManager.builder()
+    @Test
+    void nullStaffIsHandled() {
+        val entity = anOrderManager().toBuilder().staff(null).build();
+        val observed = OrderManagerTransformer.orderManagerOf(entity);
+        assertThat(observed).isNotNull();
+        assertThat(observed.getName()).isNull();
+        assertThat(observed.getStaffCode()).isNull();
+        assertThat(observed.getGradeCode()).isNull();
+    }
 
-            .staff(Staff.builder().staffId(10001L).forename("forename").surname("surname")
-                .forname2("forename2").officerCode("10001")
-                .grade(StandardReference.builder()
-                    .codeValue("123").build()).build())
-            .orderManagerId(10002L)
-            .allocationDate(LocalDate.of(2021, 4,1).atStartOfDay())
-            .endDate(LocalDate.of(2021,5,1).atStartOfDay())
-            .team(Team.builder()
-                .startDate(LocalDate.of(2021, 4,1))
-                .endDate(LocalDate.of(2021,5,1)).teamId(10003L).build())
-            .probationArea(ProbationArea.builder().probationAreaId(10004L).build()).build();
+    @Test
+    void nullTeamIsHandled() {
+        val entity = anOrderManager().toBuilder().team(null).build();
+        val observed = OrderManagerTransformer.orderManagerOf(entity);
+        assertThat(observed).isNotNull();
+        assertThat(observed.getTeamId()).isNull();
     }
 }

--- a/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
+++ b/src/test/java/uk/gov/justice/digital/delius/util/EntityHelper.java
@@ -692,6 +692,7 @@ public class EntityHelper {
                 .surname("Smith")
                 .teams(List.of())
                 .probationArea(aProbationArea())
+                .grade(aStandardReference("SPO", "Senior Probation Officer"))
                 .build();
     }
 
@@ -927,6 +928,8 @@ public class EntityHelper {
                 .staff(aStaff())
                 .activeFlag(1L)
                 .probationArea(aProbationArea())
+                .allocationDate(LocalDate.of(2021, 4, 1).atStartOfDay())
+                .endDate(LocalDate.of(2021, 5, 1).atStartOfDay())
                 .build();
     }
 


### PR DESCRIPTION
This is a rare occurrence, however there are 42 old records in production where the ALLOCATION_STAFF_ID / ALLOCATION_TEAM_ID columns are null. Hopefully the data can be corrected by NDST, but this change ensures we'll safely handle any null values in the meantime.