### PR TITLE
Bump queue orb to 1.6.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   aws-cli: circleci/aws-cli@1.4.0
   aws-ecs: circleci/aws-ecs@2.0.0
   mem: circleci/rememborb@0.0.1
-  queue: eddiewebb/queue@1.5.0
+  queue: eddiewebb/queue@1.6.5
   slack: circleci/slack@4.8.2
   jira: circleci/jira@1.3.1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           - development
           - unmapped
     docker:
-      - image: circleci/python
+      - image: cimg/python:3.9
     steps:
       - mem/recall:
           env_var: APP_VERSION
@@ -143,7 +143,7 @@ jobs:
       environment:
         type: string
     docker:
-      - image: circleci/python
+      - image: cimg/python:3.9
     steps:
       - mem/recall:
           env_var: APP_VERSION


### PR DESCRIPTION
This fixes various API compatibility issues which prevented the workflow from queueing deployments
