### PR TITLE
Increase max queue time for deployments to 30 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           env_var: APP_VERSION
       - queue/until_front_of_line:
           consider-branch: false
-          time: '10'
+          time: '30'
       - aws-cli/setup
       - run:
           name: Assume IAM role


### PR DESCRIPTION
This prevents branch deployment failures when creating lots of PRs (e.g. dependabot)