### PR TITLE
Bump HMPPS Gradle plugin to v4.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,6 +368,7 @@ workflows:
                 - main
     jobs:
       - hmpps/gradle_owasp_dependency_check:
+          cache_key: v2_0
           slack_channel: probation-integration-notifications
           context:
             - hmpps-common-vars

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.0.3"
+    id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.0"
     id 'groovy'
     id 'org.unbroken-dome.test-sets' version '4.0.0'
     id "au.com.dius.pact" version "4.3.1"


### PR DESCRIPTION
This release will
* Upgrade to spring-boot 2.6.4
* org.owasp.dependencycheck [6.5.3 -> 7.0.0]
* com.github.ben-manes:gradle-versions-plugin [0.41.0 -> 0.42.0]
* com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin [0.41.0 -> 0.42.0]
* com.google.code.gson:gson [2.8.9 -> 2.9.0]
* com.gorylenko.gradle-git-properties:com.gorylenko.gradle-git-properties.gradle.plugin [2.3.2 -> 2.4.0]
* net.javacrumbs.json-unit:json-unit-assertj [2.28.0 -> 2.32.0]
* com.microsoft.azure:applicationinsights-agent [3.2.5 -> 3.2.7]
Also applied suppression for the ktlint reporter: CVE-2019-9658 and CVE-2019-10782
