### PR TITLE
Use Spring-managed dependency versions for Jackson, Oracle JDBC, and Lombok

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,39 +18,35 @@ java {
 check.dependsOn(testIntegration)
 
 dependencies {
-
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-ldap'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    implementation("org.springframework.boot:spring-boot-starter-webflux")
-
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'com.fasterxml.jackson.core:jackson-core'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations'
+    implementation 'com.oracle.database.jdbc:ojdbc11'
     implementation 'com.unboundid:unboundid-ldapsdk:6.0.2'
-    implementation("io.springfox:springfox-boot-starter:3.0.0")
+    implementation 'io.springfox:springfox-boot-starter:3.0.0'
     implementation 'org.flywaydb:flyway-core:8.3.0'
     implementation 'com.zaxxer:HikariCP:5.0.0'
     implementation 'commons-io:commons-io:2.11.0'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.apache.commons:commons-text:1.9'
     implementation 'io.swagger:swagger-core:1.6.2'
-    implementation 'com.oracle.database.jdbc:ojdbc10:19.12.0.0'
     implementation 'io.vavr:vavr:0.10.4'
     implementation 'com.github.java-json-tools:json-patch:1.13'
 
-    // needed for record serialisation
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.12.5'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.5'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.12.5'
-
-    annotationProcessor 'org.projectlombok:lombok:1.18.22'
+    annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-    compileOnly 'org.projectlombok:lombok:1.18.22'
+    compileOnly 'org.projectlombok:lombok'
 
     runtimeOnly 'com.h2database:h2:2.1.210'
     testRuntimeOnly 'com.h2database:h2:1.4.200'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.22'
-    testCompileOnly 'org.projectlombok:lombok:1.18.22'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
 
     testImplementation 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
     testImplementation ('io.rest-assured:rest-assured:4.4.0'){


### PR DESCRIPTION
See https://docs.spring.io/spring-boot/docs/current/reference/html/dependency-versions.html