### PR TITLE
onboarding new contracts for FBD-Y

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -133,6 +133,7 @@ delius-integration-context:
           FBD-SC: CRS08
           FBD-NE: CRS08
           FBD-W: CRS08
+          FBD-Y: CRS08
           DNR-K: CRS04
           DNR-L: CRS04
           DNR-NE: CRS04


### PR DESCRIPTION
Adds the new contract type NSI mappings for the new contracts going live 31st October.