### PR TITLE
Define community-api for developer portal

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: hmpps-community-api
+  title: Community API service
+  description: API service over the NDelius DB used by HMPPS Digital team applications and services
+  tags:
+    - java
+    - spring-boot
+spec:
+  type: service
+  lifecycle: production
+  owner: group:delius-api
+  system: system:hmpps-delius
+  providesApis:
+    - api:hmpps-community
+  consumesApis:
+    - api:hmpps-delius
+  dependsOn:
+    - resource:hmpps-delius-database
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: hmpps-community
+  title: Community API
+  description: API over the NDelius DB used by HMPPS Digital team applications and services
+spec:
+  type: openapi
+  lifecycle: production
+  owner: group:delius-api
+  system: system:hmpps-delius
+  definition:
+    $text: https://community-api-public.test.probation.service.justice.gov.uk/v2/api-docs?group=Community%20API

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: group:delius-api
+  owner: group:probation-integration
   system: system:hmpps-delius
   providesApis:
     - api:hmpps-community
@@ -30,7 +30,7 @@ metadata:
 spec:
   type: openapi
   lifecycle: production
-  owner: group:delius-api
+  owner: group:probation-integration
   system: system:hmpps-delius
   definition:
     $text: https://community-api-public.test.probation.service.justice.gov.uk/v2/api-docs?group=Community%20API


### PR DESCRIPTION
Adds a Backstage entity metadata file to this repository so that the
component can be added to the developer portal
(https://developer-portal.apps.live.cloud-platform.service.justice.gov.uk/catalog)

Strategically, this file will replace most of https://github.com/ministryofjustice/hmpps-architecture-as-code/blob/main/src/main/kotlin/uk/gov/justice/hmpps/architecture/model/Delius.kt

Similar:

- https://github.com/ministryofjustice/hmpps-delius-api/pull/275