### PR TITLE
Bump HMPPS Gradle plugin to 4.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.0"
+    id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.1"
     id 'groovy'
     id 'org.unbroken-dome.test-sets' version '4.0.0'
     id "au.com.dius.pact" version "4.3.1"


### PR DESCRIPTION
This suppress jackson vulnerability CVE-2020-36518 in trivyignore
